### PR TITLE
Implements meet advocates layout

### DIFF
--- a/components/advocates/MeetTheAdvocates.vue
+++ b/components/advocates/MeetTheAdvocates.vue
@@ -57,7 +57,7 @@ export default class extends Vue {
 
   filter = {
     label: 'Locations',
-    options: ['Europe', 'Asia', 'Africa', 'America'],
+    options: ['Americas', 'Asia Pacific', 'Europe', 'Africa'],
     filterType: 'regionFilters'
   }
 }

--- a/components/advocates/MeetTheAdvocates.vue
+++ b/components/advocates/MeetTheAdvocates.vue
@@ -1,50 +1,42 @@
 <template>
   <div class="meet-the-advocates">
-    <div class="meet-the-advocates__container">
-      <h2 class="copy__title">
-        Meet the Advocates
-      </h2>
-      <p class="copy__paragraph copy__paragraph_importance_support">
-        Qiskit advocates are some of the finest minds in quantum computing,
-        all over the world. If you are interested in getting involved with the
-        quantum computing community, reach out to an advocate local to your area.
-      </p>
-      <div
-        class="meet-the-advocates__extra-filters meet-the-advocates__extra-filters_on-small-screen"
-      >
-        <AppMultiSelect
-          :label="extraFilter.label"
-          :options="extraFilter.options"
+    <h2 class="copy__title">
+      Meet the Advocates
+    </h2>
+    <p class="copy__paragraph copy__paragraph_importance_support">
+      Qiskit advocates are some of the finest minds in quantum computing,
+      all over the world. If you are interested in getting involved with the
+      quantum computing community, reach out to an advocate local to your area.
+    </p>
+    <AppFiltersResultsLayout>
+      <template slot="filters-on-m-l-screen">
+        <AppFieldset :label="filter.label">
+          <client-only>
+            <AppCheckbox
+              v-for="option in filter.options"
+              :key="option.label"
+              v-bind="option"
+            />
+          </client-only>
+        </AppFieldset>
+      </template>
+      <template slot="filters-on-s-screen">
+        <AppMultiSelect v-bind="filter.label" />
+      </template>
+      <template slot="results">
+        <AdvocateCard
+          v-for="advocate in advocates"
+          :key="`advocate-${advocate.attributes.name}`"
+          v-bind="advocate.attributes"
         />
-      </div>
-      <AppFiltersResultsLayout>
-        <template slot="filters">
-          <AppFieldset :label="extraFilter.label">
-            <client-only>
-              <AppCheckbox
-                v-for="option in extraFilter.options"
-                :key="option.label"
-                v-bind="option"
-              />
-            </client-only>
-          </AppFieldset>
-        </template>
-        <template slot="results">
-          <AdvocateCard
-            v-for="advocate in advocates"
-            :key="`advocate-${advocate.attributes.name}`"
-            v-bind="advocate.attributes"
-          />
-        </template>
-      </AppFiltersResultsLayout>
-    </div>
+      </template>
+    </AppFiltersResultsLayout>
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue'
 import { Component, Prop } from 'vue-property-decorator'
-import AppCard from '~/components/ui/AppCard.vue'
 import AdvocateCard from '~/components/advocates/AdvocateCard.vue'
 import AppMultiSelect from '~/components/ui/AppMultiSelect.vue'
 import AppFieldset from '~/components/ui/AppFieldset.vue'
@@ -60,7 +52,6 @@ type multiSelectOption = {
 @Component({
   components: {
     AdvocateCard,
-    AppCard,
     AppMultiSelect,
     AppFieldset,
     AppCheckbox,
@@ -71,17 +62,12 @@ export default class extends Vue {
   @Prop(Array) advocates!: any
 
   regions = ['Europe', 'Asia', 'Africa', 'America']
-  emptyCard = {
-    title: 'No people found',
-    description: 'No Qiskit advocates found for the given criteria. Trying doing a broader search. There are literally dozens of us.',
-    img: '/images/events/no-events.svg'
-  }
 
   regionsOptions = this.getOptions(this.regions)
   regionsLabel: string = 'Locations'
   regionsFilters: string = 'regionFilters'
 
-  extraFilter = {
+  filter = {
     label: this.regionsLabel,
     options: this.regionsOptions,
     filterType: this.regionsFilters
@@ -92,30 +78,3 @@ export default class extends Vue {
   }
 }
 </script>
-
-<style lang="scss">
-@import '~carbon-components/scss/globals/scss/typography';
-
-.meet-the-advocates {
-  background-color: $white;
-  color: $white-text-01;
-
-  &__container {
-    @include contained();
-  }
-
-  &__extra-filters {
-    &_on-large-screen {
-      @include mq($until: medium) {
-        display: none;
-      }
-    }
-
-    &_on-small-screen {
-      @include mq($from: medium) {
-        display: none;
-      }
-    }
-  }
-}
-</style>

--- a/components/advocates/MeetTheAdvocates.vue
+++ b/components/advocates/MeetTheAdvocates.vue
@@ -1,0 +1,148 @@
+<template>
+  <div class="meet-the-advocates">
+    <div class="meet-the-advocates__container">
+      <h2 class="copy__title">
+        Meet the Advocates
+      </h2>
+      <p class="copy__paragraph copy__paragraph_importance_support">
+        Qiskit advocates are some of the finest minds in quantum computing,
+        all over the world. If you are interested in getting involved with the
+        quantum computing community, reach out to an advocate local to your area.
+      </p>
+      <div
+        class="meet-the-advocates__extra-filters meet-the-advocates__extra-filters_on-small-screen"
+      >
+        <AppMultiSelect
+          :label="extraFilter.label"
+          :options="extraFilter.options"
+        />
+      </div>
+      <div class="meet-the-advocates__index">
+        <div class="meet-the-advocates__extra-filters meet-the-advocates__extra-filters_on-large-screen">
+          <AppFieldset :label="extraFilter.label">
+            <client-only>
+              <cv-checkbox
+                v-for="option in extraFilter.options"
+                :key="option.label"
+                class="meet-the-advocates__extra-filters__checkboxes"
+                :value="option.value"
+                :label="option.label"
+              />
+            </client-only>
+          </AppFieldset>
+        </div>
+        <div class="meet-the-advocates__main-content">
+          <AdvocateCard
+            v-for="advocate in advocates"
+            :key="`advocate-${advocate.attributes.name}`"
+            v-bind="advocate.attributes"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { Component, Prop } from 'vue-property-decorator'
+import AppCard from '~/components/ui/AppCard.vue'
+import AdvocateCard from '~/components/advocates/AdvocateCard.vue'
+import AppMultiSelect from '~/components/ui/AppMultiSelect.vue'
+import AppFieldset from '~/components/ui/AppFieldset.vue'
+
+type multiSelectOption = {
+  label: string,
+  value: string,
+  name: string
+}
+
+@Component({
+  components: {
+    AdvocateCard,
+    AppCard,
+    AppMultiSelect,
+    AppFieldset
+  }
+})
+export default class extends Vue {
+  @Prop(Array) advocates!: any
+
+  regions = ['Europe', 'Asia', 'Africa', 'America']
+  emptyCard = {
+    title: 'No people found',
+    description: 'No Qiskit advocates found for the given criteria. Trying doing a broader search. There are literally dozens of us.',
+    img: '/images/events/no-events.svg'
+  }
+
+  regionsOptions = this.getOptions(this.regions)
+  regionsLabel: string = 'Locations'
+  regionsFilters: string = 'regionFilters'
+
+  extraFilter = {
+    label: this.regionsLabel,
+    options: this.regionsOptions,
+    filterType: this.regionsFilters
+  }
+
+  getOptions (optionsList: any): Array<multiSelectOption> {
+    return optionsList.map((item: string) => ({ label: item, value: item, name: item }))
+  }
+}
+</script>
+
+<style lang="scss">
+@import '~carbon-components/scss/globals/scss/typography';
+
+.meet-the-advocates {
+  background-color: $white;
+  color: $white-text-01;
+
+  &__container {
+    @include contained();
+  }
+
+  &__index {
+    display: flex;
+    justify-content: space-between;
+    margin-top: $layout-05;
+
+    @include mq($until: medium) {
+      flex-direction: column;
+    }
+  }
+
+  &__extra-filters {
+    &__checkboxes {
+      .bx--checkbox-label::before {
+        border: 1px solid $black-100;
+      }
+
+      .bx--checkbox:focus + .bx--checkbox-label::before {
+        box-shadow: 0 0 0 2px $white, 0 0 0 4px $purple-60;
+      }
+    }
+
+    &_on-large-screen {
+      @include mq($until: medium) {
+        display: none;
+      }
+    }
+
+    &_on-small-screen {
+      @include mq($from: medium) {
+        display: none;
+      }
+    }
+  }
+
+  &__main-content {
+    width: 75%;
+
+    @include mq($until: medium) {
+      width: 100%;
+      margin-top: $layout-04;
+    }
+  }
+}
+</style>

--- a/components/advocates/MeetTheAdvocates.vue
+++ b/components/advocates/MeetTheAdvocates.vue
@@ -21,12 +21,10 @@
         <div class="meet-the-advocates__extra-filters meet-the-advocates__extra-filters_on-large-screen">
           <AppFieldset :label="extraFilter.label">
             <client-only>
-              <cv-checkbox
+              <AppCheckbox
                 v-for="option in extraFilter.options"
                 :key="option.label"
-                class="meet-the-advocates__extra-filters__checkboxes"
-                :value="option.value"
-                :label="option.label"
+                v-bind="option"
               />
             </client-only>
           </AppFieldset>
@@ -50,6 +48,7 @@ import AppCard from '~/components/ui/AppCard.vue'
 import AdvocateCard from '~/components/advocates/AdvocateCard.vue'
 import AppMultiSelect from '~/components/ui/AppMultiSelect.vue'
 import AppFieldset from '~/components/ui/AppFieldset.vue'
+import AppCheckbox from '~/components/ui/AppCheckbox.vue'
 
 type multiSelectOption = {
   label: string,
@@ -62,7 +61,8 @@ type multiSelectOption = {
     AdvocateCard,
     AppCard,
     AppMultiSelect,
-    AppFieldset
+    AppFieldset,
+    AppCheckbox
   }
 })
 export default class extends Vue {
@@ -113,16 +113,6 @@ export default class extends Vue {
   }
 
   &__extra-filters {
-    &__checkboxes {
-      .bx--checkbox-label::before {
-        border: 1px solid $black-100;
-      }
-
-      .bx--checkbox:focus + .bx--checkbox-label::before {
-        box-shadow: 0 0 0 2px $white, 0 0 0 4px $purple-60;
-      }
-    }
-
     &_on-large-screen {
       @include mq($until: medium) {
         display: none;

--- a/components/advocates/MeetTheAdvocates.vue
+++ b/components/advocates/MeetTheAdvocates.vue
@@ -14,8 +14,8 @@
           <client-only>
             <AppCheckbox
               v-for="option in filter.options"
-              :key="option.label"
-              v-bind="option"
+              :key="option"
+              :option="option"
             />
           </client-only>
         </AppFieldset>
@@ -43,12 +43,6 @@ import AppFieldset from '~/components/ui/AppFieldset.vue'
 import AppCheckbox from '~/components/ui/AppCheckbox.vue'
 import AppFiltersResultsLayout from '~/components/ui/AppFiltersResultsLayout.vue'
 
-type multiSelectOption = {
-  label: string,
-  value: string,
-  name: string
-}
-
 @Component({
   components: {
     AdvocateCard,
@@ -61,20 +55,10 @@ type multiSelectOption = {
 export default class extends Vue {
   @Prop(Array) advocates!: any
 
-  regions = ['Europe', 'Asia', 'Africa', 'America']
-
-  regionsOptions = this.getOptions(this.regions)
-  regionsLabel: string = 'Locations'
-  regionsFilters: string = 'regionFilters'
-
   filter = {
-    label: this.regionsLabel,
-    options: this.regionsOptions,
-    filterType: this.regionsFilters
-  }
-
-  getOptions (optionsList: any): Array<multiSelectOption> {
-    return optionsList.map((item: string) => ({ label: item, value: item, name: item }))
+    label: 'Locations',
+    options: ['Europe', 'Asia', 'Africa', 'America'],
+    filterType: 'regionFilters'
   }
 }
 </script>

--- a/components/advocates/MeetTheAdvocates.vue
+++ b/components/advocates/MeetTheAdvocates.vue
@@ -17,8 +17,8 @@
           :options="extraFilter.options"
         />
       </div>
-      <div class="meet-the-advocates__index">
-        <div class="meet-the-advocates__extra-filters meet-the-advocates__extra-filters_on-large-screen">
+      <AppFiltersResultsLayout>
+        <template slot="filters">
           <AppFieldset :label="extraFilter.label">
             <client-only>
               <AppCheckbox
@@ -28,15 +28,15 @@
               />
             </client-only>
           </AppFieldset>
-        </div>
-        <div class="meet-the-advocates__main-content">
+        </template>
+        <template slot="results">
           <AdvocateCard
             v-for="advocate in advocates"
             :key="`advocate-${advocate.attributes.name}`"
             v-bind="advocate.attributes"
           />
-        </div>
-      </div>
+        </template>
+      </AppFiltersResultsLayout>
     </div>
   </div>
 </template>
@@ -49,6 +49,7 @@ import AdvocateCard from '~/components/advocates/AdvocateCard.vue'
 import AppMultiSelect from '~/components/ui/AppMultiSelect.vue'
 import AppFieldset from '~/components/ui/AppFieldset.vue'
 import AppCheckbox from '~/components/ui/AppCheckbox.vue'
+import AppFiltersResultsLayout from '~/components/ui/AppFiltersResultsLayout.vue'
 
 type multiSelectOption = {
   label: string,
@@ -62,7 +63,8 @@ type multiSelectOption = {
     AppCard,
     AppMultiSelect,
     AppFieldset,
-    AppCheckbox
+    AppCheckbox,
+    AppFiltersResultsLayout
   }
 })
 export default class extends Vue {
@@ -102,16 +104,6 @@ export default class extends Vue {
     @include contained();
   }
 
-  &__index {
-    display: flex;
-    justify-content: space-between;
-    margin-top: $layout-05;
-
-    @include mq($until: medium) {
-      flex-direction: column;
-    }
-  }
-
   &__extra-filters {
     &_on-large-screen {
       @include mq($until: medium) {
@@ -123,15 +115,6 @@ export default class extends Vue {
       @include mq($from: medium) {
         display: none;
       }
-    }
-  }
-
-  &__main-content {
-    width: 75%;
-
-    @include mq($until: medium) {
-      width: 100%;
-      margin-top: $layout-04;
     }
   }
 }

--- a/components/advocates/MeetTheAdvocates.vue
+++ b/components/advocates/MeetTheAdvocates.vue
@@ -21,7 +21,7 @@
         </AppFieldset>
       </template>
       <template slot="filters-on-s-screen">
-        <AppMultiSelect v-bind="filter.label" />
+        <AppMultiSelect v-bind="filter" />
       </template>
       <template slot="results">
         <AdvocateCard

--- a/components/ui/AppCheckbox.vue
+++ b/components/ui/AppCheckbox.vue
@@ -14,6 +14,8 @@ import { Component, Prop } from 'vue-property-decorator'
 export default class extends Vue {
   @Prop(String) value!: string
   @Prop(String) label!: string
+  // TODO: Add checked, aria-checked and @change when doing the filter behaviour. Also
+  // reuse this component on events page
 }
 </script>
 

--- a/components/ui/AppCheckbox.vue
+++ b/components/ui/AppCheckbox.vue
@@ -1,8 +1,7 @@
 <template>
   <cv-checkbox
     class="app-checkbox"
-    :value="value"
-    :label="label"
+    v-bind="formatedOption"
   />
 </template>
 
@@ -10,12 +9,22 @@
 import Vue from 'vue'
 import { Component, Prop } from 'vue-property-decorator'
 
+type ckeckboxOption = {
+  label: string,
+  value: string
+}
+
 @Component
 export default class extends Vue {
-  @Prop(String) value!: string
-  @Prop(String) label!: string
+  @Prop(String) option!: string
   // TODO: Add checked, aria-checked and @change when doing the filter behaviour. Also
   // reuse this component on events page
+
+  formatedOption = this.formatOption(this.option)
+
+  formatOption (option: string): ckeckboxOption {
+    return { label: option, value: option }
+  }
 }
 </script>
 

--- a/components/ui/AppCheckbox.vue
+++ b/components/ui/AppCheckbox.vue
@@ -1,7 +1,7 @@
 <template>
   <cv-checkbox
     class="app-checkbox"
-    v-bind="formatedOption"
+    v-bind="formattedOption"
   />
 </template>
 
@@ -9,7 +9,7 @@
 import Vue from 'vue'
 import { Component, Prop } from 'vue-property-decorator'
 
-type ckeckboxOption = {
+type checkboxOption = {
   label: string,
   value: string
 }
@@ -20,9 +20,9 @@ export default class extends Vue {
   // TODO: Add checked, aria-checked and @change when doing the filter behaviour. Also
   // reuse this component on events page
 
-  formatedOption = this.formatOption(this.option)
+  formattedOption = this.formatOption(this.option)
 
-  formatOption (option: string): ckeckboxOption {
+  formatOption (option: string): checkboxOption {
     return { label: option, value: option }
   }
 }

--- a/components/ui/AppCheckbox.vue
+++ b/components/ui/AppCheckbox.vue
@@ -1,0 +1,30 @@
+<template>
+  <cv-checkbox
+    class="app-checkbox"
+    :value="value"
+    :label="label"
+  />
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { Component, Prop } from 'vue-property-decorator'
+
+@Component
+export default class extends Vue {
+  @Prop(String) value!: string
+  @Prop(String) label!: string
+}
+</script>
+
+<style lang="scss">
+.app-checkbox {
+  .bx--checkbox-label::before {
+    border: 1px solid $black-100;
+  }
+
+  .bx--checkbox:focus + .bx--checkbox-label::before {
+    box-shadow: 0 0 0 2px $white, 0 0 0 4px $purple-60;
+  }
+}
+</style>

--- a/components/ui/AppFiltersResultsLayout.vue
+++ b/components/ui/AppFiltersResultsLayout.vue
@@ -1,12 +1,13 @@
 <template>
   <div class="app-filters-results-layout">
-    <div class="app-filters-results-layout__container">
-      <div class="app-filters-results-layout__filters app-filters-results-layout__filters_on-large-screen">
-        <slot name="filters" />
-      </div>
-      <div class="app-filters-results-layout__results">
-        <slot name="results" />
-      </div>
+    <div class="app-filters-results-layout__filters app-filters-results-layout__filters_on-large-screen">
+      <slot name="filters-on-m-l-screen" />
+    </div>
+    <div class="app-filters-results-layout__filters app-filters-results-layout__filters_on-small-screen">
+      <slot name="filters-on-s-screen" />
+    </div>
+    <div class="app-filters-results-layout__results">
+      <slot name="results" />
     </div>
   </div>
 </template>
@@ -20,24 +21,18 @@ export default class extends Vue {}
 </script>
 
 <style lang="scss">
-@import '~carbon-components/scss/globals/scss/typography';
-
 .app-filters-results-layout {
-  background-color: $white;
-  color: $white-text-01;
+  display: flex;
+  justify-content: space-between;
+  margin-top: $layout-05;
 
-  &__container {
-    @include contained();
-    display: flex;
-    justify-content: space-between;
-    margin-top: $layout-05;
-
-    @include mq($until: medium) {
-      flex-direction: column;
-    }
+  @include mq($until: medium) {
+    flex-direction: column;
   }
 
   &__filters {
+    color: $gray-100;
+
     &_on-large-screen {
       @include mq($until: medium) {
         display: none;

--- a/components/ui/AppFiltersResultsLayout.vue
+++ b/components/ui/AppFiltersResultsLayout.vue
@@ -1,0 +1,63 @@
+<template>
+  <div class="app-filters-results-layout">
+    <div class="app-filters-results-layout__container">
+      <div class="app-filters-results-layout__filters app-filters-results-layout__filters_on-large-screen">
+        <slot name="filters" />
+      </div>
+      <div class="app-filters-results-layout__results">
+        <slot name="results" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { Component } from 'vue-property-decorator'
+
+@Component
+export default class extends Vue {}
+</script>
+
+<style lang="scss">
+@import '~carbon-components/scss/globals/scss/typography';
+
+.app-filters-results-layout {
+  background-color: $white;
+  color: $white-text-01;
+
+  &__container {
+    @include contained();
+    display: flex;
+    justify-content: space-between;
+    margin-top: $layout-05;
+
+    @include mq($until: medium) {
+      flex-direction: column;
+    }
+  }
+
+  &__filters {
+    &_on-large-screen {
+      @include mq($until: medium) {
+        display: none;
+      }
+    }
+
+    &_on-small-screen {
+      @include mq($from: medium) {
+        display: none;
+      }
+    }
+  }
+
+  &__results {
+    width: 75%;
+
+    @include mq($until: medium) {
+      width: 100%;
+      margin-top: $layout-04;
+    }
+  }
+}
+</style>

--- a/components/ui/AppMultiSelect.vue
+++ b/components/ui/AppMultiSelect.vue
@@ -7,7 +7,7 @@
       :options="formatedOptions"
       :value="value"
       :selection-feedback="feedback"
-      @change="$emit('change-on-multi-select', $event)"
+      @change="$emit('change-selection', $event)"
     />
   </client-only>
 </template>

--- a/components/ui/AppMultiSelect.vue
+++ b/components/ui/AppMultiSelect.vue
@@ -4,7 +4,7 @@
       class="app-multi-select"
       :theme="theme"
       :label="label"
-      :options="options"
+      :options="formatedOptions"
       :value="value"
       :selection-feedback="feedback"
       @change="$emit('change-on-multi-select', $event)"
@@ -16,14 +16,26 @@
 import Vue from 'vue'
 import { Component, Prop } from 'vue-property-decorator'
 
+type multiSelectOption = {
+  label: string,
+  value: string,
+  name: string
+}
+
 @Component
 export default class extends Vue {
-  @Prop(Array) options!: any
+  @Prop(Array) options!: Array<string>
   @Prop(String) label!: any
   @Prop(Array) value!: any
 
+  formatedOptions = this.formatOptions(this.options)
+
   theme: string = 'light'
   feedback: string = 'fixed'
+
+  formatOptions (optionsList: any): Array<multiSelectOption> {
+    return optionsList.map((item: string) => ({ label: item, value: item, name: item }))
+  }
 }
 </script>
 

--- a/components/ui/AppMultiSelect.vue
+++ b/components/ui/AppMultiSelect.vue
@@ -1,13 +1,15 @@
 <template>
-  <cv-multi-select
-    class="app-multi-select"
-    :theme="theme"
-    :label="label"
-    :options="options"
-    :value="value"
-    :selection-feedback="feedback"
-    @change="$emit('change-on-multi-select', $event)"
-  />
+  <client-only>
+    <cv-multi-select
+      class="app-multi-select"
+      :theme="theme"
+      :label="label"
+      :options="options"
+      :value="value"
+      :selection-feedback="feedback"
+      @change="$emit('change-on-multi-select', $event)"
+    />
+  </client-only>
 </template>
 
 <script lang="ts">

--- a/pages/advocates/index.vue
+++ b/pages/advocates/index.vue
@@ -32,16 +32,7 @@
         </h2>
       </MapSection>
       <PageSection id="meet-the-advocates" framed>
-        <h2 class="community-page__header community-page__header_elegant">
-          Meet the Advocates
-        </h2>
-        <div class="advocate-cards-container">
-          <AdvocateCard
-            v-for="profile in profiles"
-            :key="`advocate-${profile.attributes.name}`"
-            v-bind="profile.attributes"
-          />
-        </div>
+        <MeetTheAdvocates :advocates="profiles" />
       </PageSection>
     </div>
   </main>
@@ -57,6 +48,7 @@ import AdvocateCard from '~/components/advocates/AdvocateCard.vue'
 import CompactFeature from '~/components/ui/CompactFeature.vue'
 import AppCta from '~/components/ui/AppCta.vue'
 import TheAdvocatesHeader from '~/components/advocates/TheAdvocatesHeader.vue'
+import MeetTheAdvocates from '~/components/advocates/MeetTheAdvocates.vue'
 
 type Benefit = Pick<CompactFeature, 'icon'|'fileType'|'title'|'description'>
 
@@ -68,7 +60,8 @@ type Benefit = Pick<CompactFeature, 'icon'|'fileType'|'title'|'description'>
     AdvocateCard,
     CompactFeature,
     AppCta,
-    TheAdvocatesHeader
+    TheAdvocatesHeader,
+    MeetTheAdvocates
   },
 
   head () {
@@ -192,30 +185,5 @@ main {
 
 #global-community {
   color: $text-01;
-}
-
-#meet-the-advocates {
-  color: $text-01;
-
-  .advocate-cards-container {
-    margin-top: $layout-04;
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: $spacing-05;
-
-    & > * {
-      @include mq($until: medium) {
-        margin-bottom: $layout-01;
-      }
-    }
-
-    .advocate-card {
-      width: 100%;
-    }
-
-    @include mq($until: medium) {
-      display: block;
-    }
-  }
 }
 </style>

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -15,14 +15,12 @@
         :key="filter.label"
         class="event-page__extra-filters event-page__extra-filters_on-small-screen"
       >
-        <client-only>
-          <AppMultiSelect
-            :label="filter.label"
-            :options="filter.options"
-            :value="getCheckedFilters(filter.filterType)"
-            @change-on-multi-select="updateWholeFilter(filter.filterType, $event)"
-          />
-        </client-only>
+        <AppMultiSelect
+          :label="filter.label"
+          :options="filter.options"
+          :value="getCheckedFilters(filter.filterType)"
+          @change-on-multi-select="updateWholeFilter(filter.filterType, $event)"
+        />
       </div>
       <div class="event-page__event-index">
         <div class="event-page__extra-filters event-page__extra-filters_on-large-screen">

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -99,7 +99,7 @@ import AppFieldset from '~/components/ui/AppFieldset.vue'
 import {
   CommunityEvent,
   WORLD_REGION_OPTIONS,
-  COMMUNITY_EVENT_TYPE_OPTIONS,
+  COMMUNITY_EVENT_TYPE_OPTIONS
 } from '~/store/modules/events.ts'
 import { EVENT_REQUEST_LINK } from '~/constants/appLinks'
 

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -32,13 +32,13 @@
             <client-only>
               <cv-checkbox
                 v-for="option in filter.options"
-                :key="option.label"
+                :key="option"
                 class="event-page__extra-filters__checkboxes"
-                :value="option.value"
-                :label="option.label"
-                :checked="isFilterChecked(filter.filterType, option.value)"
-                :aria-checked="isFilterChecked(filter.filterType, option.value)"
-                @change="updateFilter(filter.filterType, option.value, $event)"
+                :value="option"
+                :label="option"
+                :checked="isFilterChecked(filter.filterType, option)"
+                :aria-checked="isFilterChecked(filter.filterType, option)"
+                @change="updateFilter(filter.filterType, option, $event)"
               />
             </client-only>
           </AppFieldset>
@@ -100,7 +100,6 @@ import {
   CommunityEvent,
   WORLD_REGION_OPTIONS,
   COMMUNITY_EVENT_TYPE_OPTIONS,
-  EventMultiSelectOption
 } from '~/store/modules/events.ts'
 import { EVENT_REQUEST_LINK } from '~/constants/appLinks'
 
@@ -146,8 +145,6 @@ import { EVENT_REQUEST_LINK } from '~/constants/appLinks'
   }
 })
 export default class extends QiskitPage {
-  regions = WORLD_REGION_OPTIONS
-  types = COMMUNITY_EVENT_TYPE_OPTIONS
   routeName: string = 'events'
   eventRequestLink = EVENT_REQUEST_LINK
   emptyCard = {
@@ -156,33 +153,21 @@ export default class extends QiskitPage {
     img: '/images/events/no-events.svg'
   }
 
-  // multiselect
-  regionsOptions = this.getOptions(this.regions)
-  typesOptions = this.getOptions(this.types)
-  regionsLabel: string = 'Locations'
-  typesLabel: string = 'Types'
-  regionsFilters: string = 'regionFilters'
-  typesFilters: string = 'typeFilters'
-
   extraFilters = [
     {
-      label: this.regionsLabel,
-      options: this.regionsOptions,
-      filterType: this.regionsFilters
+      label: 'Locations',
+      options: WORLD_REGION_OPTIONS,
+      filterType: 'regionFilters'
     },
     {
-      label: this.typesLabel,
-      options: this.typesOptions,
-      filterType: this.typesFilters
+      label: 'Types',
+      options: COMMUNITY_EVENT_TYPE_OPTIONS,
+      filterType: 'typeFilters'
     }
   ]
 
   get noEvents (): boolean {
     return (this as any).filteredEvents.length === 0
-  }
-
-  getOptions (optionsList: any): Array<EventMultiSelectOption> {
-    return optionsList.map((item: string) => ({ label: item, value: item, name: item }))
   }
 
   getCheckedFilters (filter: string) {

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -19,7 +19,7 @@
           :label="filter.label"
           :options="filter.options"
           :value="getCheckedFilters(filter.filterType)"
-          @change-on-multi-select="updateWholeFilter(filter.filterType, $event)"
+          @change-selection="updateWholeFilter(filter.filterType, $event)"
         />
       </div>
       <div class="event-page__event-index">

--- a/store/modules/events.ts
+++ b/store/modules/events.ts
@@ -43,12 +43,6 @@ type CommunityEvent = {
   to: string
 }
 
-type EventMultiSelectOption = {
-  label: string,
-  value: string,
-  name: string
-}
-
 const WORLD_REGION_OPTIONS = Object.freeze([
   WORLD_REGIONS.americas,
   WORLD_REGIONS.asiaPacific,
@@ -72,8 +66,7 @@ export {
   COMMUNITY_EVENT_TYPES,
   WORLD_REGIONS,
   WORLD_REGION_OPTIONS,
-  COMMUNITY_EVENT_TYPE_OPTIONS,
-  EventMultiSelectOption
+  COMMUNITY_EVENT_TYPE_OPTIONS
 }
 
 export default {


### PR DESCRIPTION
Fix #1074 

This PR:
- Creates a component for the filters-results layouts we have on learn's, events', and advocates' page but it's only used on the advocates' page. We have an [issue to extend this layout](https://github.com/Qiskit/qiskit.org/issues/944) to the rest of the pages
- Creates an AppCheckbox component that should be finished and reused on the events' page when [implementing the behavior of the filter](https://github.com/Qiskit/qiskit.org/issues/1086)

I did my best naming the components, but I'm not sure if it's easy to follow, so please, if you have suggestions, let me know