### PR TITLE
Add Dynamic Year to Footer

### DIFF
--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -1,8 +1,20 @@
 <template>
   <footer>
-    <p>Copyright IBM Corp. 2018-2019</p>
+    <p>Copyright IBM Corp. 2018-{{ currentYear }}</p>
   </footer>
 </template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { Component } from 'vue-property-decorator'
+
+const today = new Date()
+
+@Component
+export default class extends Vue {
+  currentYear = today.getFullYear()
+}
+</script>
 
 <style scoped>
 footer {


### PR DESCRIPTION
Eventpages have a seperate footer, which has a copyright-notice including a year. 
This is currently hardcoded and shows "Copyright IBM Corp. 2018-2019".

Example: https://qiskit.org/events/camp-2020/

This PR updates the footer component to use dynamic year instead of just updating it to 2020.