### PR TITLE
Remove overflow-x to solve the issue with scrollTo()

### DIFF
--- a/assets/scss/layout.scss
+++ b/assets/scss/layout.scss
@@ -21,7 +21,6 @@ body,
   flex-direction: column;
   height: 100%;
   min-height: 100%;
-  overflow-x: hidden;
 }
 
 .content-root > main {


### PR DESCRIPTION
Fix #411 

As #411 explains, removing `overflow-x: hidden` makes iOS Safari to missbehave when there is overflowing content (such as the video in the Community > Eduction page) and allows the user to scroll hortizontally and reach the parts of the content indended to be hidden.

Nevertheless, this risk is lower than the existing one since our current data confirms most of the visits comes from desktop devices and linking to a section is a very common pattern in the web and should not break.