### PR TITLE
fixed typo in Ignis

### DIFF
--- a/src/components/page-ignis.js
+++ b/src/components/page-ignis.js
@@ -90,7 +90,7 @@ class PageIgnis extends localize(i18next)(LitElement) {
             <h3>${i18next.t('pages.ignis.stackTitle')}</h3>
             <div class="stack-list">
               <div class="element">
-                <div class="title">Qiskit Ingis Experiments</div>
+                <div class="title">Qiskit Ignis Experiments</div>
                 <div class="subtitle">List of Quantum Circuits or Pulse Schedules</div>
               </div>
               <div class="element">


### PR DESCRIPTION
This commit corrects the misspelled "Ignis" in [Qiskit Ignis](https://qiskit.org/ignis) -> Stack