### PR TITLE
Add link to overview in home page

### DIFF
--- a/components/landing/LandingCta.vue
+++ b/components/landing/LandingCta.vue
@@ -28,8 +28,7 @@ export default class extends Vue {
 .landing-cta {
   @include type-style('body-short-01');
   text-decoration: none;
-  display: inline-flex;
-  flex-direction: row;
+  display: flex;
   align-items: center;
   padding: 0 $spacing-07;
 

--- a/components/landing/LandingCta.vue
+++ b/components/landing/LandingCta.vue
@@ -38,6 +38,7 @@ export default class extends Vue {
   }
 
   @include mq($until: large) {
+    justify-content: space-between;
     padding: $spacing-03 $spacing-05;
     width: 12rem;
   }

--- a/components/landing/LandingCta.vue
+++ b/components/landing/LandingCta.vue
@@ -1,7 +1,7 @@
 <template>
   <AppLink
     class="landing-cta"
-    :class="`landing-cta_kind_${kind}`"
+    :class="`landing-cta_${kind}`"
     v-bind="$attrs"
   >
     <slot />
@@ -31,46 +31,43 @@ export default class extends Vue {
   display: inline-flex;
   flex-direction: row;
   align-items: center;
+  padding: 0 $spacing-07;
 
-  &_kind_primary {
+  @include mq($from: large) {
+    width: 15rem;
+  }
+
+  @include mq($until: large) {
+    padding: $spacing-03 $spacing-05;
+    width: 12rem;
+  }
+
+  &_primary {
     color: $white;
     background-color: $purple-70;
-    padding: $spacing-07;
-    width: 15rem;
 
     &:hover {
       background-color: $purple-90;
     }
 
-    @include mq($from: medium, $until: large) {
-      padding: $spacing-05 $spacing-07;
-      width: 13rem;
-    }
-
-    @include mq($until: medium) {
-      padding: $spacing-03 $spacing-05;
-      width: 11rem;
+    @include mq($from: large) {
+      padding-top: $spacing-07;
+      padding-bottom: $spacing-07;
     }
   }
 
-  &_kind_secondary {
+  &_secondary {
     color: $purple-70;
     background-color: $cool-gray-10;
-    min-height: 3rem;
-    padding: $spacing-05 $spacing-07;
 
     &:hover {
       color: $cool-gray-10;
       background-color: $purple-70;
     }
 
-    @include mq($until: large) {
-      padding: $spacing-03 $spacing-05;
-    }
-
-    @include mq($until: medium) {
-      padding: $spacing-03 $spacing-05;
-      min-height: 2rem;
+    @include mq($from: large) {
+      padding-top: $spacing-05;
+      padding-bottom: $spacing-05;
     }
   }
 

--- a/components/landing/LandingCta.vue
+++ b/components/landing/LandingCta.vue
@@ -64,6 +64,10 @@ export default class extends Vue {
       background-color: $purple-70;
     }
 
+    @include mq($until: large) {
+      padding: $spacing-03 $spacing-05;
+    }
+
     @include mq($until: medium) {
       padding: $spacing-03 $spacing-05;
       min-height: 2rem;

--- a/components/landing/LandingCta.vue
+++ b/components/landing/LandingCta.vue
@@ -38,7 +38,7 @@ export default class extends Vue {
 
   @include mq($until: large) {
     justify-content: space-between;
-    padding: $spacing-03 $spacing-05;
+    padding: $spacing-05;
     width: 12rem;
   }
 

--- a/components/landing/LandingCta.vue
+++ b/components/landing/LandingCta.vue
@@ -57,6 +57,7 @@ export default class extends Vue {
     color: $purple-70;
     background-color: $cool-gray-10;
     min-height: 3rem;
+    padding: $spacing-05 $spacing-07;
 
     &:hover {
       color: $cool-gray-10;
@@ -64,6 +65,7 @@ export default class extends Vue {
     }
 
     @include mq($until: medium) {
+      padding: $spacing-03 $spacing-05;
       min-height: 2rem;
     }
   }

--- a/components/landing/TheFeatures/index.vue
+++ b/components/landing/TheFeatures/index.vue
@@ -18,6 +18,15 @@
         quantum systems and simulators.
       </p>
       <TheFeatureMosaic class="the-features__mosaic" />
+      <LandingCta
+        url="/overview"
+        kind="secondary"
+        @click="$trackClickEvent({
+          action: 'Overview'
+        })"
+      >
+        Full Overview
+      </LandingCta>
     </div>
   </article>
 </template>
@@ -27,9 +36,10 @@ import Vue from 'vue'
 
 import { Component } from 'vue-property-decorator'
 import TheFeatureMosaic from '~/components/landing/TheFeatures/TheFeatureMosaic.vue'
+import LandingCta from '~/components/landing/LandingCta.vue'
 
 @Component({
-  components: { TheFeatureMosaic }
+  components: { TheFeatureMosaic, LandingCta }
 })
 export default class extends Vue { }
 </script>

--- a/components/landing/TheHeroMoment/index.vue
+++ b/components/landing/TheHeroMoment/index.vue
@@ -13,7 +13,6 @@
         computers at the level of pulses, circuits and algorithms.
       </p>
       <LandingCta
-        class="the-hero-moment__cta"
         url="https://qiskit.org/documentation/install.html"
         @click="$trackClickEvent({
           action: 'Get Started'
@@ -140,10 +139,6 @@ export default class extends Vue {
       max-width: 3 * $column-size-small;
       margin-bottom: $layout-03;
     }
-  }
-
-  &__cta {
-    @include type-style('body-short-01');
   }
 }
 </style>


### PR DESCRIPTION
Fix #855 

In addition, this PR:
- Refactors LandingCta
- Aligns landing cta elements to fit Figma design on small and medium devices
- Unifies primary and secondary landing cta to fit Figma design