### PR TITLE
Add schemas to the website

### DIFF
--- a/deploy/deploy_cos.sh
+++ b/deploy/deploy_cos.sh
@@ -17,4 +17,7 @@ cp -r ../modelq ../build/es5-bundled/.
 cp -r ../robots.txt ../build/es5-bundled/.
 cp -r ../404.html ../build/es5-bundled/.
 
+git clone --depth=1 https://github.com/Qiskit/qiskit-terra.git
+cp -r qiskit-terra/qiskit/schemas ../build/es5-bundled/.
+
 rclone sync ../build/es5-bundled IBMCOS:qiskit-org-website


### PR DESCRIPTION
This commit adds the qiskit api schemas (mainly qobj and backend
information) to the qiskit.org deploy script. This is just a stop gap
to start uploading. A follow up patch here will be to just add this
upload step to the qiskit-terra repo directly since the object store
means we don't have to (and shouldn't) centralize all the artifacts
hosted on the qiskit.org domain in a single massive git repo.

Fixes #48