### PR TITLE
Removes event card arrow if the event hasn't web

### DIFF
--- a/components/cards/EventCard.vue
+++ b/components/cards/EventCard.vue
@@ -25,7 +25,7 @@
               <Calendar20 class="event-card__icon" />
               <span class="event-card__date"><time>{{ date }}</time></span>
             </div>
-            <ArrowRight20 v-if="to" class="event-card__icon event-card__icon--purple"/>
+            <ArrowRight20 v-if="hasWebsite" class="event-card__icon event-card__icon--purple"/>
           </div>
         </footer>
       </div>
@@ -50,6 +50,8 @@ export default class extends Vue {
   @Prop(String) place
   @Prop(String) date
   @Prop(String) to
+
+  hasWebsite: boolean = !!this.to
 }
 </script>
 

--- a/components/cards/EventCard.vue
+++ b/components/cards/EventCard.vue
@@ -25,7 +25,7 @@
               <Calendar20 class="event-card__icon" />
               <span class="event-card__date"><time>{{ date }}</time></span>
             </div>
-            <ArrowRight20 class="event-card__icon event-card__icon--purple" />
+            <ArrowRight20 v-if="to" class="event-card__icon event-card__icon--purple"/>
           </div>
         </footer>
       </div>

--- a/content/events/past-community-events.json
+++ b/content/events/past-community-events.json
@@ -13,7 +13,8 @@
     "image": "/images/events/promo-asia.jpg",
     "place": "New Haven, CT",
     "location": "Asia",
-    "date": "April 2, 2020"
+    "date": "April 2, 2020",
+    "to": "/events/asia"
   },
   {
     "title": "CQE Recruiting Forum",


### PR DESCRIPTION
Fix #506 

<img width="800" alt="Screen Shot 2020-04-09 at 15 02 55" src="https://user-images.githubusercontent.com/17231966/78897903-34918080-7a73-11ea-98a0-30a6b15b58b8.png">
