### PR TITLE
Fix type-styles for the landing and element pages

### DIFF
--- a/assets/scss/carbon/community-theme.scss
+++ b/assets/scss/carbon/community-theme.scss
@@ -9,5 +9,23 @@ $carbon--theme--custom: map-merge(
   )
 );
 
+/* TODO: Remove when adapting to Carbon. */
+@mixin code-08() {
+  font-family: carbon--font-family('mono');
+  font-size: 2rem;
+  font-weight: carbon--font-weight('bold');
+  letter-spacing: 0.32px;
+  margin-bottom: 2rem;
+};
+
+/* TODO: Remove when adapting to Carbon. */
+@mixin code-09() {
+  font-family: carbon--font-family('mono');
+  font-size: 2.5rem;
+  font-weight: bold;
+  letter-spacing: 0.32px;
+  margin-bottom: 2rem;
+};
+
 $carbon--theme: $carbon--theme--custom;
 @include carbon--theme();

--- a/assets/scss/carbon/community-theme.scss
+++ b/assets/scss/carbon/community-theme.scss
@@ -1,4 +1,4 @@
-@import '@carbon/themes/scss/themes';
+@import '~@carbon/themes/scss/themes';
 
 $carbon--theme--custom: map-merge(
   $carbon--theme--g90,
@@ -11,4 +11,3 @@ $carbon--theme--custom: map-merge(
 
 $carbon--theme: $carbon--theme--custom;
 @include carbon--theme();
-@import '~carbon-components/scss/globals/scss/styles.scss';

--- a/assets/scss/carbon/components.scss
+++ b/assets/scss/carbon/components.scss
@@ -1,0 +1,2 @@
+@import './community-theme';
+@import '~carbon-components/scss/globals/scss/styles.scss';

--- a/components/ctas/Cta.vue
+++ b/components/ctas/Cta.vue
@@ -37,18 +37,19 @@ export default class extends Vue {
 </script>
 
 <style lang="scss" scoped>
+@import '~carbon-components/scss/globals/scss/typography';
+
 .cta {
+  @include type-style('productive-heading-02');
+  display: inline-block;
   padding: 0.66rem 1rem;
   background-color: var(--primary-color);
   border: 2px solid var(--secondary-color);
-  font-size: 0.75em;
-  font-weight: 100;
   color: white;
   text-transform: uppercase;
   text-decoration: none;
   box-shadow: 0 4px 6px rgba(50,50,93,.11),0 1px 3px rgba(0,0,0,.08);
   white-space: nowrap;
-  line-height: 4rem;
 
   &--secondary {
     color: black;

--- a/components/ctas/LegacyCta.vue
+++ b/components/ctas/LegacyCta.vue
@@ -31,14 +31,15 @@ export default class extends Vue {
 </script>
 
 <style lang="scss" scoped>
+@import '~carbon-components/scss/globals/scss/typography';
+
 .legacy-cta {
-  font-size: 0.7rem;
+  @include type-style('productive-heading-01');
   display: inline-block;
   padding: 0.5rem 0.8rem;
   border: 2px black solid;
   color: black;
   text-decoration: none;
-  font-weight: 800;
   transition: background-color linear 200ms,
               color linear 200ms,
               fill linear 200ms;

--- a/components/footers/FooterSubsection.vue
+++ b/components/footers/FooterSubsection.vue
@@ -24,10 +24,11 @@ export default class extends Vue {
 </script>
 
 <style lang="scss" scoped>
+@import '~carbon-components/scss/globals/scss/typography';
+
 .footer-title {
+  @include type-style('productive-heading-03');
   margin-top: 2rem;
-  font-size: inherit;
-  font-weight: normal;
   padding-bottom: 0.5rem;
   border-bottom: 1px solid var(--primary-color-lightmost);
 }

--- a/components/footers/LinkList.vue
+++ b/components/footers/LinkList.vue
@@ -32,6 +32,8 @@ export default class extends Vue {
 </script>
 
 <style lang="scss" scoped>
+@import '~carbon-components/scss/globals/scss/typography';
+
 ul {
   list-style: none;
   margin-top: 1.5rem;
@@ -44,6 +46,7 @@ li {
 }
 
 .footer-link {
+  @include type-style('productive-heading-02');
   color: inherit;
   text-decoration: none;
   display: inline-block;

--- a/components/footers/PageFooter.vue
+++ b/components/footers/PageFooter.vue
@@ -38,7 +38,6 @@ export default class extends Vue {
 .page-footer {
   display: flex;
   flex-direction: row;
-  font-size: 0.9rem;
   color: var(--primary-color-lightmost);
 
   &--framed {

--- a/components/headers/LegacyPresentation.vue
+++ b/components/headers/LegacyPresentation.vue
@@ -59,7 +59,7 @@ export default class extends Vue {
 </script>
 
 <style lang="scss" scoped>
-@import '~/assets/scss/mixins.scss';
+@import '~carbon-components/scss/globals/scss/typography';
 
 .legacy-presentation {
   color: var(--legacy-presentation-text-color, white);
@@ -83,14 +83,11 @@ export default class extends Vue {
   }
 
   &__title {
-    font-size: 2rem;
-    font-weight: 400;
-    font-family: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace;
+    @include type-style('productive-heading-07');
   }
 
   &__description {
-    font-size: 1.2rem;
-    font-weight: 400;
+    @include type-style('body-short-02');
     margin: 1.1rem 0;
   }
 

--- a/components/headers/LegacyPresentation.vue
+++ b/components/headers/LegacyPresentation.vue
@@ -83,11 +83,11 @@ export default class extends Vue {
   }
 
   &__title {
-    @include type-style('productive-heading-07');
+    @include code-09();
   }
 
   &__description {
-    @include type-style('body-short-02');
+    @include type-style('productive-heading-04');
     margin: 1.1rem 0;
   }
 

--- a/components/menus/QiskitOrgMenu.vue
+++ b/components/menus/QiskitOrgMenu.vue
@@ -167,8 +167,10 @@ export default class extends Vue {
 </script>
 
 <style lang="scss" scoped>
+@import '~carbon-components/scss/globals/scss/typography';
+
 @mixin vertical-navigation-item() {
-  font-size: 0.9rem;
+  @include type-style('productive-heading-02');
   text-decoration: none;
   color: white;
   padding: 0.5rem 1.5em;
@@ -179,8 +181,6 @@ export default class extends Vue {
 }
 
 .menu-container {
-  font-size: 16px;
-  font-weight: 400;
   border-bottom: 1px solid black;
   background-color: var(--gray-90);
   --link-color: white;
@@ -194,7 +194,6 @@ export default class extends Vue {
 .menu {
   height: 60px;
   display: flex;
-  font-size: 0.8rem;
   & > * {
     height: 100%;
   }
@@ -207,6 +206,7 @@ export default class extends Vue {
   display: flex;
 
   &__item {
+    @include type-style('productive-heading-02');
     display: inline-flex;
     align-items: center;
     padding: 0 1em;
@@ -214,7 +214,6 @@ export default class extends Vue {
     text-decoration: none;
 
     &.nuxt-link-active {
-      font-weight: bold;
       position: relative;
       top: 1px;
       border-bottom: 4px solid var(--secondary-color);
@@ -250,6 +249,7 @@ export default class extends Vue {
 }
 
 .link-to-home {
+  @include type-style('productive-heading-03');
   display: inline-flex;
   align-items: center;
   margin-left: -1.2rem;
@@ -258,7 +258,6 @@ export default class extends Vue {
   text-decoration: none;
 
   @include mq($until: large) {
-    font-size: 1.1rem;
     margin-left: -0.5rem;
   }
 }
@@ -314,8 +313,7 @@ export default class extends Vue {
   overflow-y: auto;
 
   h2 {
-    font-size: 0.8rem;
-    font-weight: normal;
+    @include type-style('productive-heading-03');
     color: var(--primary-color-lightmost);
     padding: 1em;
   }
@@ -338,7 +336,6 @@ export default class extends Vue {
     color: var(--body-color-dark);
 
     &.nuxt-link-active {
-      font-weight: bold;
       border-left: 4px solid var(--secondary-color);
       padding-left: calc(3rem - 4px);
     }

--- a/components/menus/QiskitOrgMenu.vue
+++ b/components/menus/QiskitOrgMenu.vue
@@ -249,7 +249,7 @@ export default class extends Vue {
 }
 
 .link-to-home {
-  @include type-style('productive-heading-03');
+  @include type-style('productive-heading-02');
   display: inline-flex;
   align-items: center;
   margin-left: -1.2rem;

--- a/components/qiskit/SoftwareStack.vue
+++ b/components/qiskit/SoftwareStack.vue
@@ -25,6 +25,8 @@ export default class extends Vue {
 </script>
 
 <style lang="scss" scoped>
+@import '~carbon-components/scss/globals/scss/typography';
+
 .stack-list {
   list-style: none;
 
@@ -67,15 +69,14 @@ export default class extends Vue {
     line-height: normal;
     position: relative;
     top: -0.2rem;
-    font-weight: 400;
   }
 
   &__title {
-    font-size: 0.9rem;
+    @include type-style('productive-heading-02');
   }
 
   &__description {
-    font-size: 0.7rem;
+    @include type-style('body-short-01');
   }
 }
 </style>

--- a/components/qiskit/SyntaxHighlight.vue
+++ b/components/qiskit/SyntaxHighlight.vue
@@ -30,6 +30,8 @@ export default class extends Vue {
 </script>
 
 <style lang="scss" scoped>
+@import '~carbon-components/scss/globals/scss/typography';
+
 .syntax-highlight {
   position: relative;
 
@@ -43,8 +45,8 @@ export default class extends Vue {
   }
 
   code {
+    @include type-style('code-02');
     padding: 1.5rem 1rem;
-    font-size: 0.7rem;
   }
 }
 </style>

--- a/components/sections/LegacySection.vue
+++ b/components/sections/LegacySection.vue
@@ -39,12 +39,13 @@ export default class extends Vue {
     }
 
     h2 {
-      @include type-style('productive-heading-06');
+      @include code-08();
     }
 
     p {
-      @include type-style('body-short-02');
-      line-height: 1.7rem;
+      @include type-style('body-long-02');
+      /* TODO: Remove when adapting to Carbon. Should be regulated by the type style. */
+      line-height: 2rem;
       margin-top: 0.9rem;
       margin-bottom: 0.9rem;
 

--- a/components/sections/LegacySection.vue
+++ b/components/sections/LegacySection.vue
@@ -17,7 +17,7 @@ export default class extends Vue {
 </script>
 
 <style lang="scss" scoped>
-@import '~/assets/scss/mixins.scss';
+@import '~carbon-components/scss/globals/scss/typography';
 
 .legacy-section {
   & > div {
@@ -39,22 +39,17 @@ export default class extends Vue {
     }
 
     h2 {
-      font-size: 1.5rem;
-      font-weight: 300;
-      font-family: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace;
-      margin-bottom: 1.5rem;
+      @include type-style('productive-heading-06');
     }
 
     p {
-      font-weight: normal;
-      font-size: 0.85rem;
+      @include type-style('body-short-02');
       line-height: 1.7rem;
       margin-top: 0.9rem;
       margin-bottom: 0.9rem;
 
       a {
         color: black;
-        font-style: italic;
       }
     }
   }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -61,8 +61,7 @@ const config: Configuration = {
   ** Global CSS
   */
   css: [
-    '~/static/css/fonts.css',
-    '~/assets/scss/carbon-theme.scss'
+    '~/static/css/fonts.css'
   ],
 
   /*
@@ -91,7 +90,8 @@ const config: Configuration = {
     */
     scss: [
       './assets/scss/mq.scss',
-      './assets/scss/mixins.scss'
+      './assets/scss/mixins.scss',
+      './assets/scss/carbon/community-theme.scss'
     ]
   },
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -162,6 +162,8 @@ export default class extends QiskitPage {
 </script>
 
 <style lang="scss">
+@import '~carbon-components/scss/globals/scss/typography';
+
 .legacy-section {
   background-color: white;
 }
@@ -184,7 +186,7 @@ export default class extends QiskitPage {
     padding: 0.8rem;
 
     a {
-      font-weight: 400;
+      @include type-style('productive-heading-02');
       text-decoration: none;
 
       &:hover {
@@ -201,7 +203,6 @@ export default class extends QiskitPage {
     .name {
       color: black;
       margin-left: 0.5rem;
-      font-size: 0.8rem;
     }
   }
 }

--- a/plugins/carbon.ts
+++ b/plugins/carbon.ts
@@ -1,5 +1,6 @@
 import Vue from 'vue'
 import CarbonComponentsVue from '@carbon/vue'
+import '~/assets/scss/carbon/components.scss'
 import { CarbonIconsVue } from '@carbon/icons-vue'
 import Calendar20 from '@carbon/icons-vue/lib/calendar/20'
 import Map20 from '@carbon/icons-vue/lib/map/20'

--- a/static/css/fonts.css
+++ b/static/css/fonts.css
@@ -1,46 +1,8 @@
 @font-face {
-  font-family: 'IBM Plex Mono';
-  font-style: normal;
-  font-weight: 700;
-  src: local("IBM Plex Mono Bold"), local("IBMPlexMono-Bold"), url("/fonts/IBM-Plex-Mono/fonts/complete/woff/IBMPlexMono-Bold.woff") format("woff"); }
-
-@font-face {
-  font-family: 'IBM Plex Mono';
-  font-style: normal;
-  font-weight: 400;
-  src: local("IBM Plex Mono"), local("IBMPlexMono"), url("/fonts/IBM-Plex-Mono/fonts/complete/woff/IBMPlexMono-Regular.woff") format("woff");
-}
-
-@font-face {
-  font-family: 'IBM Plex Mono';
-  font-style: italic;
-  font-weight: 400;
-  src: local("IBM Plex Mono Italic"), local("IBMPlexMono-Italic"), url("/fonts/IBM-Plex-Mono/fonts/complete/woff/IBMPlexMono-Italic.woff") format("woff");
-}
-
-@font-face {
-  font-family: 'IBM Plex Sans';
-  font-style: normal;
-  font-weight: 700;
-  src: local("IBM Plex Sans Bold"), local("IBMPlexSans-Bold"), url("/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Bold.woff") format("woff"); }
-
-@font-face {
-  font-family: 'IBM Plex Sans';
-  font-style: italic;
-  font-weight: 700;
-  src: local("IBM Plex Sans Bold Italic"), local("IBMPlexSans-BoldItalic"), url("/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-BoldItalic.woff") format("woff"); }
-
-@font-face {
   font-family: 'IBM Plex Sans';
   font-style: normal;
   font-weight: 300;
   src: local("IBM Plex Sans Light"), local("IBMPlexSans-Light"), url("/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Light.woff") format("woff"); }
-
-@font-face {
-  font-family: 'IBM Plex Sans';
-  font-style: italic;
-  font-weight: 300;
-  src: local("IBM Plex Sans Light Italic"), local("IBMPlexSans-LightItalic"), url("/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-LightItalic.woff") format("woff"); }
 
 @font-face {
   font-family: 'IBM Plex Sans';
@@ -50,6 +12,12 @@
 
 @font-face {
   font-family: 'IBM Plex Sans';
-  font-style: italic;
+  font-style: normal;
+  font-weight: 600;
+  src: local("IBM Plex Sans SemiBold"), local("IBMPlexSans-SemiBold"), url("/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-SemiBold.woff") format("woff"); }
+
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
   font-weight: 400;
-  src: local("IBM Plex Sans Italic"), local("IBMPlexSans-Italic"), url("/fonts/IBM-Plex-Sans/fonts/complete/woff/IBMPlexSans-Italic.woff") format("woff"); }
+  src: local("IBM Plex Mono"), local("IBMPlexMono"), url("/fonts/IBM-Plex-Mono/fonts/complete/woff/IBMPlexMono-Regular.woff") format("woff"); }

--- a/static/css/fonts.css
+++ b/static/css/fonts.css
@@ -21,3 +21,7 @@
   font-style: normal;
   font-weight: 400;
   src: local("IBM Plex Mono"), local("IBMPlexMono"), url("/fonts/IBM-Plex-Mono/fonts/complete/woff/IBMPlexMono-Regular.woff") format("woff"); }
+
+html {
+  text-rendering: optimizeLegibility;
+}


### PR DESCRIPTION
Fix #453

The PR does not try to use Carbon as intended, creating a correct type hierarchy but using those Carbon styles closest to how qiskit.org landing and element pages look right now to start using Carbon infrastructure.