### PR TITLE
Add .gitignore to Documentation

### DIFF
--- a/documentation/.gitignore
+++ b/documentation/.gitignore
@@ -1,0 +1,3 @@
+# ignore doctrees
+.doctrees/
+_sources/


### PR DESCRIPTION
This commit adds a `.gitignore` for documentation. Will create a PR for deleting all the existing `_sources` and `.doctrees`.

These files are deleted because when local master is tried to merge with `master`, it errors:
```
error: Your local changes to the following files would be overwritten by merge:
.
.
.
Please commit your changes or stash them before you merge.
Aborting