### PR TITLE
Set errexit and use && for travis deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,4 @@ jobs:
     - name: Build and Deploy
       if: (type = push OR type = cron) AND branch = master
       script:
-        - npm run generate
-        - cd deploy && bash ./deploy_cos.sh
+        - npm run generate && cd deploy && bash ./deploy_cos.sh

--- a/deploy/deploy_cos.sh
+++ b/deploy/deploy_cos.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 #install rclone
 curl https://downloads.rclone.org/rclone-current-linux-amd64.deb -o rclone.deb


### PR DESCRIPTION
This commit fixes the potential issue where a failed website build
results in rclone deleting the contents of the bucket. This is
accomplished by making 2 changes. The first is to set errexit in the
deploy_cos.sh bash script, which results in any intermediate failure in
the script exiting instead of continue with the execution of the script.
The second is to make the travis script rely on && instead of multiple
script lines. Travis doesn't exit when an earlier script line fails and
instead continues like bash without errexit and fails after all lines
are executed. To work around this all the deploy commands are run in a
single line using && so that it will exit after the website build fails.