### PR TITLE
Remove target blank on documentation link

### DIFF
--- a/src/components/app-shell.js
+++ b/src/components/app-shell.js
@@ -163,7 +163,7 @@ class AppShell extends localize(i18next)(connect(store)(LitElement)) {
             <a href="/aqua" ?selected=${this.page === 'aqua'}>Aqua</a>
           </nav>
           <nav class="second">
-            <a href="/documentation/" target="_blank">${i18next.t('documentation')}</a>
+            <a href="/documentation/">${i18next.t('documentation')}</a>
             <a href="/vscode" ?selected=${this.page === 'vscode'}>${i18next.t('tools')}</a>
             <a href="/fun" ?selected=${this.page === 'fun'}>${i18next.t('fun')}</a>
           </nav>

--- a/src/router.js
+++ b/src/router.js
@@ -46,6 +46,13 @@ export function init(outlet) {
       },
     },
     {
+      path: '/documentation',
+      component: 'page-documentation',
+      action: () => {
+        window.location.replace('/documentation');
+      },
+    },
+    {
       path: '/fun',
       name: 'fun',
       component: 'page-fun',


### PR DESCRIPTION
Link in local is a not found, because the web works a SPA and documentation is other app, but in production should be work fine.

Fixed #89 