### PR TITLE
Leave only one CTA and convert event link to the source code into actual links

### DIFF
--- a/components/experiments/ExperimentHeader.vue
+++ b/components/experiments/ExperimentHeader.vue
@@ -16,14 +16,22 @@
         Back to experiments
       </nuxt-link>
       <h1>{{ name }}</h1>
-      <p class="experiment-header__author">
-        {{ authors }}
+      <p class="experiment-header__meta">
+        <span class="experiment-header__author">
+          {{ authors }}
+        </span>
+        |
+        <a
+          class="experiment-header__source-code-link"
+          :href="source"
+          target="_blank"
+          rel="noopener"
+        >
+          Explore the code
+        </a>
       </p>
       <Cta v-if="launch" :to="launch">
         Launch
-      </Cta>
-      <Cta v-if="source" :to="source" type="secondary">
-        Explore the code
       </Cta>
       <div class="experiment-header__media">
         <Media
@@ -72,15 +80,21 @@ export default class extends Vue {
   }
 }
 
-.experiment-header__author {
+.experiment-header__meta {
   @include type-style('body-short-01');
   color: $purple-30;
   margin: 1rem 0 1rem 0;
+}
 
-  &::before {
+.experiment-header__author {
+    &::before {
     content: "by";
     color: $text-02;
   }
+}
+
+.experiment-header__source-code-link {
+  color: currentColor;
 }
 
 .experiment-header__back-navigation {
@@ -111,6 +125,7 @@ export default class extends Vue {
 }
 
 .experiment-header__media {
+  margin-top: 1rem;
   width: 100%;
 
   & > * {

--- a/components/ui/Cta.vue
+++ b/components/ui/Cta.vue
@@ -1,7 +1,7 @@
 <template>
   <component
     :is="!isStatic && isInternal(to) ? 'nuxt-link' : 'a'"
-    :class="[ 'cta', `cta--${type}`]"
+    class="cta"
     :href="to"
     :to="!isStatic && isInternal(to) ? to : null"
     :rel="isExternal(to) ? 'noopener' : null"
@@ -16,12 +16,9 @@
 import Vue from 'vue'
 import { Component, Prop } from 'vue-property-decorator'
 
-type CtaType = 'primary' | 'secondary' | 'tertiary'
-
 @Component
 export default class extends Vue {
   @Prop(String) to
-  @Prop({ default: 'primary' }) type!: CtaType
   @Prop(Boolean) isStatic
 
   isExternal (url: string): boolean {
@@ -46,38 +43,12 @@ export default class extends Vue {
   text-decoration: none;
   border: 2px solid;
 
-  &--primary, &--secondary {
-    @include type-style('productive-heading-02');
-    padding: 0.66rem 1rem;
-    border-color: $interactive-01;
-    text-transform: uppercase;
-    white-space: nowrap;
-  }
-
-  &--primary {
-    color: $text-01;
-    background-color: $ui-01;
-  }
-
-  &--secondary {
-    color: $inverse-01;
-    background-color: $inverse-02;
-  }
-
-  &--tertiary {
-    @include type-style('productive-heading-01');
-    padding: 0.5rem 0.8rem;
-    border-color: $ui-01;
-    color: $inverse-01;
-    transition: background-color linear 200ms,
-                color linear 200ms,
-                fill linear 200ms;
-
-    &:hover {
-      background-color: $ui-01;
-      color: $text-01;
-      fill: $text-01;
-    }
-  }
+  @include type-style('productive-heading-02');
+  padding: 0.66rem 1rem;
+  border-color: $interactive-01;
+  text-transform: uppercase;
+  white-space: nowrap;
+  color: $text-01;
+  background-color: $ui-01;
 }
 </style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -13,7 +13,6 @@
         <p>Would you like to learn how to code a quantum computer? Take a look at the Coding with Qiskit Video Series, where Abraham Asfaw explains everything you need to know. Starting with installing Qiskit, to investigating the latest algorithms and research topics.</p>
         <Cta
           to="https://www.youtube.com/playlist?list=PLOFEBzvs-Vvp2xg9-POLJhQwtVktlYGbY"
-          type="tertiary"
           @click="$trackClickEvent({
             action: 'Coding with Qiskit Video Series'
           })"
@@ -26,7 +25,6 @@
         <p>This activity pack will entertain your kids with fun activities about quantum computing. Fun for all kids and parents!</p>
         <Cta
           to="/activities/quantum-activity-pack-for-kids.pdf"
-          type="tertiary"
           is-static
           @click="$trackClickEvent({
             action: 'Activity pack for kids'
@@ -42,7 +40,6 @@
         <p>New to quantum computing? Try out the IBM Quantum Experience to get started with Qiskit in the cloud. No installation required and free hosted tutorials. Work is saved in the cloud and automatically updated with every Qiskit release.</p>
         <Cta
           to="https://quantum-computing.ibm.com/login"
-          type="tertiary"
           @click="$trackClickEvent({
             action: 'Introducing Qiskit notebooks: Try out'
           })"


### PR DESCRIPTION
Fix #479

This PR makes using the CTA as the component the website uses for converting users. So, it is used consistently across all the site. The chosen style corresponds to that of the community site:

![Captura de pantalla 2020-04-22 a las 15 54 41](https://user-images.githubusercontent.com/757942/79990718-aaeda400-84b1-11ea-9778-f1da518a53d4.png)

Other uses of links showing like buttons have been converted into simple links like the "Explore the code button" in the experiments individual pages.