### PR TITLE
ISSUE-426 Fix video background in events page

### DIFF
--- a/assets/scss/mq.scss
+++ b/assets/scss/mq.scss
@@ -4,5 +4,6 @@ $mq-responsive: true;
 
 $mq-breakpoints: (
   desktop: 600px,
-  wide-desktop: 880px
+  wide-desktop: 880px,
+  super-wide-desktop: 1200px
 );

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -1,6 +1,6 @@
 <template>
   <main>
-    <header class="header-video">
+    <header v-if="isDesktop" class="header-video">
       <video
         ref="video"
         class="header-video__video"
@@ -31,6 +31,7 @@ import QiskitPage from '~/components/qiskit/QiskitPage.vue'
 
 export default class extends QiskitPage {
   routeName: string = 'events'
+  windowWidth: Number = 0
 
   autoplayVideo () {
     if (!this.$refs.video) {
@@ -46,10 +47,16 @@ export default class extends QiskitPage {
     }, 1)
   }
 
+  get isDesktop () {
+    return this.windowWidth > 600
+  }
+
   mounted () {
-    if (window.innerWidth > 600) {
+    this.windowWidth = window.innerWidth
+
+    this.$nextTick(() => {
       this.autoplayVideo()
-    }
+    })
   }
 }
 </script>
@@ -73,7 +80,7 @@ export default class extends QiskitPage {
     content: '';
     height: 100%;
     width: 100%;
-    bottom: -2px;
+    bottom: -.5rem;
     position: absolute;
     background: linear-gradient(0deg, var(--primary-color) 0%, #242a2e00 100%);
   }

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -33,17 +33,23 @@ export default class extends QiskitPage {
   routeName: string = 'events'
 
   autoplayVideo () {
+    if (!this.$refs.video) {
+      return
+    }
+
+    const video = this.$refs.video as any
+
     setTimeout(() => {
-      if (this.$refs.video) {
-        this.$refs.video.load()
-        this.$refs.video.muted = true
-        this.$refs.video.play()
-      }
+      video.load()
+      video.muted = true
+      video.play()
     }, 1)
   }
 
-  created () {
-    this.autoplayVideo()
+  mounted () {
+    if (window.innerWidth > 600) {
+      this.autoplayVideo()
+    }
   }
 }
 </script>
@@ -53,18 +59,21 @@ export default class extends QiskitPage {
 .header-video {
   position: relative;
   overflow: hidden;
-  height: 40vh;
+  height: 35vh;
 
   &__video {
     position: absolute;
     width: 100%;
-    top: -50%;
+    @include mq($from: super-wide-desktop) {
+      top: -60%;
+    }
   }
 
   &:after {
     content: '';
     height: 100%;
     width: 100%;
+    bottom: -2px;
     position: absolute;
     background: linear-gradient(0deg, var(--primary-color) 0%, #242a2e00 100%);
   }

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -1,6 +1,6 @@
 <template>
   <main>
-    <header v-if="isDesktop" class="header-video">
+    <header v-if="isDesktop" class="header-video" playsinline>
       <video
         ref="video"
         class="header-video__video"
@@ -38,25 +38,22 @@ export default class extends QiskitPage {
       return
     }
 
-    const video = this.$refs.video as any
+    const video = this.$refs.video as HTMLMediaElement
 
-    setTimeout(() => {
-      video.load()
-      video.muted = true
-      video.play()
-    }, 1)
+    video.load()
+    video.muted = true
+    video.play()
   }
 
   get isDesktop () {
     return this.windowWidth > 600
   }
 
-  mounted () {
+  async mounted () {
     this.windowWidth = window.innerWidth
 
-    this.$nextTick(() => {
-      this.autoplayVideo()
-    })
+    await this.$nextTick()
+    this.autoplayVideo()
   }
 }
 </script>


### PR DESCRIPTION
Closes #426 

Make background video to load always asynchronous to not affect our web performance, force autoplay and prevent the whole video's header from rendering at all when the user is loading the page from a mobile device.