### PR TITLE
Change Community title to refer to social media

### DIFF
--- a/locales/en/app.json
+++ b/locales/en/app.json
@@ -24,7 +24,7 @@
       "ibmQExperienceDescription": "New to quantum computing? Try out the IBM Q Experience to get started with Qiskit in the cloud. No installation required and free hosted tutorials. Work is saved in the cloud and automatically updated with every Qiskit release.",
       "ibmQExperienceButtonTryOut": "Try it",
       "ibmQExperienceAltImage": "Screenshot of the IBM Q Experience Qiskit notebooks",
-      "communityTitle": "Qiskit community",
+      "communityTitle": "Where to find us",
       "communityDescription": "Qiskit is driven by our avid community of Qiskitters! We are committed to our goal of bringing quantum computing to people of all backgrounds, and are always excited to hear your feedback directly from you. There are many ways to stay informed, contribute to, and collaborate on Qiskit.",
       "supportingTitle": "Supporting organizations and collaborators",
       "supportingDescription": "Our Qiskitters community come from a broad range of organizations. If you are a contributor and would like to be listed, please email qiskit@qiskit.org. Thanks and keep developing!"

--- a/locales/en/app.json
+++ b/locales/en/app.json
@@ -25,7 +25,7 @@
       "ibmQExperienceButtonTryOut": "Try it",
       "ibmQExperienceAltImage": "Screenshot of the IBM Q Experience Qiskit notebooks",
       "communityTitle": "Where to find us",
-      "communityDescription": "Qiskit is driven by our avid community of Qiskitters! We are committed to our goal of bringing quantum computing to people of all backgrounds, and are always excited to hear your feedback directly from you. There are many ways to stay informed, contribute to, and collaborate on Qiskit.",
+      "communityDescription": "Through connecting, contributing and collaborating, our diverse community of Qiskitters propels Qiskit to new forefronts and fields. In our commitment to open this quantum computing community to people of all backgrounds, we span across several platforms. Find us today to start connecting and contributing!",
       "supportingTitle": "Supporting organizations and collaborators",
       "supportingDescription": "Our Qiskitters community come from a broad range of organizations. If you are a contributor and would like to be listed, please email qiskit@qiskit.org. Thanks and keep developing!"
     },


### PR DESCRIPTION
Fix #297 

@CatherineKlauss it would be convenient to also review the `communityDescription`. These texts correspond with the following qiskit.org section:

![Captura de pantalla 2019-11-06 a las 12 58 04](https://user-images.githubusercontent.com/757942/68296515-19ba7a80-0095-11ea-833d-c3e1185e40bf.png)
