### PR TITLE
Fix alignment of the footer

### DIFF
--- a/components/layouts/PageFooter/index.vue
+++ b/components/layouts/PageFooter/index.vue
@@ -19,7 +19,9 @@
     </section>
     <section class="secondary-footer-container">
       <div class="secondary-footer">
-        <div class="secondary-footer__copyright">©Qiskit | All Rights Reserved</div>
+        <div class="secondary-footer__copyright">
+          ©Qiskit | All Rights Reserved
+        </div>
         <div class="secondary-footer__links">
           <AppLink
             v-for="link in secondaryFooterLinks"
@@ -65,17 +67,18 @@ export default class extends Vue {
 
 .main-footer-container {
   background-color: $cool-gray-10;
-  overflow: hidden;
+  padding: $spacing-07 0;
 }
 
 .secondary-footer-container {
   background-color: $white;
   padding-bottom: $spacing-08;
+  padding: $spacing-07 0;
+  padding-bottom: $spacing-07 * 1.5; // make room for the "cookies preferences" button
 }
 
 .main-footer, .secondary-footer {
   @include contained();
-  padding: $spacing-07 0;
   display: flex;
   justify-content: space-between;
 }
@@ -88,7 +91,6 @@ export default class extends Vue {
   &__logo {
     height: 32px;
     width: 112px;
-    margin: 0 $spacing-07;
 
     @include mq($until: medium) {
       margin-bottom: $spacing-07;
@@ -98,11 +100,12 @@ export default class extends Vue {
   &__sections {
     display: grid;
     grid-template-columns: repeat(6, 1fr);
-    margin: 0 $spacing-07;
     row-gap: $spacing-07;
+    max-width: 12 * $column-size-large;
 
     @include mq($from:medium, $until: large) {
       grid-template-columns: repeat(5, 1fr);
+      max-width: 6 * $column-size-medium;
 
       & > :last-child {
         grid-column: 5 / 6;
@@ -120,13 +123,11 @@ export default class extends Vue {
   &__copyright, &__link {
     @include type-style('caption-01');
     color: $cool-gray-60;
-    margin-left: $spacing-07;
   }
 
   &__links {
     display: flex;
     justify-content: space-between;
-    margin-right: $spacing-07;
 
     @include mq($until: medium) {
       flex-direction: column;
@@ -134,6 +135,7 @@ export default class extends Vue {
   }
 
   &__link {
+    margin-left: $spacing-07;
     text-decoration: none;
 
     @include mq($until: medium) {

--- a/components/layouts/PageFooter/index.vue
+++ b/components/layouts/PageFooter/index.vue
@@ -91,6 +91,11 @@ export default class extends Vue {
   &__logo {
     height: 32px;
     width: 112px;
+    margin-right: $layout-06;
+
+    @include mq($from: medium, $until: large) {
+      margin-right: $layout-05;
+    }
 
     @include mq($until: medium) {
       margin-bottom: $spacing-07;
@@ -101,11 +106,9 @@ export default class extends Vue {
     display: grid;
     grid-template-columns: repeat(6, 1fr);
     row-gap: $spacing-07;
-    max-width: 12 * $column-size-large;
 
     @include mq($from:medium, $until: large) {
       grid-template-columns: repeat(5, 1fr);
-      max-width: 6 * $column-size-medium;
 
       & > :last-child {
         grid-column: 5 / 6;

--- a/components/layouts/PageFooter/index.vue
+++ b/components/layouts/PageFooter/index.vue
@@ -74,7 +74,7 @@ export default class extends Vue {
   background-color: $white;
   padding-bottom: $spacing-08;
   padding: $spacing-07 0;
-  padding-bottom: $spacing-07 * 1.5; // make room for the "cookies preferences" button
+  padding-bottom: $spacing-07 + 2.5rem; // make room for the "cookies preferences" button
 }
 
 .main-footer, .secondary-footer {


### PR DESCRIPTION
The `contained` mixing modifies the left and right paddings of the element which is applied to. This violates the principle of minimum astonishment (tracked on #657) which I think lead to some unnecessary extra margins.