### PR TITLE
switch to import * in terra and aer examples

### DIFF
--- a/src/components/page-aer.js
+++ b/src/components/page-aer.js
@@ -150,8 +150,7 @@ class PageAer extends localize(i18next)(PageViewElement) {
             <code-sample type="python" copy-clipboard-button>
               <!-- htmlmin:ignore -->
               <template>
-                from qiskit import QuantumRegister, ClassicalRegister
-                from qiskit import QuantumCircuit, execute, Aer, IBMQ
+                from qiskit import *
                 from qiskit.providers.aer import noise
 
                 # Choose a real device to simulate

--- a/src/components/page-terra.js
+++ b/src/components/page-terra.js
@@ -153,8 +153,7 @@ class PageTerra extends localize(i18next)(PageViewElement) {
             <code-sample type="python" copy-clipboard-button>
               <!-- htmlmin:ignore -->
               <template>
-                from qiskit import QuantumRegister, ClassicalRegister
-                from qiskit import QuantumCircuit, Aer, execute
+                from qiskit import *
 
                 q = QuantumRegister(2)
                 c = ClassicalRegister(2)


### PR DESCRIPTION
As discussed with @jaygambetta, we should move to * imports in the terra and aer examples.