### PR TITLE
[Issue 359] Enable applying Component decorator to abstract classes.

### DIFF
--- a/components/qiskit/QiskitElementPage.vue
+++ b/components/qiskit/QiskitElementPage.vue
@@ -3,8 +3,8 @@ import { Component } from 'vue-property-decorator'
 import QiskitPage from '~/components/qiskit/QiskitPage.vue'
 
 @Component
-export default class extends QiskitPage {
-  title: string = ''
-  description: string = ''
+export default abstract class extends QiskitPage {
+  abstract title: string
+  abstract description: string
 }
 </script>

--- a/components/qiskit/QiskitPage.vue
+++ b/components/qiskit/QiskitPage.vue
@@ -1,7 +1,9 @@
 <script lang="ts">
 import { Component, Mixins } from 'vue-property-decorator'
-import SegmentMixin from '~/mixins/segment-analytics'
+import SegmentMixin, { TrackedPage } from '~/mixins/segment-analytics'
 
 @Component
-export default class extends Mixins(SegmentMixin) { }
+export default abstract class extends Mixins(SegmentMixin) implements TrackedPage {
+  abstract routeName: string;
+}
 </script>

--- a/mixins/segment-analytics.ts
+++ b/mixins/segment-analytics.ts
@@ -1,5 +1,27 @@
-import Vue from 'vue'
+import Vue, { ComponentOptions } from 'vue'
 import { Component } from 'vue-property-decorator'
+import { Route } from 'vue-router'
+
+// Patch the Component decorator to work with abstract classes.
+// @ts-ignore is needed for avoiding the error:
+// "Overload signatures must all be exported or non-exported."
+// See https://github.com/microsoft/TypeScript/issues/21566#issuecomment-362462824
+declare module 'vue-property-decorator' {
+  abstract class _Abstract extends Vue {}
+  // @ts-ignore
+  function Component<V extends Vue>(options: ComponentOptions<V> & ThisType<V>): <VC extends typeof _Abstract>(target: VC) => VC;
+  // @ts-ignore
+  function Component<VC extends typeof _Abstract>(target: VC): VC;
+}
+
+/**
+ * The interface that all tracked pages must implement.
+ */
+interface TrackedPage extends Vue {
+  routeName: string
+}
+
+type TrackedPageGuardNext = (to: ((vm: TrackedPage) => any)) => void
 
 /**
  * Mixin enabling page visitation tracking in Bluemix Analytics. To use it:
@@ -34,7 +56,7 @@ import { Component } from 'vue-property-decorator'
  */
 @Component
 export default class extends Vue {
-  beforeRouteEnter (_to, _from, next) {
+  beforeRouteEnter (_from: Route, _to: Route, next: TrackedPageGuardNext): any {
     next((pageComponent) => {
       if (!pageComponent.routeName) {
         return console.warn('Component', pageComponent,
@@ -45,3 +67,5 @@ export default class extends Vue {
     })
   }
 }
+
+export { TrackedPage }

--- a/mixins/segment-analytics.ts
+++ b/mixins/segment-analytics.ts
@@ -18,6 +18,14 @@ declare module 'vue-property-decorator' {
  * The interface that all tracked pages must implement.
  */
 interface TrackedPage extends Vue {
+  /**
+   * A unique kebab-case string identifying the page regardless URL or title
+   * changing over time. This value should be resilient to change, more related
+   * to the page functionality.
+   *
+   * @example
+   * `'support-guides'`, `'notebooks-list'`, `'ignis-introduction'`...
+   */
   routeName: string
 }
 

--- a/plugins/segment-analytics.ts
+++ b/plugins/segment-analytics.ts
@@ -155,6 +155,7 @@ function afterAnalyticsReady<S extends any[]> (callback: (...S) => void) {
 
 declare module 'vue/types/vue' {
   interface Vue {
+    $metaInfo: { title: string }
     $trackClickEvent(params: ClickEventParams): void
     $trackPage(routeName: string, title: string): void
   }


### PR DESCRIPTION
Closes #359

Abstract page components are convenient in this project to enforce all
pages to add the `routeName` property for tracking purposes, and `title`
and `description` for element-specific pages.

However, the Component decorator that comes with Nuxt is not ready for
decorating abstract classes. The `abstract` modifier is TypeScript
specific and has no impact during runtime. An abstract class is the same
as a regular class, from a JavaScript perspective. This PR augments the
TypeScript definition of Component to allow abstract classes to be
decorated.

It also introduces the interface `TrackedPage` which is implemented by
the `QiskitPage` page component so all the concrete descendants must
implement the requirements imposed by `TrackedPage`. In this case, the
existence of the `routeName` property.