### PR TITLE
Add temporal fallbacks while waiting for produt final decisions

### DIFF
--- a/content/education/textbook-toc.md
+++ b/content/education/textbook-toc.md
@@ -15,6 +15,7 @@
 - Proving Universality
 - More Circuit Identities
 ### Chapter 3. Quantum Protocols and Quantum Algorithms
+- Defining Quantum Circuits
 - Quantum Teleportation
 - Superdense Coding
 - Deutsch-Josza Algorithm

--- a/content/events/past-community-events.json
+++ b/content/events/past-community-events.json
@@ -1,85 +1,74 @@
 [
   {
-    "title": "Hackathon @ Harvard",
+    "title": "Circuit Sessions with Jay Gambetta",
     "types": [
-      "Hackathon",
-      "Camp"
+      "Online"
     ],
-    "image": "/images/events/no-picture.jpg",
+    "image": "https://dl.airtable.com/.attachmentThumbnails/a91433373aa5040bbcbdacc2c3d1324c/d4820c12",
+    "place": "Online",
+    "location": "Online",
+    "date": "April 15, 2020"
+  },
+  {
+    "title": "Quantum Coding with Lauren Capelluto",
+    "types": [
+      "Online"
+    ],
+    "image": "https://dl.airtable.com/.attachmentThumbnails/bbbfcbac2f2fbae91d75b2f90e6b5589/613c7759",
+    "place": "Online",
+    "location": "Online",
+    "date": "April 8, 2020"
+  },
+  {
+    "title": "Quantum Coding with Nathan Earnest-Noble",
+    "types": [
+      "Online"
+    ],
+    "image": "https://dl.airtable.com/.attachmentThumbnails/042cae53b96f33b9d122f516aa6187da/eb5fb425",
+    "place": "Online",
+    "location": "Online",
+    "date": "April 1, 2020",
+    "to": "https://www.youtube.com/watch?v=_1XTChcvbOs"
+  },
+  {
+    "title": "Guest Lecture @ Harvard (Algorithms)",
+    "types": [
+      "Talks"
+    ],
+    "image": "https://dl.airtable.com/.attachmentThumbnails/f2f06eca861764c80f3b0f9e34a136da/fca521b3",
     "place": "Boston, MA",
     "location": "Americas",
-    "date": "April 2-3, 2020"
+    "date": "March 26, 2020"
   },
   {
-    "title": "Yale YQI Roundtable event",
+    "title": "Qiskit & Answers with Abe Asfaw",
     "types": [
-      "Conference",
-      "Hackathon"
+      "Online"
     ],
-    "image": "/images/events/no-picture.jpg",
-    "place": "New Haven, CT",
-    "location": "Asia Pacific",
-    "date": "April 2, 2020"
-  },
-  {
-    "title": "CQE Recruiting Forum",
-    "types": [
-      "Conference"
-    ],
-    "image": "/images/events/no-picture.jpg",
-    "place": "Chicago, IL",
+    "image": "https://dl.airtable.com/.attachmentThumbnails/7a81262ae0e59634990efb461f4baffa/38a7b065",
+    "place": "Online",
     "location": "Online",
-    "date": "April 1, 2020"
+    "date": "March 25, 2020",
+    "to": "https://www.youtube.com/watch?v=khlr15i123Q"
   },
   {
-    "title": "Hackathon @ Uni College Dublin",
+    "title": "Guest Lecture @ Harvard (Hardware)",
     "types": [
-      "Hackathon"
+      "Talks"
     ],
-    "image": "/images/events/no-picture.jpg",
-    "place": "Dublin, Ireland",
-    "location": "Online",
-    "date": "March 28, 2020"
-  },
-  {
-    "title": "Q Meetup in Bangkok",
-    "types": [
-      "Conference"
-    ],
-    "image": "/images/events/no-picture.jpg",
-    "place": "Bangkok, Thailand",
-    "location": "Asia Pacific",
-    "date": "March 26-31, 2020"
-  },
-  {
-    "title": "NSBE Annual Convention",
-    "types": [
-      "Conference"
-    ],
-    "image": "/images/events/no-picture.jpg",
-    "place": "San Antonio, TX",
+    "image": "https://dl.airtable.com/.attachmentThumbnails/11b1ef339b83fad7999ccc446123d008/32aa4f34",
+    "place": "Boston, MA",
     "location": "Americas",
-    "date": "March 25-29, 2020",
-    "to": "http://convention.nsbe.org"
+    "date": "March 24, 2020"
   },
   {
-    "title": "Hack-Q-Thon (NYC High School Hackathon)",
+    "title": "Guest Lecture @ UPenn",
     "types": [
-      "Hackathon"
+      "Talks"
     ],
-    "image": "/images/events/no-picture.jpg",
-    "place": "NYU Campus, NY",
-    "location": "Asia Pacific",
-    "date": "March 21, 2020"
-  },
-  {
-    "title": "Hackathon @ Uni College London",
-    "types": [
-      "Hackathon"
-    ],
-    "image": "/images/events/no-picture.jpg",
-    "place": "London, England",
-    "location": "Online",
-    "date": "March 19-20, 2020"
+    "image": "https://dl.airtable.com/.attachmentThumbnails/9cfcf2ff507fb4fc6c7f897d794e3f1a/a26fb26b",
+    "place": "Pennsylvania",
+    "location": "Americas",
+    "date": "March 18, 2020"
   }
 ]

--- a/content/events/upcoming-community-events.json
+++ b/content/events/upcoming-community-events.json
@@ -1,22 +1,12 @@
 [
   {
-    "title": "Hackathon @ Princeton",
+    "title": "Seminar Series with Antti Vepsäläinen",
     "types": [
-      "Hackathon"
+      "Online"
     ],
-    "image": "/images/events/no-picture.jpg",
-    "place": "Princeton, NJ",
-    "location": "Europe",
-    "date": "April 18-19, 2020"
-  },
-  {
-    "title": "Hackathon @ Stanford",
-    "types": [
-      "Hackathon"
-    ],
-    "image": "/images/events/no-picture.jpg",
-    "place": "Stanford, CA",
+    "image": "https://dl.airtable.com/.attachmentThumbnails/c32682d762a93287ba21024fa406ca5e/25b55ec1",
+    "place": "Online",
     "location": "Online",
-    "date": "May 1-2, 2020"
+    "date": "April 17, 2020"
   }
 ]

--- a/hooks/event-conversion-utils.ts
+++ b/hooks/event-conversion-utils.ts
@@ -6,7 +6,6 @@ import {
   CommunityEventType,
   WorldLocation,
   COMMUNITY_EVENT_TYPES,
-  WORLD_LOCATION_OPTIONS,
   COMMUNITY_EVENT_TYPE_OPTIONS
 } from '../store/modules/events'
 
@@ -17,6 +16,7 @@ const RECORD_FIELDS = Object.freeze({
   typeOfEvent: 'Type of Event',
   eventWebsite: 'Event Website',
   eventLocation: 'Event Location',
+  region: 'Region',
   image: 'Picture?',
   published: 'SUZIE - for website?'
 } as const)
@@ -62,6 +62,18 @@ function getName (record: any): string {
 function getTypes (record: any): CommunityEventType[] {
   const value = record.get(RECORD_FIELDS.typeOfEvent) || []
   const valueList = (Array.isArray(value) ? value : [value]) as string[]
+
+  // TODO: Remove when the Online type is under the "Type of Event" column in
+  // Airtable. Right now, it is in the "Region" column and we need to include
+  // it as a type.
+  //
+  // See also:
+  // https://github.com/Qiskit/qiskit.org/issues/526
+  const location = getLocation(record)
+  if (location) {
+    valueList.push(location)
+  }
+
   const communityEventTypes = filterWithWhitelist(valueList, COMMUNITY_EVENT_TYPE_OPTIONS)
   const noTypes = communityEventTypes.length === 0
   return noTypes ? [COMMUNITY_EVENT_TYPES.talks] : communityEventTypes
@@ -99,13 +111,12 @@ function getThumbnailUrl (imageAttachment: any): string|null {
   return largeThumbnail ? largeThumbnail.url : null
 }
 
-function getPlace (record: any) {
-  return record.get(RECORD_FIELDS.eventLocation)
+function getPlace (record: any): string|null {
+  return record.get(RECORD_FIELDS.eventLocation) || getLocation(record)
 }
 
-function getLocation (_record: any): WorldLocation {
-  const options = WORLD_LOCATION_OPTIONS
-  return options[Math.floor(Math.random() * options.length)]
+function getLocation (record: any): WorldLocation|null {
+  return record.get(RECORD_FIELDS.region) || null
 }
 
 function getDates (record: any): [Date, Date|undefined] {

--- a/store/modules/events.ts
+++ b/store/modules/events.ts
@@ -12,7 +12,14 @@ const WORLD_LOCATIONS = Object.freeze({
   americas: 'Americas',
   asiaPacific: 'Asia Pacific',
   europe: 'Europe',
-  africa: 'Africa'
+  africa: 'Africa',
+  // TODO: Remove when "Online" is under "Type of Event" in Airtable. Right now
+  // it is a region but the event squad expressed its will of "Online" being an
+  // event type.
+  //
+  // See also:
+  // https://github.com/Qiskit/qiskit.org/issues/526
+  online: 'Online'
 } as const)
 
 type CommunityEventSet = 'past'|'upcoming'
@@ -23,8 +30,14 @@ type CommunityEvent = {
   types: CommunityEventType[],
   title: string,
   image: string,
-  place: string,
-  location: WorldLocation,
+  // TODO: We need to clarify if region and place have default values and what
+  // these are. Place and location may seem mandatory but human error is
+  // possible. In that case, what's the value of place and location?
+  //
+  // See also:
+  // https://github.com/Qiskit/qiskit.org/issues/527
+  place: string|null,
+  location: WorldLocation|null,
   date: string,
   to: string
 }
@@ -96,7 +109,7 @@ export default {
         if (noFilters) { return allEvents }
 
         return allEvents.filter((event) => {
-          const propValue = event[propToFilter]
+          const propValue = event[propToFilter] || []
           const valueArray = Array.isArray(propValue) ? propValue : [propValue]
           return valueArray.some(value => selectedFilters.includes(value))
         })


### PR DESCRIPTION
This PR restores `Online` as a `Location` although it copies it to an event type for the UI to be able of filtering those by type as agreed in offline conversations.

It depends on #527 and #526 to be solved before removing temporal code.