### PR TITLE
Fix mobile filters to light theme

### DIFF
--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -196,50 +196,54 @@ export default class extends QiskitPage {
 
   &__filters-time {
     margin-top: $layout-03;
-    & .bx--tabs__nav-link {
+    .bx--tabs__nav-link {
       color: $black-100;
       border-bottom-color: $gray-20;
     }
 
-    & .bx--tabs__nav-item:not(.bx--tabs__nav-item--disabled) .bx--tabs__nav-link,
+    .bx--tabs__nav-item:not(.bx--tabs__nav-item--disabled) .bx--tabs__nav-link,
     .bx--tabs__nav-item:hover:not(.bx--tabs__nav-item--selected):not(.bx--tabs__nav-item--disabled) .bx--tabs__nav-link {
       color: $cool-gray-80;
     }
 
-    & .bx--tabs__nav-item--selected:not(.bx--tabs__nav-item--disabled) .bx--tabs__nav-link {
+    .bx--tabs__nav-item--selected:not(.bx--tabs__nav-item--disabled) .bx--tabs__nav-link {
         border-bottom-color: $purple-70;
     }
 
     @include mq($until: medium) {
-      & .bx--tabs__nav-item,
-      & .bx--tabs-trigger {
-        background-color: $white;
+      .bx--tabs__nav-item,
+      .bx--tabs-trigger {
+        background-color: $cool-gray-10;
       }
 
-      & .bx--tabs-trigger-text {
+      .bx--tabs-trigger svg {
+        fill: $cool-gray-80;
+      }
+
+      .bx--tabs-trigger-text {
         color: $white-text-01;
       }
 
-      & .bx--tabs__nav-link {
+      .bx--tabs__nav-link {
         border-bottom: none;
       }
 
-      & .bx--tabs__nav-item:hover:not(.bx--tabs__nav-item--selected):not(.bx--tabs__nav-item--disabled) .bx--tabs__nav-link {
-      color: $white;
-    }
+      .bx--tabs__nav-item:hover:not(.bx--tabs__nav-item--selected):not(.bx--tabs__nav-item--disabled) {
+        background-color: #e5e5e5;
+      }
     }
   }
 
   &__filters-others {
-    & .bx--checkbox-label::before {
+    .bx--checkbox-label::before {
       border: 1px solid $black-100;
     }
 
-    & .bx--checkbox:focus + .bx--checkbox-label::before {
+    .bx--checkbox:focus + .bx--checkbox-label::before {
       box-shadow: 0 0 0 2px $white, 0 0 0 4px $purple-60;
     }
 
-    & .bx--label {
+    .bx--label {
       color: $cool-gray-80;
     }
   }

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -213,7 +213,7 @@ export default class extends QiskitPage {
     @include mq($until: medium) {
       .bx--tabs__nav-item,
       .bx--tabs-trigger {
-        background-color: $cool-gray-10;
+        background-color: $white;
       }
 
       .bx--tabs-trigger svg {

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -217,7 +217,7 @@ export default class extends QiskitPage {
       }
 
       .bx--tabs-trigger {
-        border-bottom: 1px solid #E0E0E0;
+        border-bottom: 1px solid $gray-20;
       }
 
       .bx--tabs-trigger svg {
@@ -246,7 +246,7 @@ export default class extends QiskitPage {
       }
 
       .bx--tabs__nav-item:hover:not(.bx--tabs__nav-item--selected):not(.bx--tabs__nav-item--disabled) {
-        background-color: #e5e5e5;
+        background-color: $cool-gray-20;
         box-shadow: initial;
       }
     }

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -66,7 +66,8 @@
             Nothing here yet -
             <AppLink
               class="event-page__link"
-              v-bind="eventRequestLink">
+              v-bind="eventRequestLink"
+            >
               {{ eventRequestLink.label }}
             </AppLink>
           </p>
@@ -169,7 +170,7 @@ export default class extends QiskitPage {
 }
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
 @import '~carbon-components/scss/globals/scss/typography';
 
 .event-page {
@@ -195,32 +196,50 @@ export default class extends QiskitPage {
 
   &__filters-time {
     margin-top: $layout-03;
-    // deep selector idea taken from
-    // https://vue-loader.vuejs.org/guide/scoped-css.html#deep-selectors
-    ::v-deep .bx--tabs__nav-link {
+    & .bx--tabs__nav-link {
       color: $black-100;
       border-bottom-color: $gray-20;
     }
 
-    ::v-deep .bx--tabs__nav-item:not(.bx--tabs__nav-item--disabled) .bx--tabs__nav-link {
+    & .bx--tabs__nav-item:not(.bx--tabs__nav-item--disabled) .bx--tabs__nav-link,
+    .bx--tabs__nav-item:hover:not(.bx--tabs__nav-item--selected):not(.bx--tabs__nav-item--disabled) .bx--tabs__nav-link {
       color: $cool-gray-80;
     }
 
-    ::v-deep .bx--tabs__nav-item--selected:not(.bx--tabs__nav-item--disabled) .bx--tabs__nav-link {
+    & .bx--tabs__nav-item--selected:not(.bx--tabs__nav-item--disabled) .bx--tabs__nav-link {
         border-bottom-color: $purple-70;
+    }
+
+    @include mq($until: medium) {
+      & .bx--tabs__nav-item,
+      & .bx--tabs-trigger {
+        background-color: $white;
+      }
+
+      & .bx--tabs-trigger-text {
+        color: $white-text-01;
+      }
+
+      & .bx--tabs__nav-link {
+        border-bottom: none;
+      }
+
+      & .bx--tabs__nav-item:hover:not(.bx--tabs__nav-item--selected):not(.bx--tabs__nav-item--disabled) .bx--tabs__nav-link {
+      color: $white;
+    }
     }
   }
 
   &__filters-others {
-    ::v-deep .bx--checkbox-label::before {
+    & .bx--checkbox-label::before {
       border: 1px solid $black-100;
     }
 
-    ::v-deep .bx--checkbox:focus + .bx--checkbox-label::before {
+    & .bx--checkbox:focus + .bx--checkbox-label::before {
       box-shadow: 0 0 0 2px $white, 0 0 0 4px $purple-60;
     }
 
-    ::v-deep .bx--label {
+    & .bx--label {
       color: $cool-gray-80;
     }
   }

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -5,8 +5,8 @@
       <div class="event-page__filters-time">
         <client-only>
           <cv-tabs aria-label="navigation tab label" @tab-selected="selectTab">
-            <cv-tab id="tab-1" label="Upcoming" />
-            <cv-tab id="tab-2" label="Past" />
+            <cv-tab id="tab-1" label="Upcoming events" />
+            <cv-tab id="tab-2" label="Past events" />
           </cv-tabs>
         </client-only>
       </div>
@@ -211,25 +211,42 @@ export default class extends QiskitPage {
     }
 
     @include mq($until: medium) {
-      .bx--tabs__nav-item,
       .bx--tabs-trigger {
         background-color: $white;
       }
 
+      .bx--tabs-trigger {
+        border-bottom: 1px solid #E0E0E0;
+      }
+
       .bx--tabs-trigger svg {
-        fill: $cool-gray-80;
+        fill: $black-100;
       }
 
       .bx--tabs-trigger-text {
-        color: $white-text-01;
+        color: $gray-100;
       }
 
-      .bx--tabs__nav-link {
+      .bx--tabs-trigger--open {
+        border-bottom: 1px solid $gray-60;
+      }
+
+      .bx--tabs-trigger--open,
+      .bx--tabs__nav-item {
+        background-color: $cool-gray-10;
+      }
+
+      .bx--tabs__nav {
+        box-shadow: initial;
+      }
+
+      .bx--tabs__nav-item:last-child .bx--tabs__nav-link {
         border-bottom: none;
       }
 
       .bx--tabs__nav-item:hover:not(.bx--tabs__nav-item--selected):not(.bx--tabs__nav-item--disabled) {
         background-color: #e5e5e5;
+        box-shadow: initial;
       }
     }
   }


### PR DESCRIPTION
Resolves #955


Updated the colors on the dropdown tabs for mobile.

Note: in order to not recreate another v-deep selector, I had to remove the scoped attribute in the component's style tag, which I think should be fine since this is an event-page.