### PR TITLE
fix tutorials link

### DIFF
--- a/src/components/app-shell.js
+++ b/src/components/app-shell.js
@@ -230,7 +230,7 @@ class AppShell extends localize(i18next)(connect(store)(LitElement)) {
           <nav class="second">
             <a href="/education">${i18next.t('education')}</a>
             <a
-              href="https://nbviewer.jupyter.org/github/Qiskit/qiskit-tutorials/blob/master/qiskit/start_here.ipynb"
+              href="https://nbviewer.jupyter.org/github/Qiskit/qiskit-tutorials/blob/master/qiskit/1_start_here.ipynb"
               rel="noopener"
               target="_blank"
               @click=${() => trackClickEvent({


### PR DESCRIPTION
Fix the tutorials link now that the name of `start_here` has been changed.