### PR TITLE
Event card for desktop

### DIFF
--- a/assets/scss/theme.scss
+++ b/assets/scss/theme.scss
@@ -12,6 +12,9 @@
   --secondary-color-darkmost: #6105f2;
   --body-color-light: #e0e0e0;
   --body-color-dark: #333333;
+  --purple-60: #8a3ffc;
+  --gray-70: #525252;
+  --white: #ffffff;
 }
 
 h1 {

--- a/components/cards/EventCard.vue
+++ b/components/cards/EventCard.vue
@@ -16,15 +16,15 @@
 
         <footer>
           <div class="event-card__info-detail">
-            <Map20 class="event-card__icon-map" />
+            <Map20 class="event-card__icon" />
             <span class="event-card__place">{{ place }}</span>
           </div>
           <div class="event-card__date-and-arrow">
             <div class="event-card__info-detail">
-              <Calendar20 class="event-card__icon-calendar" />
+              <Calendar20 class="event-card__icon" />
               <span class="event-card__date"><time>{{ date }}</time></span>
             </div>
-            <ArrowRight20 class="event-card__icon-arrow-right" />
+            <ArrowRight20 class="event-card__icon event-card__icon--purple" />
           </div>
         </footer>
       </div>
@@ -53,24 +53,6 @@ export default class extends Vue {
 </script>
 
 <style lang="scss" scoped>
-@mixin config-icons($prefix, $colors...) {
-  @each $color in $colors {
-    .#{$prefix}#{nth($color, 1)} {
-      fill: nth($color, 2);
-      position: relative;
-      top: .3em;
-      width: 1.25rem;
-      height: 1.25rem;
-    }
-  }
-}
-
-@include config-icons('event-card__icon-',
-    'map' var(--white),
-    'calendar' var(--white),
-    'arrow-right' var(--purple-60)
-);
-
 .card-link {
   text-decoration: none;
 }
@@ -79,10 +61,10 @@ export default class extends Vue {
   height: 15.875rem;
   width: 100%;
   background-color: var(--gray-70);
+  color: var(--white);
   display: flex;
 
   &__content {
-    color: var(--white);
     width: 50%;
     margin: 1rem;
     display: flex;
@@ -105,6 +87,18 @@ export default class extends Vue {
 
   &__info-detail {
     margin-top: 0.625rem;
+  }
+
+  &__icon {
+  fill: currentColor;
+  position: relative;
+  top: .3em;
+  width: 1.25rem;
+  height: 1.25rem;
+
+    &--purple {
+      color: var(--purple-60)
+    }
   }
 
   &__date-and-arrow {

--- a/components/cards/EventCard.vue
+++ b/components/cards/EventCard.vue
@@ -22,7 +22,7 @@
           <div class="event-card__date-and-arrow">
             <div class="event-card__info-detail">
               <Calendar20 class="event-card__icon-calendar" />
-              <span class="event-card__date">{{ date }}</span>
+              <span class="event-card__date"><time>{{ date }}</time></span>
             </div>
             <ArrowRight20 class="event-card__icon-arrow-right" />
           </div>

--- a/components/cards/EventCard.vue
+++ b/components/cards/EventCard.vue
@@ -12,9 +12,11 @@
           </div>
           <div>
             <p><Map20 /> {{ place }}</p>
-            <p><Calendar20 /> {{ date }}</p>
+            <div class="event-content__date-and-arrow">
+              <p><Calendar20 /> {{ date }}</p>
+              <ArrowRight20 class="event-content__arrow-right" />
+            </div>
           </div>
-          <ArrowRight20 class="event-content__arrow-right" />
         </div>
         <div
           class="event-content__picture"
@@ -62,23 +64,35 @@ export default class extends Vue {
 
   &__details {
     width: 50%;
-    display: grid;
+    margin: 16px;
+    display: flex;
+    flex-direction: column;
     justify-content: space-between;
     fill: var(--white);
   }
 
   &__details p {
     font-size: 0.875rem;
+    line-height: 1.25rem;
+    margin-top: 0;
   }
 
   &__details h3 {
     font-size: 1.5rem;
   }
 
-  &__arrow-right {
+  &__details svg {
+    top: .15em;
     position: relative;
-    bottom: -1.25rem;
-    right: -1.25rem;
+  }
+
+  &__date-and-arrow {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+  }
+
+  &__arrow-right {
     fill: var(--purple-60);
   }
 

--- a/components/cards/EventCard.vue
+++ b/components/cards/EventCard.vue
@@ -90,11 +90,11 @@ export default class extends Vue {
   }
 
   &__icon {
-  fill: currentColor;
-  position: relative;
-  top: .3em;
-  width: 1.25rem;
-  height: 1.25rem;
+    fill: currentColor;
+    position: relative;
+    top: .3em;
+    width: 1.25rem;
+    height: 1.25rem;
 
     &--purple {
       color: var(--purple-60)

--- a/components/cards/EventCard.vue
+++ b/components/cards/EventCard.vue
@@ -1,0 +1,78 @@
+<template>
+  <article>
+    <nuxt-link
+      :to="to"
+      class="card-link"
+    >
+      <div class="event-content">
+        <div class="event-content__details">
+          <div>
+            <p>{{ type }}</p>
+            <h3>{{ title }}</h3>
+          </div>
+          <div>
+            <p class="event-content__place">
+              {{ place }}
+            </p>
+            <p class="event-content__date">
+              {{ date }}
+            </p>
+          </div>
+        </div>
+        <div
+          class="event-content__picture"
+          :style="`background-image: ${decorate(image)};`"
+        />
+      </div>
+    </nuxt-link>
+  </article>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { Component, Prop } from 'vue-property-decorator'
+
+@Component
+export default class extends Vue {
+  @Prop(String) type
+  @Prop(String) title
+  @Prop(String) image
+  @Prop(String) place
+  @Prop(String) date
+  @Prop(String) to
+
+  decorate (image) {
+    const bgEffects = [
+      `url(${image})`
+    ]
+    return bgEffects.join(', ')
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.card-link {
+  text-decoration: none;
+}
+
+.event-content {
+  width: 735px;
+  height: 254px;
+  display: flex;
+  font-size: 0.9rem;
+  color: var(--body-color-light);
+  background-color: var(--primary-color);
+
+  &__details {
+    display: grid;
+    justify-content: space-between;
+  }
+
+  &__picture {
+    width: 100%;
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-position: center;
+  }
+}
+</style>

--- a/components/cards/EventCard.vue
+++ b/components/cards/EventCard.vue
@@ -58,7 +58,7 @@ export default class extends Vue {
 }
 
 .event-card {
-  height: 15.875rem;
+  height: 15.88rem;
   width: 100%;
   background-color: var(--gray-70);
   color: var(--white);
@@ -74,19 +74,19 @@ export default class extends Vue {
 
   &__title {
     font-size: 1.5rem;
-    margin-top: 0.313rem;
+    margin-top: 0.31rem;
   }
 
   &__subtitle, &__place, &__date {
-    font-size: 0.875rem;
+    font-size: 0.88rem;
   }
 
   &__place, &__date {
-    padding-left: 0.313rem;
+    padding-left: 0.31rem;
   }
 
   &__info-detail {
-    margin-top: 0.625rem;
+    margin-top: 0.63rem;
   }
 
   &__icon {

--- a/components/cards/EventCard.vue
+++ b/components/cards/EventCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <article>
+  <article class="event-card">
     <nuxt-link
       :to="to"
       class="card-link"
@@ -11,15 +11,10 @@
             <h3>{{ title }}</h3>
           </div>
           <div>
-            <Map32 />
-            <p class="event-content__place">
-              {{ place }}
-            </p>
-            <Calendar32 />
-            <p class="event-content__date">
-              {{ date }}
-            </p>
+            <p><Map20 /> {{ place }}</p>
+            <p><Calendar20 /> {{ date }}</p>
           </div>
+          <ArrowRight20 class="event-content__arrow-right" />
         </div>
         <div
           class="event-content__picture"
@@ -58,21 +53,37 @@ export default class extends Vue {
 }
 
 .event-content {
-  width: 735px;
-  height: 254px;
+  height: 15.875rem;
+  width: 100%;
   display: flex;
   font-size: 0.9rem;
-  color: var(--body-color-light);
-  fill: var(--body-color-light);
-  background-color: var(--primary-color);
+  color: var(--white);
+  background-color: var(--gray-70);
 
   &__details {
+    width: 50%;
     display: grid;
     justify-content: space-between;
+    fill: var(--white);
+  }
+
+  &__details p {
+    font-size: 0.875rem;
+  }
+
+  &__details h3 {
+    font-size: 1.5rem;
+  }
+
+  &__arrow-right {
+    position: relative;
+    bottom: -1.25rem;
+    right: -1.25rem;
+    fill: var(--purple-60);
   }
 
   &__picture {
-    width: 100%;
+    width: 50%;
     background-repeat: no-repeat;
     background-size: cover;
     background-position: center;

--- a/components/cards/EventCard.vue
+++ b/components/cards/EventCard.vue
@@ -73,7 +73,6 @@ export default class extends Vue {
 
   &__details p {
     font-size: 0.875rem;
-    line-height: 1.25rem;
     margin-top: 0;
   }
 

--- a/components/cards/EventCard.vue
+++ b/components/cards/EventCard.vue
@@ -11,6 +11,7 @@
             <h3>{{ title }}</h3>
           </div>
           <div>
+            <Bee32 />
             <p class="event-content__place">
               {{ place }}
             </p>

--- a/components/cards/EventCard.vue
+++ b/components/cards/EventCard.vue
@@ -1,30 +1,40 @@
 <template>
-  <article class="event-card">
-    <nuxt-link
-      :to="to"
-      class="card-link"
-    >
-      <div class="event-content">
-        <div class="event-content__details">
-          <div>
-            <p>{{ type }}</p>
-            <h3>{{ title }}</h3>
+  <nuxt-link
+    :to="to"
+    class="card-link"
+  >
+    <article class="event-card">
+      <div class="event-card__content">
+        <header>
+          <span class="event-card__subtitle">
+            {{ type }}
+          </span>
+          <h3 class="event-card__title">
+            {{ title }}
+          </h3>
+        </header>
+
+        <footer>
+          <div class="event-card__info-detail">
+            <Map20 class="event-card__icon-map" />
+            <span class="event-card__place">{{ place }}</span>
           </div>
-          <div>
-            <p><Map20 /> {{ place }}</p>
-            <div class="event-content__date-and-arrow">
-              <p><Calendar20 /> {{ date }}</p>
-              <ArrowRight20 class="event-content__arrow-right" />
+          <div class="event-card__date-and-arrow">
+            <div class="event-card__info-detail">
+              <Calendar20 class="event-card__icon-calendar" />
+              <span class="event-card__date">{{ date }}</span>
             </div>
+            <ArrowRight20 class="event-card__icon-arrow-right" />
           </div>
-        </div>
-        <div
-          class="event-content__picture"
-          :style="`background-image: ${decorate(image)};`"
-        />
+        </footer>
       </div>
-    </nuxt-link>
-  </article>
+
+      <div
+        class="event-card__media"
+        :style="`background-image: ${decorate(image)};`"
+      />
+    </article>
+  </nuxt-link>
 </template>
 
 <script lang="ts">
@@ -50,39 +60,56 @@ export default class extends Vue {
 </script>
 
 <style lang="scss" scoped>
+@mixin config-icons($prefix, $colors...) {
+  @each $color in $colors {
+    .#{$prefix}#{nth($color, 1)} {
+      fill: nth($color, 2);
+      position: relative;
+      top: .2em;
+    }
+  }
+}
+
+@include config-icons('event-card__icon-',
+    'map' var(--white),
+    'calendar' var(--white),
+    'arrow-right' var(--purple-60)
+);
+
 .card-link {
   text-decoration: none;
 }
 
-.event-content {
+.event-card {
   height: 15.875rem;
   width: 100%;
-  display: flex;
-  font-size: 0.9rem;
-  color: var(--white);
   background-color: var(--gray-70);
+  display: flex;
 
-  &__details {
+  &__content {
+    color: var(--white);
     width: 50%;
     margin: 16px;
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    fill: var(--white);
   }
 
-  &__details p {
-    font-size: 0.875rem;
-    margin-top: 0;
-  }
-
-  &__details h3 {
+  &__title {
     font-size: 1.5rem;
+    margin-top: 0.313rem;
   }
 
-  &__details svg {
-    top: .15em;
-    position: relative;
+  &__subtitle, &__place, &__date {
+    font-size: 0.875rem;
+  }
+
+  &__place, &__date {
+    padding-left: 0.313rem;
+  }
+
+  &__info-detail {
+    margin-top: 0.625rem;
   }
 
   &__date-and-arrow {
@@ -91,11 +118,7 @@ export default class extends Vue {
     align-items: baseline;
   }
 
-  &__arrow-right {
-    fill: var(--purple-60);
-  }
-
-  &__picture {
+  &__media {
     width: 50%;
     background-repeat: no-repeat;
     background-size: cover;

--- a/components/cards/EventCard.vue
+++ b/components/cards/EventCard.vue
@@ -65,7 +65,9 @@ export default class extends Vue {
     .#{$prefix}#{nth($color, 1)} {
       fill: nth($color, 2);
       position: relative;
-      top: .2em;
+      top: .3em;
+      width: 1.25rem;
+      height: 1.25rem;
     }
   }
 }
@@ -89,7 +91,7 @@ export default class extends Vue {
   &__content {
     color: var(--white);
     width: 50%;
-    margin: 16px;
+    margin: 1rem;
     display: flex;
     flex-direction: column;
     justify-content: space-between;

--- a/components/cards/EventCard.vue
+++ b/components/cards/EventCard.vue
@@ -11,10 +11,11 @@
             <h3>{{ title }}</h3>
           </div>
           <div>
-            <Bee32 />
+            <Map32 />
             <p class="event-content__place">
               {{ place }}
             </p>
+            <Calendar32 />
             <p class="event-content__date">
               {{ date }}
             </p>
@@ -62,6 +63,7 @@ export default class extends Vue {
   display: flex;
   font-size: 0.9rem;
   color: var(--body-color-light);
+  fill: var(--body-color-light);
   background-color: var(--primary-color);
 
   &__details {

--- a/components/cards/EventCard.vue
+++ b/components/cards/EventCard.vue
@@ -31,7 +31,7 @@
 
       <div
         class="event-card__media"
-        :style="`background-image: ${decorate(image)};`"
+        :style="`background-image: url(${image});`"
       />
     </article>
   </nuxt-link>
@@ -49,13 +49,6 @@ export default class extends Vue {
   @Prop(String) place
   @Prop(String) date
   @Prop(String) to
-
-  decorate (image) {
-    const bgEffects = [
-      `url(${image})`
-    ]
-    return bgEffects.join(', ')
-  }
 }
 </script>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -817,11 +817,11 @@
       "integrity": "sha512-L3pK5YbXj2B/lXHb0NyHbGzOLpMBOP0uL9J4wARCr/NNvuyqJEkgj9JSSX7OAORkOk9NncOdpgCyKzjIBheU6w=="
     },
     "@carbon/icons-vue": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/@carbon/icons-vue/-/icons-vue-10.8.0.tgz",
-      "integrity": "sha512-kWfr6sKYTMQMTpUJ9S/iias0N9dn5GPfnZWBa1kC0/pUbimuD9XPUVFS7+uZRGy7QqeIVZFe8qlU/2W5eAqZCQ==",
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/@carbon/icons-vue/-/icons-vue-10.8.2.tgz",
+      "integrity": "sha512-dJllyOJu2D4i6GTmRocJG5YQKe+Ei5IBnuCsglNbI3gkDXnrF962eE86sV3IDnOyjjqFbUFR+27Oqln5Ha9EfQ==",
       "requires": {
-        "@carbon/icon-helpers": "^10.5.0"
+        "@carbon/icon-helpers": "^10.5.2"
       }
     },
     "@carbon/vue": {
@@ -829,8 +829,6 @@
       "resolved": "https://registry.npmjs.org/@carbon/vue/-/vue-2.23.1.tgz",
       "integrity": "sha512-KthfhPOLiolWkIp8rDv33XTbPuCWiWthR2X0+6y4UrM//zrLYdNlbrmZ9vEwSIr8D8XxvYdVWJ938RGN56CVmA==",
       "requires": {
-        "@carbon/icons-vue": "10.8.0",
-        "carbon-components": "10.9.0",
         "flatpickr": "4.6.3",
         "vue": "^2.6.10"
       }
@@ -5301,9 +5299,9 @@
       "dev": true
     },
     "carbon-components": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/carbon-components/-/carbon-components-10.9.0.tgz",
-      "integrity": "sha512-r0fHHGV1nAGazL42ecsFSBHlrRlg/2d1XAvnlnRzOvZW8O+DFR4XxpAgf5ZWKFCiiysS5eDympZTqTflN/NewQ==",
+      "version": "10.9.3",
+      "resolved": "https://registry.npmjs.org/carbon-components/-/carbon-components-10.9.3.tgz",
+      "integrity": "sha512-8TPIBjFIez2ymh3RmbHilel+/ReqpbfPf9IUBTOLtSdxI2VuyBWFxtBB/82xtHpUr3RfPdQ1U/rxDKYxoDOxrg==",
       "requires": {
         "carbon-icons": "^7.0.7",
         "flatpickr": "4.6.1",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
     "node": ">=12.x"
   },
   "dependencies": {
+    "@carbon/icons-vue": "^10.8.2",
     "@carbon/vue": "^2.23.0",
     "@nuxtjs/axios": "^5.9.3",
+    "carbon-components": "^10.9.3",
     "cross-env": "^6.0.3",
     "npm": "^6.13.4",
     "nuxt": "^2.10.2",

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -12,15 +12,28 @@
         Your browser does not support HTML5 video.
       </video>
     </header>
+    <EventCard
+      type="Camp"
+      title="Qiskit Camp 2020"
+      image="/images/events/promo-vermont.jpg"
+      place="Vermont, United States"
+      date="March 20-25, 2020"
+      to="/experiments/quantalier"
+    />
   </main>
 </template>
 
 <script lang="ts">
 import { Component } from 'vue-property-decorator'
 import QiskitPage from '~/components/qiskit/QiskitPage.vue'
+import EventCard from '~/components/cards/EventCard.vue'
 
 @Component({
   layout: 'event',
+
+  components: {
+    EventCard
+  },
 
   head () {
     return {

--- a/plugins/carbon.ts
+++ b/plugins/carbon.ts
@@ -2,13 +2,15 @@ import Vue from 'vue'
 import 'carbon-components/css/carbon-components.css'
 import CarbonComponentsVue from '@carbon/vue'
 import { CarbonIconsVue } from '@carbon/icons-vue'
-import Calendar32 from '@carbon/icons-vue/lib/calendar/32'
-import Map32 from '@carbon/icons-vue/lib/map/32'
+import Calendar20 from '@carbon/icons-vue/lib/calendar/20'
+import Map20 from '@carbon/icons-vue/lib/map/20'
+import ArrowRight20 from '@carbon/icons-vue/lib/arrow--right/20'
 
 Vue.use(CarbonComponentsVue)
 Vue.use(CarbonIconsVue, {
   components: {
-    Calendar32,
-    Map32
+    Calendar20,
+    Map20,
+    ArrowRight20
   }
 })

--- a/plugins/carbon.ts
+++ b/plugins/carbon.ts
@@ -1,5 +1,14 @@
 import Vue from 'vue'
 import 'carbon-components/css/carbon-components.css'
 import CarbonComponentsVue from '@carbon/vue'
+import { CarbonIconsVue } from '@carbon/icons-vue'
+import Calendar32 from '@carbon/icons-vue/lib/calendar/32'
+import Map32 from '@carbon/icons-vue/lib/map/32'
 
 Vue.use(CarbonComponentsVue)
+Vue.use(CarbonIconsVue, {
+  components: {
+    Calendar32,
+    Map32
+  }
+})

--- a/plugins/carbon.ts
+++ b/plugins/carbon.ts
@@ -1,10 +1,5 @@
 import Vue from 'vue'
 import 'carbon-components/css/carbon-components.css'
 import CarbonComponentsVue from '@carbon/vue'
-import { Bee32 } from '@carbon/icons-vue'
 
-Vue.use(CarbonComponentsVue, {
-  components: {
-    Bee32
-  }
-})
+Vue.use(CarbonComponentsVue)

--- a/plugins/carbon.ts
+++ b/plugins/carbon.ts
@@ -1,5 +1,10 @@
 import Vue from 'vue'
 import 'carbon-components/css/carbon-components.css'
 import CarbonComponentsVue from '@carbon/vue'
+import { Bee32 } from '@carbon/icons-vue'
 
-Vue.use(CarbonComponentsVue)
+Vue.use(CarbonComponentsVue, {
+  components: {
+    Bee32
+  }
+})


### PR DESCRIPTION
Closes #433 

To see the component in action go to https://qiskitorg-git-fork-y4izus-yg-event-card.qiskit.now.sh/events.

This is how it looks in different browsers:
- Firefox
<img width="839" alt="event-card-firefox" src="https://user-images.githubusercontent.com/17231966/75777770-d9bf8780-5d56-11ea-99e3-4e1d8a1051a7.png">

- Chrome
<img width="810" alt="event-card-chrome" src="https://user-images.githubusercontent.com/17231966/75777796-e6dc7680-5d56-11ea-925b-779b3776e73e.png">

- Safari
<img width="723" alt="event-card-safari" src="https://user-images.githubusercontent.com/17231966/75777808-ecd25780-5d56-11ea-9a2e-d9c5d4ebecc8.png">
