### PR TITLE
Allow filtering events with multiple types

### DIFF
--- a/content/education/textbook-toc.md
+++ b/content/education/textbook-toc.md
@@ -33,7 +33,7 @@
 - Randomized Benchmarking
 - Measuring Quantum Volume
 ### Chapter 6. Investigating Quantum Hardware Using Microwave Pulses
-- Calibrating Qubits with OpenPulse
+- Calibrating Qubits with Qiskit Pulse
 - Accessing Higher Energy States
-### Chapter 7. Demos
-- Estimating Pi Using Quantum Phase Estimation Algorithm
+### Chapter 7. Problem Sets & Exercises
+### Chapter 8. Games & Demos

--- a/content/events/past-community-events.json
+++ b/content/events/past-community-events.json
@@ -1,83 +1,85 @@
 [
   {
     "title": "Hackathon @ Harvard",
-    "type": [
-      "Hackathon"
+    "types": [
+      "Hackathon",
+      "Camp"
     ],
-    "image": "/images/events/promo-asia.jpg",
+    "image": "/images/events/no-picture.jpg",
     "place": "Boston, MA",
-    "location": "Africa",
+    "location": "Americas",
     "date": "April 2-3, 2020"
   },
   {
     "title": "Yale YQI Roundtable event",
-    "type": [
-      "Conference"
+    "types": [
+      "Conference",
+      "Hackathon"
     ],
-    "image": "/images/events/promo-asia.jpg",
+    "image": "/images/events/no-picture.jpg",
     "place": "New Haven, CT",
-    "location": "Online",
+    "location": "Asia Pacific",
     "date": "April 2, 2020"
   },
   {
     "title": "CQE Recruiting Forum",
-    "type": [
+    "types": [
       "Conference"
     ],
-    "image": "/images/events/promo-finland-unconference.jpg",
+    "image": "/images/events/no-picture.jpg",
     "place": "Chicago, IL",
-    "location": "Americas",
+    "location": "Online",
     "date": "April 1, 2020"
   },
   {
     "title": "Hackathon @ Uni College Dublin",
-    "type": [
+    "types": [
       "Hackathon"
     ],
-    "image": "/images/events/promo-finland-unconference.jpg",
+    "image": "/images/events/no-picture.jpg",
     "place": "Dublin, Ireland",
-    "location": "Africa",
+    "location": "Online",
     "date": "March 28, 2020"
   },
   {
     "title": "Q Meetup in Bangkok",
-    "type": [
+    "types": [
       "Conference"
     ],
-    "image": "/images/events/promo-asia.jpg",
+    "image": "/images/events/no-picture.jpg",
     "place": "Bangkok, Thailand",
-    "location": "Europe",
+    "location": "Asia Pacific",
     "date": "March 26-31, 2020"
   },
   {
     "title": "NSBE Annual Convention",
-    "type": [
+    "types": [
       "Conference"
     ],
-    "image": "/images/events/promo-vermont.jpg",
+    "image": "/images/events/no-picture.jpg",
     "place": "San Antonio, TX",
-    "location": "Online",
+    "location": "Americas",
     "date": "March 25-29, 2020",
     "to": "http://convention.nsbe.org"
   },
   {
     "title": "Hack-Q-Thon (NYC High School Hackathon)",
-    "type": [
+    "types": [
       "Hackathon"
     ],
-    "image": "/images/events/promo-asia.jpg",
+    "image": "/images/events/no-picture.jpg",
     "place": "NYU Campus, NY",
-    "location": "Africa",
+    "location": "Asia Pacific",
     "date": "March 21, 2020"
   },
   {
     "title": "Hackathon @ Uni College London",
-    "type": [
+    "types": [
       "Hackathon"
     ],
-    "image": "/images/events/promo-vermont.jpg",
+    "image": "/images/events/no-picture.jpg",
     "place": "London, England",
-    "location": "Asia Pacific",
+    "location": "Online",
     "date": "March 19-20, 2020"
   }
 ]

--- a/content/events/past-community-events.json
+++ b/content/events/past-community-events.json
@@ -1,75 +1,83 @@
 [
   {
     "title": "Hackathon @ Harvard",
-    "type": "Hackathon",
-    "image": "/images/events/promo-finland-unconference.jpg",
+    "type": [
+      "Hackathon"
+    ],
+    "image": "/images/events/promo-asia.jpg",
     "place": "Boston, MA",
-    "location": "America",
+    "location": "Africa",
     "date": "April 2-3, 2020"
   },
   {
     "title": "Yale YQI Roundtable event",
-    "type": "Conference",
+    "type": [
+      "Conference"
+    ],
     "image": "/images/events/promo-asia.jpg",
     "place": "New Haven, CT",
-    "location": "Asia",
-    "date": "April 2, 2020",
-    "to": "/events/asia"
+    "location": "Online",
+    "date": "April 2, 2020"
   },
   {
     "title": "CQE Recruiting Forum",
-    "type": "Conference",
-    "image": "/images/events/promo-asia.jpg",
+    "type": [
+      "Conference"
+    ],
+    "image": "/images/events/promo-finland-unconference.jpg",
     "place": "Chicago, IL",
-    "location": "Africa",
+    "location": "Americas",
     "date": "April 1, 2020"
   },
   {
     "title": "Hackathon @ Uni College Dublin",
-    "type": "Hackathon",
+    "type": [
+      "Hackathon"
+    ],
     "image": "/images/events/promo-finland-unconference.jpg",
     "place": "Dublin, Ireland",
-    "location": "Asia Pacific",
+    "location": "Africa",
     "date": "March 28, 2020"
   },
   {
     "title": "Q Meetup in Bangkok",
-    "type": "Conference",
-    "image": "/images/events/promo-finland-unconference.jpg",
+    "type": [
+      "Conference"
+    ],
+    "image": "/images/events/promo-asia.jpg",
     "place": "Bangkok, Thailand",
     "location": "Europe",
     "date": "March 26-31, 2020"
   },
   {
     "title": "NSBE Annual Convention",
-    "type": "Conference",
+    "type": [
+      "Conference"
+    ],
     "image": "/images/events/promo-vermont.jpg",
     "place": "San Antonio, TX",
-    "location": "Africa",
+    "location": "Online",
     "date": "March 25-29, 2020",
     "to": "http://convention.nsbe.org"
   },
   {
     "title": "Hack-Q-Thon (NYC High School Hackathon)",
-    "type": "Hackathon",
-    "image": "/images/events/promo-finland-unconference.jpg",
+    "type": [
+      "Hackathon"
+    ],
+    "image": "/images/events/promo-asia.jpg",
     "place": "NYU Campus, NY",
-    "location": "Europe",
+    "location": "Africa",
     "date": "March 21, 2020"
   },
   {
     "title": "Hackathon @ Uni College London",
-    "type": "Hackathon",
+    "type": [
+      "Hackathon"
+    ],
     "image": "/images/events/promo-vermont.jpg",
     "place": "London, England",
-    "location": "Africa",
+    "location": "Asia Pacific",
     "date": "March 19-20, 2020"
-  },
-  {
-    "title": "Qiskit Camp 2020 (NY)",
-    "type": "Camp",
-    "image": "/images/events/promo-finland-unconference.jpg",
-    "location": "Europe",
-    "date": "March 10-13, 2020"
   }
 ]

--- a/content/events/upcoming-community-events.json
+++ b/content/events/upcoming-community-events.json
@@ -1,18 +1,22 @@
 [
   {
     "title": "Hackathon @ Princeton",
-    "type": "Hackathon",
-    "image": "/images/events/promo-vermont.jpg",
+    "type": [
+      "Hackathon"
+    ],
+    "image": "/images/events/promo-finland-unconference.jpg",
     "place": "Princeton, NJ",
     "location": "Africa",
     "date": "April 18-19, 2020"
   },
   {
     "title": "Hackathon @ Stanford",
-    "type": "Hackathon",
+    "type": [
+      "Hackathon"
+    ],
     "image": "/images/events/promo-finland-unconference.jpg",
     "place": "Stanford, CA",
-    "location": "Online",
+    "location": "Americas",
     "date": "May 1-2, 2020"
   }
 ]

--- a/content/events/upcoming-community-events.json
+++ b/content/events/upcoming-community-events.json
@@ -1,22 +1,22 @@
 [
   {
     "title": "Hackathon @ Princeton",
-    "type": [
+    "types": [
       "Hackathon"
     ],
-    "image": "/images/events/promo-finland-unconference.jpg",
+    "image": "/images/events/no-picture.jpg",
     "place": "Princeton, NJ",
-    "location": "Africa",
+    "location": "Europe",
     "date": "April 18-19, 2020"
   },
   {
     "title": "Hackathon @ Stanford",
-    "type": [
+    "types": [
       "Hackathon"
     ],
-    "image": "/images/events/promo-finland-unconference.jpg",
+    "image": "/images/events/no-picture.jpg",
     "place": "Stanford, CA",
-    "location": "Americas",
+    "location": "Online",
     "date": "May 1-2, 2020"
   }
 ]

--- a/hooks/event-conversion-utils.ts
+++ b/hooks/event-conversion-utils.ts
@@ -43,7 +43,7 @@ async function fetchCommunityEvents (apiKey: string, { days }): Promise<Communit
 function convertToCommunityEvent (record: any): CommunityEvent {
   return {
     title: getName(record),
-    type: getType(record),
+    types: getTypes(record),
     image: getImage(record),
     place: getPlace(record),
     location: getLocation(record),
@@ -56,12 +56,12 @@ function getName (record: any): string {
   return record.get(RECORD_FIELDS.name)
 }
 
-function getType (record: any): CommunityEventType[] {
+function getTypes (record: any): CommunityEventType[] {
   const value = record.get(RECORD_FIELDS.typeOfEvent) || []
   const valueList = (Array.isArray(value) ? value : [value]) as string[]
   const communityEventTypes = filterWithWhitelist(valueList, TYPE_CATEGORIES)
-  const isEmpty = communityEventTypes.length === 0
-  return isEmpty ? ['Conference'] : communityEventTypes
+  const noTypes = communityEventTypes.length === 0
+  return noTypes ? ['Conference'] : communityEventTypes
 }
 
 function filterWithWhitelist<W> (list: any[], whitelist: W[]): W[] {
@@ -151,7 +151,7 @@ export {
   fetchCommunityEvents,
   convertToCommunityEvent,
   getName,
-  getType,
+  getTypes,
   getImage,
   getPlace,
   getLocation,

--- a/hooks/event-conversion-utils.ts
+++ b/hooks/event-conversion-utils.ts
@@ -43,7 +43,7 @@ async function fetchCommunityEvents (apiKey: string, { days }): Promise<Communit
 function convertToCommunityEvent (record: any): CommunityEvent {
   return {
     title: getName(record),
-    type: getType(record, TYPE_CATEGORIES, 'Conference'),
+    type: getType(record),
     image: getImage(record),
     place: getPlace(record),
     location: getLocation(record),
@@ -56,12 +56,16 @@ function getName (record: any): string {
   return record.get(RECORD_FIELDS.name)
 }
 
-function getType (record: any, whitelist: CommunityEventType[], defaultType: CommunityEventType): CommunityEventType[] {
+function getType (record: any): CommunityEventType[] {
   const value = record.get(RECORD_FIELDS.typeOfEvent) || []
-  const valueList = Array.isArray(value) ? value : [value]
-  const communityEventTypes = valueList.filter(type => whitelist.includes(type))
+  const valueList = (Array.isArray(value) ? value : [value]) as string[]
+  const communityEventTypes = filterWithWhitelist(valueList, TYPE_CATEGORIES)
   const isEmpty = communityEventTypes.length === 0
-  return isEmpty ? [defaultType] : communityEventTypes
+  return isEmpty ? ['Conference'] : communityEventTypes
+}
+
+function filterWithWhitelist<W> (list: any[], whitelist: W[]): W[] {
+  return list.filter((type): type is W => whitelist.includes(type))
 }
 
 function getImage (record: any): string {
@@ -153,5 +157,6 @@ export {
   getLocation,
   getWebsite,
   getDates,
-  formatDates
+  formatDates,
+  filterWithWhitelist
 }

--- a/hooks/event-conversion-utils.ts
+++ b/hooks/event-conversion-utils.ts
@@ -5,7 +5,8 @@ import {
   CommunityEvent,
   CommunityEventType,
   WorldLocation,
-  LOCATION_CATEGORIES
+  LOCATION_CATEGORIES,
+  TYPE_CATEGORIES
 } from '../store/modules/events'
 
 const RECORD_FIELDS = {
@@ -42,7 +43,7 @@ async function fetchCommunityEvents (apiKey: string, { days }): Promise<Communit
 function convertToCommunityEvent (record: any): CommunityEvent {
   return {
     title: getName(record),
-    type: getType(record),
+    type: getType(record, TYPE_CATEGORIES, 'Conference'),
     image: getImage(record),
     place: getPlace(record),
     location: getLocation(record),
@@ -55,17 +56,12 @@ function getName (record: any): string {
   return record.get(RECORD_FIELDS.name)
 }
 
-function getType (record: any): CommunityEventType {
-  if (record.get(RECORD_FIELDS.name).toLowerCase().includes('qiskit camp')) {
-    return 'Camp'
-  }
-  if ((record.get(RECORD_FIELDS.typeOfEvent) || []).includes('Hackathon')) {
-    return 'Hackathon'
-  }
-  if ((record.get(RECORD_FIELDS.typeOfEvent) || []).includes('Unconference')) {
-    return 'Unconference'
-  }
-  return 'Conference'
+function getType (record: any, whitelist: CommunityEventType[], defaultType: CommunityEventType): CommunityEventType[] {
+  const value = record.get(RECORD_FIELDS.typeOfEvent) || []
+  const valueList = Array.isArray(value) ? value : [value]
+  const communityEventTypes = valueList.filter(type => whitelist.includes(type))
+  const isEmpty = communityEventTypes.length === 0
+  return isEmpty ? [defaultType] : communityEventTypes
 }
 
 function getImage (record: any): string {

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@
 // https://github.com/Al-un/learn-nuxt-ts/blob/master/docs/06.test.md
 
 module.exports = {
+  preset: 'ts-jest/presets/js-with-ts',
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
     '^~/(.*)$': '<rootDir>/$1'

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -67,7 +67,7 @@
           <EventCard
             v-for="event in filteredEvents"
             :key="`${event.place}-${event.date}`"
-            :type="formatType(event.type)"
+            :type="formatType(event.types)"
             :title="event.title"
             :image="event.image"
             :place="event.place"

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -67,7 +67,7 @@
           <EventCard
             v-for="event in filteredEvents"
             :key="`${event.place}-${event.date}`"
-            :type="event.type"
+            :type="formatType(event.type)"
             :title="event.title"
             :image="event.image"
             :place="event.place"
@@ -186,6 +186,10 @@ export default class extends QiskitPage {
     const activeSet = selectedTab === 0 ? 'upcoming' : 'past'
 
     this.$store.commit('setActiveSet', activeSet)
+  }
+
+  formatType (types: CommunityEvent[]): string {
+    return types.join(', ')
   }
 }
 </script>

--- a/store/modules/events.ts
+++ b/store/modules/events.ts
@@ -3,7 +3,7 @@ type WorldLocation = 'Americas'|'Asia Pacific'|'Europe'|'Africa'|'TBD'|'Online'
 type CommunityEventType = 'Hackathon'|'Camp'|'Unconference'|'Conference'
 
 type CommunityEvent = {
-  type: CommunityEventType[],
+  types: CommunityEventType[],
   title: string,
   image: string,
   place: string,
@@ -55,7 +55,7 @@ export default {
 
       if (noTypeFilters && noLocationFilters) { return events }
 
-      const eventsAfterApplyTypeFilter = filterBy(events, typeFilters, 'type')
+      const eventsAfterApplyTypeFilter = filterBy(events, typeFilters, 'types')
 
       return filterBy(eventsAfterApplyTypeFilter, locationFilters, 'location')
 

--- a/store/modules/events.ts
+++ b/store/modules/events.ts
@@ -17,12 +17,14 @@ const LOCATION_CATEGORIES: WorldLocation[] = ['Americas', 'Asia Pacific', 'Europ
 export { CommunityEvent, CommunityEventType, WorldLocation, LOCATION_CATEGORIES }
 
 export default {
-  state: {
-    activeSet: 'upcoming',
-    upcomingCommunityEvents: [],
-    pastCommunityEvents: [],
-    typeFilters: [],
-    locationFilters: []
+  state () {
+    return {
+      activeSet: 'upcoming',
+      upcomingCommunityEvents: [],
+      pastCommunityEvents: [],
+      typeFilters: [],
+      locationFilters: []
+    }
   },
   getters: {
     typeFilters (state) {

--- a/store/modules/events.ts
+++ b/store/modules/events.ts
@@ -3,7 +3,7 @@ type WorldLocation = 'Americas'|'Asia Pacific'|'Europe'|'Africa'|'TBD'|'Online'
 type CommunityEventType = 'Hackathon'|'Camp'|'Unconference'|'Conference'
 
 type CommunityEvent = {
-  type: CommunityEventType,
+  type: CommunityEventType[],
   title: string,
   image: string,
   place: string,
@@ -13,8 +13,15 @@ type CommunityEvent = {
 }
 
 const LOCATION_CATEGORIES: WorldLocation[] = ['Americas', 'Asia Pacific', 'Europe', 'Africa', 'Online']
+const TYPE_CATEGORIES: CommunityEventType[] = ['Hackathon', 'Camp', 'Unconference']
 
-export { CommunityEvent, CommunityEventType, WorldLocation, LOCATION_CATEGORIES }
+export {
+  CommunityEvent,
+  CommunityEventType,
+  WorldLocation,
+  LOCATION_CATEGORIES,
+  TYPE_CATEGORIES
+}
 
 export default {
   state () {

--- a/store/modules/events.ts
+++ b/store/modules/events.ts
@@ -50,12 +50,16 @@ export default {
 
       return filterBy(eventsAfterApplyTypeFilter, locationFilters, 'location')
 
-      function filterBy (allEvents, selectedFilters, propToFilter) {
+      function filterBy (allEvents: CommunityEvent[], selectedFilters: string[], propToFilter: keyof CommunityEvent) {
         const noFilters = selectedFilters.length === 0
 
         if (noFilters) { return allEvents }
 
-        return allEvents.filter(event => selectedFilters.includes(event[propToFilter]))
+        return allEvents.filter((event) => {
+          const propValue = event[propToFilter]
+          const valueArray = Array.isArray(propValue) ? propValue : [propValue]
+          return valueArray.some(value => selectedFilters.includes(value))
+        })
       }
     }
   },

--- a/tests/hooks/event-conversion-utils.spec.ts
+++ b/tests/hooks/event-conversion-utils.spec.ts
@@ -1,15 +1,12 @@
 import {
   RECORD_FIELDS,
   formatDates,
+  filterWithWhitelist,
   convertToCommunityEvent,
   getType,
   getDates,
   getImage
 } from '~/hooks/event-conversion-utils'
-
-import {
-  TYPE_CATEGORIES
-} from '~/store/modules/events'
 
 type RecordFields = {
   name: string,
@@ -70,14 +67,14 @@ describe('getType', () => {
       name: 'Fake Camp',
       types: ['Hackathon', 'Community', 'Unknown']
     })
-    expect(getType(camp, TYPE_CATEGORIES, 'Conference')).toEqual(['Hackathon'])
+    expect(getType(camp)).toEqual(['Hackathon'])
   })
 
   it('if there is no type, get the default type', () => {
     const camp = new FakeRecord({
       name: 'Fake Camp'
     })
-    expect(getType(camp, TYPE_CATEGORIES, 'Conference')).toEqual(['Conference'])
+    expect(getType(camp)).toEqual(['Conference'])
   })
 
   it('if no type is in the whitelist, get the default type', () => {
@@ -85,7 +82,7 @@ describe('getType', () => {
       name: 'Fake Camp',
       types: ['A', 'B', 'C']
     })
-    expect(getType(camp, TYPE_CATEGORIES, 'Conference')).toEqual(['Conference'])
+    expect(getType(camp)).toEqual(['Conference'])
   })
 
   it('get an array of one value if the type is not an array but one value', () => {
@@ -93,7 +90,14 @@ describe('getType', () => {
       name: 'Fake Conference',
       types: 'Hackathon'
     })
-    expect(getType(camp, TYPE_CATEGORIES, 'Conference')).toEqual(['Hackathon'])
+    expect(getType(camp)).toEqual(['Hackathon'])
+  })
+})
+
+describe('filterByWhitelist', () => {
+  it('given a list, creates a new list only with the values in a whitelist', () => {
+    const list = ['a', 'x', 'b', 'y', 'c', 'z', 'a', 'x', 'b', 'y']
+    expect(filterWithWhitelist(list, ['a', 'b', 'c'])).toEqual(['a', 'b', 'c', 'a', 'b'])
   })
 })
 

--- a/tests/hooks/event-conversion-utils.spec.ts
+++ b/tests/hooks/event-conversion-utils.spec.ts
@@ -3,7 +3,7 @@ import {
   formatDates,
   filterWithWhitelist,
   convertToCommunityEvent,
-  getType,
+  getTypes,
   getDates,
   getImage
 } from '~/hooks/event-conversion-utils'
@@ -48,12 +48,12 @@ describe('convertToCommunityEvent', () => {
     website: 'https://qiskit.org/events'
   })
 
-  it('extract and format information from the record', () => {
+  it('extracts and format information from the record', () => {
     // TODO: Now ignoring image and location since they are random. Add them once implemented.
-    const { title, type, place, date, to } = convertToCommunityEvent(fakeRecord)
-    expect({ title, type, place, date, to }).toEqual({
+    const { title, types, place, date, to } = convertToCommunityEvent(fakeRecord)
+    expect({ title, types, place, date, to }).toEqual({
       title: 'Fake conference',
-      type: ['Hackathon'],
+      types: ['Hackathon'],
       place: 'Someplace',
       date: 'January 1-2, 2020',
       to: 'https://qiskit.org/events'
@@ -62,40 +62,40 @@ describe('convertToCommunityEvent', () => {
 })
 
 describe('getType', () => {
-  it('filter the values so only those in the whitelist gets into the event', () => {
+  it('filters the values so only those in the whitelist gets into the event', () => {
     const camp = new FakeRecord({
       name: 'Fake Camp',
       types: ['Hackathon', 'Community', 'Unknown']
     })
-    expect(getType(camp)).toEqual(['Hackathon'])
+    expect(getTypes(camp)).toEqual(['Hackathon'])
   })
 
-  it('if there is no type, get the default type', () => {
+  it('gets the default type if there is no type', () => {
     const camp = new FakeRecord({
       name: 'Fake Camp'
     })
-    expect(getType(camp)).toEqual(['Conference'])
+    expect(getTypes(camp)).toEqual(['Conference'])
   })
 
-  it('if no type is in the whitelist, get the default type', () => {
+  it('gets the default type if no type is in the whitelist', () => {
     const camp = new FakeRecord({
       name: 'Fake Camp',
       types: ['A', 'B', 'C']
     })
-    expect(getType(camp)).toEqual(['Conference'])
+    expect(getTypes(camp)).toEqual(['Conference'])
   })
 
-  it('get an array of one value if the type is not an array but one value', () => {
+  it('gets an array of one value if the type is not an array but one value', () => {
     const camp = new FakeRecord({
       name: 'Fake Conference',
       types: 'Hackathon'
     })
-    expect(getType(camp)).toEqual(['Hackathon'])
+    expect(getTypes(camp)).toEqual(['Hackathon'])
   })
 })
 
 describe('filterByWhitelist', () => {
-  it('given a list, creates a new list only with the values in a whitelist', () => {
+  it('creates a new list, from an input one, only with the values in a whitelist', () => {
     const list = ['a', 'x', 'b', 'y', 'c', 'z', 'a', 'x', 'b', 'y']
     expect(filterWithWhitelist(list, ['a', 'b', 'c'])).toEqual(['a', 'b', 'c', 'a', 'b'])
   })
@@ -220,11 +220,11 @@ describe('formatDates', () => {
     expect(formatDates(start, endNextYear)).toBe('January 1, 2020 - January 1, 2021')
   })
 
-  it('factor out the year when years are equal', () => {
+  it('factors out the year when years are equal', () => {
     expect(formatDates(start, endNextMonth)).toBe('January 1 - February 1, 2020')
   })
 
-  it('factour out year and month when the event falls into the same month', () => {
+  it('factors out year and month when the event falls into the same month', () => {
     expect(formatDates(start, endNextDay)).toBe('January 1-2, 2020')
   })
 })

--- a/tests/store/events.spec.ts
+++ b/tests/store/events.spec.ts
@@ -5,27 +5,27 @@ describe('module events', () => {
 
   const unconferenceCampInAsia = {
     title: 'Fake event A',
-    type: ['Unconference', 'Camp'],
+    types: ['Unconference', 'Camp'],
     location: 'Asia Pacific'
   }
   const hackathonInEurope = {
     title: 'Fake event B',
-    type: ['Unconference', 'Hackathon'],
+    types: ['Unconference', 'Hackathon'],
     location: 'Europe'
   }
   const campInAfrica = {
     title: 'Fake event C',
-    type: ['Camp'],
+    types: ['Camp'],
     location: 'Africa'
   }
   const hackathonInAmericas = {
     title: 'Fake event D',
-    type: ['Camp', 'Hackathon'],
+    types: ['Camp', 'Hackathon'],
     location: 'Americas'
   }
   const unconferenceOnline = {
     title: 'Fake event E',
-    type: ['Unconference'],
+    types: ['Unconference'],
     location: 'Online'
   }
 
@@ -45,16 +45,16 @@ describe('module events', () => {
   })
 
   describe('filteredEvents', () => {
-    it('get future events by default', () => {
+    it('gets future events by default', () => {
       expect(store.getters.filteredEvents).toEqual(futureEvents)
     })
 
-    it('get past events after setting the the active set to past', () => {
+    it('gets past events after setting the the active set to past', () => {
       store.commit('setActiveSet', 'past')
       expect(store.getters.filteredEvents).toEqual(pastEvents)
     })
 
-    it('get active-set filtered by location', () => {
+    it('gets active-set filtered by location', () => {
       store.commit('addFilter', {
         filter: 'locationFilters',
         filterValue: 'Asia Pacific'
@@ -62,7 +62,7 @@ describe('module events', () => {
       expect(store.getters.filteredEvents).toEqual([unconferenceCampInAsia])
     })
 
-    it('get active-set filtered by type', () => {
+    it('gets active-set filtered by type', () => {
       store.commit('addFilter', {
         filter: 'typeFilters',
         filterValue: 'Hackathon'
@@ -70,7 +70,7 @@ describe('module events', () => {
       expect(store.getters.filteredEvents).toEqual([hackathonInEurope])
     })
 
-    it('get active-set filtered by type, considering events with several types', () => {
+    it('gets active-set filtered by type, considering events with several types', () => {
       store.commit('addFilter', {
         filter: 'typeFilters',
         filterValue: 'Camp'
@@ -78,7 +78,7 @@ describe('module events', () => {
       expect(store.getters.filteredEvents).toEqual([unconferenceCampInAsia, campInAfrica])
     })
 
-    it('get active-set filtered by type and location', () => {
+    it('gets active-set filtered by type and location', () => {
       store.commit('addFilter', {
         filter: 'typeFilters',
         filterValue: 'Camp'

--- a/tests/store/events.spec.ts
+++ b/tests/store/events.spec.ts
@@ -1,0 +1,93 @@
+import createStore from '~/store'
+
+describe('module events', () => {
+  let store: any
+
+  const unconferenceCampInAsia = {
+    title: 'Fake event A',
+    type: ['Unconference', 'Camp'],
+    location: 'Asia Pacific'
+  }
+  const hackathonInEurope = {
+    title: 'Fake event B',
+    type: ['Unconference', 'Hackathon'],
+    location: 'Europe'
+  }
+  const campInAfrica = {
+    title: 'Fake event C',
+    type: ['Camp'],
+    location: 'Africa'
+  }
+  const hackathonInAmericas = {
+    title: 'Fake event D',
+    type: ['Camp', 'Hackathon'],
+    location: 'Americas'
+  }
+  const unconferenceOnline = {
+    title: 'Fake event E',
+    type: ['Unconference'],
+    location: 'Online'
+  }
+
+  const futureEvents = [unconferenceCampInAsia, hackathonInEurope, campInAfrica]
+  const pastEvents = [hackathonInAmericas, unconferenceOnline]
+
+  beforeEach(() => {
+    store = createStore()
+    store.commit('setEvents', {
+      events: 'upcomingCommunityEvents',
+      eventsSet: futureEvents
+    })
+    store.commit('setEvents', {
+      events: 'pastCommunityEvents',
+      eventsSet: pastEvents
+    })
+  })
+
+  describe('filteredEvents', () => {
+    it('get future events by default', () => {
+      expect(store.getters.filteredEvents).toEqual(futureEvents)
+    })
+
+    it('get past events after setting the the active set to past', () => {
+      store.commit('setActiveSet', 'past')
+      expect(store.getters.filteredEvents).toEqual(pastEvents)
+    })
+
+    it('get active-set filtered by location', () => {
+      store.commit('addFilter', {
+        filter: 'locationFilters',
+        filterValue: 'Asia Pacific'
+      })
+      expect(store.getters.filteredEvents).toEqual([unconferenceCampInAsia])
+    })
+
+    it('get active-set filtered by type', () => {
+      store.commit('addFilter', {
+        filter: 'typeFilters',
+        filterValue: 'Hackathon'
+      })
+      expect(store.getters.filteredEvents).toEqual([hackathonInEurope])
+    })
+
+    it('get active-set filtered by type, considering events with several types', () => {
+      store.commit('addFilter', {
+        filter: 'typeFilters',
+        filterValue: 'Camp'
+      })
+      expect(store.getters.filteredEvents).toEqual([unconferenceCampInAsia, campInAfrica])
+    })
+
+    it('get active-set filtered by type and location', () => {
+      store.commit('addFilter', {
+        filter: 'typeFilters',
+        filterValue: 'Camp'
+      })
+      store.commit('addFilter', {
+        filter: 'locationFilters',
+        filterValue: 'Africa'
+      })
+      expect(store.getters.filteredEvents).toEqual([campInAfrica])
+    })
+  })
+})


### PR DESCRIPTION
Fix #518 

This PR also changes the state object of the store (to be a function) following Nux.js recommendation at:
https://nuxtjs.org/guide/vuex-store/#activate-the-store

> Regardless of the mode, your `state` value should **always be a `function`** to avoid unwanted shared state on the server side.