### PR TITLE
Extend const symbolic pattern to world locations and derive types from these consts

### DIFF
--- a/hooks/event-conversion-utils.ts
+++ b/hooks/event-conversion-utils.ts
@@ -6,8 +6,8 @@ import {
   CommunityEventType,
   WorldLocation,
   COMMUNITY_EVENT_TYPES,
-  LOCATION_CATEGORIES,
-  TYPE_CATEGORIES
+  WORLD_LOCATION_OPTIONS,
+  TYPE_OPTIONS
 } from '../store/modules/events'
 
 const RECORD_FIELDS = {
@@ -60,7 +60,7 @@ function getName (record: any): string {
 function getTypes (record: any): CommunityEventType[] {
   const value = record.get(RECORD_FIELDS.typeOfEvent) || []
   const valueList = (Array.isArray(value) ? value : [value]) as string[]
-  const communityEventTypes = filterWithWhitelist(valueList, TYPE_CATEGORIES)
+  const communityEventTypes = filterWithWhitelist(valueList, TYPE_OPTIONS)
   const noTypes = communityEventTypes.length === 0
   return noTypes ? [COMMUNITY_EVENT_TYPES.talks] : communityEventTypes
 }
@@ -102,7 +102,7 @@ function getPlace (record: any) {
 }
 
 function getLocation (_record: any): WorldLocation {
-  const options: WorldLocation[] = LOCATION_CATEGORIES
+  const options: WorldLocation[] = WORLD_LOCATION_OPTIONS
   return options[Math.floor(Math.random() * options.length)]
 }
 

--- a/hooks/event-conversion-utils.ts
+++ b/hooks/event-conversion-utils.ts
@@ -7,7 +7,7 @@ import {
   WorldLocation,
   COMMUNITY_EVENT_TYPES,
   WORLD_LOCATION_OPTIONS,
-  TYPE_OPTIONS
+  COMMUNITY_EVENT_TYPE_OPTIONS
 } from '../store/modules/events'
 
 const RECORD_FIELDS = {
@@ -60,7 +60,7 @@ function getName (record: any): string {
 function getTypes (record: any): CommunityEventType[] {
   const value = record.get(RECORD_FIELDS.typeOfEvent) || []
   const valueList = (Array.isArray(value) ? value : [value]) as string[]
-  const communityEventTypes = filterWithWhitelist(valueList, TYPE_OPTIONS)
+  const communityEventTypes = filterWithWhitelist(valueList, COMMUNITY_EVENT_TYPE_OPTIONS)
   const noTypes = communityEventTypes.length === 0
   return noTypes ? [COMMUNITY_EVENT_TYPES.talks] : communityEventTypes
 }

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -92,8 +92,8 @@ import QiskitPage from '~/components/qiskit/QiskitPage.vue'
 import EventCard from '~/components/cards/EventCard.vue'
 import {
   CommunityEvent,
-  LOCATION_CATEGORIES,
-  TYPE_CATEGORIES
+  WORLD_LOCATION_OPTIONS,
+  TYPE_OPTIONS
 } from '~/store/modules/events.ts'
 
 @Component({
@@ -135,8 +135,8 @@ import {
 })
 
 export default class extends QiskitPage {
-  locations = LOCATION_CATEGORIES
-  types = TYPE_CATEGORIES
+  locations = WORLD_LOCATION_OPTIONS
+  types = TYPE_OPTIONS
   routeName: string = 'events'
   windowWidth: Number = 0
 

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -93,7 +93,7 @@ import EventCard from '~/components/cards/EventCard.vue'
 import {
   CommunityEvent,
   WORLD_LOCATION_OPTIONS,
-  TYPE_OPTIONS
+  COMMUNITY_EVENT_TYPE_OPTIONS
 } from '~/store/modules/events.ts'
 
 @Component({
@@ -136,7 +136,7 @@ import {
 
 export default class extends QiskitPage {
   locations = WORLD_LOCATION_OPTIONS
-  types = TYPE_OPTIONS
+  types = COMMUNITY_EVENT_TYPE_OPTIONS
   routeName: string = 'events'
   windowWidth: Number = 0
 

--- a/store/modules/events.ts
+++ b/store/modules/events.ts
@@ -37,7 +37,7 @@ const WORLD_LOCATION_OPTIONS: WorldLocation[] = [
   WORLD_LOCATIONS.africa,
   WORLD_LOCATIONS.online
 ]
-const TYPE_OPTIONS: CommunityEventType[] = [
+const COMMUNITY_EVENT_TYPE_OPTIONS: CommunityEventType[] = [
   COMMUNITY_EVENT_TYPES.hackathon,
   COMMUNITY_EVENT_TYPES.camp,
   COMMUNITY_EVENT_TYPES.unconference,
@@ -53,7 +53,7 @@ export {
   WorldLocation,
   COMMUNITY_EVENT_TYPES,
   WORLD_LOCATION_OPTIONS,
-  TYPE_OPTIONS
+  COMMUNITY_EVENT_TYPE_OPTIONS
 }
 
 export default {

--- a/store/modules/events.ts
+++ b/store/modules/events.ts
@@ -1,6 +1,24 @@
+const COMMUNITY_EVENT_TYPES = Object.freeze({
+  hackathon: 'Hackathon',
+  camp: 'Camp',
+  unconference: 'Unconference',
+  industryEvent: 'Industry Event',
+  workshop: 'Workshop',
+  talks: 'Talks',
+  virtualEvent: 'Virtual Event'
+} as const)
+
+const WORLD_LOCATIONS = Object.freeze({
+  americas: 'Americas',
+  asiaPacific: 'Asia Pacific',
+  europe: 'Europe',
+  africa: 'Africa',
+  online: 'Online'
+} as const)
+
 type CommunityEventSet = 'past'|'upcoming'
-type WorldLocation = 'Americas'|'Asia Pacific'|'Europe'|'Africa'|'TBD'|'Online'
-type CommunityEventType = 'Hackathon'|'Camp'|'Unconference'|'Industry Event'|'Workshop'|'Talks'|'Virtual Event'
+type WorldLocation = typeof WORLD_LOCATIONS[keyof typeof WORLD_LOCATIONS]
+type CommunityEventType = typeof COMMUNITY_EVENT_TYPES[keyof typeof COMMUNITY_EVENT_TYPES]
 
 type CommunityEvent = {
   types: CommunityEventType[],
@@ -12,22 +30,14 @@ type CommunityEvent = {
   to: string
 }
 
-type CommunityEventTypes = {
-  [key: string]: CommunityEventType
-}
-
-const COMMUNITY_EVENT_TYPES: CommunityEventTypes = {
-  hackathon: 'Hackathon',
-  camp: 'Camp',
-  unconference: 'Unconference',
-  industryEvent: 'Industry Event',
-  workshop: 'Workshop',
-  talks: 'Talks',
-  virtualEvent: 'Virtual Event'
-}
-
-const LOCATION_CATEGORIES: WorldLocation[] = ['Americas', 'Asia Pacific', 'Europe', 'Africa', 'Online']
-const TYPE_CATEGORIES: CommunityEventType[] = [
+const WORLD_LOCATION_OPTIONS: WorldLocation[] = [
+  WORLD_LOCATIONS.americas,
+  WORLD_LOCATIONS.asiaPacific,
+  WORLD_LOCATIONS.europe,
+  WORLD_LOCATIONS.africa,
+  WORLD_LOCATIONS.online
+]
+const TYPE_OPTIONS: CommunityEventType[] = [
   COMMUNITY_EVENT_TYPES.hackathon,
   COMMUNITY_EVENT_TYPES.camp,
   COMMUNITY_EVENT_TYPES.unconference,
@@ -41,9 +51,9 @@ export {
   CommunityEvent,
   CommunityEventType,
   WorldLocation,
-  LOCATION_CATEGORIES,
-  TYPE_CATEGORIES,
-  COMMUNITY_EVENT_TYPES
+  COMMUNITY_EVENT_TYPES,
+  WORLD_LOCATION_OPTIONS,
+  TYPE_OPTIONS
 }
 
 export default {


### PR DESCRIPTION
The const pattern for using symbolic names instead of strings is useful for avoiding typos and taking advantage of coding tools so it is extended to world location values too.

However, its use with TS may introduce some unneeded repetition when trying to write the types with the string values the symbolic names try to represent:

```ts
const SYMBOLIC_NAMES = {
  symbolA: 'Symbol A',
  symbolB: 'Symbol B'
}
type Names = 'Symbol A'|'Symbol B'
```

This PR uses [`const` assertions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions) to derive the types from the const values.