### PR TITLE
[Proposal] to fix issue 86

### DIFF
--- a/src/components/page-aqua.js
+++ b/src/components/page-aqua.js
@@ -272,12 +272,14 @@ class PageAqua extends localize(i18next)(LitElement) {
         <div class="row limited-width">
           <div class="description">
             <h3>${i18next.t('pages.aqua.chemistryGui')}</h3>
-            <code-sample type="bash">
-              <template>
-                [python3] $ qiskit_aqua_ui
-                [python3] $ qiskit_chemistry_ui
-              </template>
-            </code-sample>
+            <div class="style-scope page-aqua">
+              <div id="code-container" class="style-scope code-sample">
+                <pre id="code" class="style-scope code-sample"><code class="bash style-scope code-sample hljs style-scope code-sample">
+[python3] $ qiskit_aqua_ui
+[python3] $ qiskit_chemistry_ui
+                  </code></pre>
+              </div>
+            </div>
             <p>${i18next.t('pages.aqua.chemistryGuiDescription1')}</p>
             <p>${i18next.t('pages.aqua.chemistryGuiDescription2')}</p>
             <p>${i18next.t('pages.aqua.chemistryGuiDescription3')}</p>


### PR DESCRIPTION
I have detected that the error are in the componente '<code-base>' lit-html part.js method can't get this node if it's in double nesting or more. For example in the qiskit aer page we have this code: 

![image](https://user-images.githubusercontent.com/11163221/52894116-e6515c00-31a4-11e9-8ee9-8fb0a376c2dd.png)

This code is working because the componente have only one nesting. But nevertheless in the aqua page we have this code.

![image](https://user-images.githubusercontent.com/11163221/52894127-08e37500-31a5-11e9-9745-ddda6f566a1a.png)

We have double nesting and the lit html library get as node the text, the text isn't a html node and the code element.setAttribute failed because a string don't have this method.

I propose this fast solution but we need review the componente '<code-sample>' in all page.

