### PR TITLE
Updating pip install commands

### DIFF
--- a/src/pages/page-acqua.html
+++ b/src/pages/page-acqua.html
@@ -286,7 +286,7 @@
           <iron-pages selected="[[_selectedSectionId]]" attr-for-selected="section-id">
             <div section-id="home">
               <h3>[[localize('acqua.exampleTitle')]]</h3>
-              <pre class="terminal">$ pip install qiskit-acqua</pre>
+              <pre class="terminal">$ pip install qiskit_acqua</pre>
               <code-sample type="python" copy-clipboard-button>
                 <!-- htmlmin:ignore -->
                 <template preserve-content>
@@ -320,7 +320,7 @@
             </div>
             <div section-id="chemistry">
               <h3>[[localize('exampleTitleChemistry')]]</h3>
-              <pre class="terminal">$ pip install qiskit-acqua-chemistry</pre>
+              <pre class="terminal">$ pip install qiskit_acqua_chemistry</pre>
               <code-sample type="python" copy-clipboard-button>
                 <!-- htmlmin:ignore -->
                 <template preserve-content>
@@ -349,7 +349,7 @@
             </div>
             <div section-id="ai">
               <h3>[[localize('exampleTitleAI')]]</h3>
-              <pre class="terminal">$ pip install qiskit-acqua</pre>
+              <pre class="terminal">$ pip install qiskit_acqua</pre>
               <code-sample type="python" copy-clipboard-button>
                 <!-- htmlmin:ignore -->
                 <template preserve-content>
@@ -382,7 +382,7 @@
             </div>
             <div section-id="optimization">
               <h3>[[localize('exampleTitleOptimization')]]</h3>
-              <pre class="terminal">$ pip install qiskit-acqua</pre>
+              <pre class="terminal">$ pip install qiskit_acqua</pre>
               <code-sample type="python" copy-clipboard-button>
                 <!-- htmlmin:ignore -->
                 <template preserve-content>


### PR DESCRIPTION
  * According to https://github.com/QISKit/qiskit-acqua/blob/master/setup.py#L36 the command to install the `qiskit_acqua` library using pip would be `pip install qiskit_acqua`.

  * According to https://github.com/QISKit/qiskit-acqua-chemistry/blob/master/setup.py#L35 the command to install the `qiskit_acqua_chemistry` library using pip would be `pip install qiskit_acqua_chemistry`.

It seems the pypi links are still not working; this PR is only to help if those are the final names of the pip packages 