### PR TITLE
Remove header title width constraint

### DIFF
--- a/components/advocates/TheAdvocatesHeader.vue
+++ b/components/advocates/TheAdvocatesHeader.vue
@@ -26,7 +26,9 @@ export default class extends Vue { }
 <style lang="scss">
 .advocates-header {
   .page-header__title {
-    max-width: none;
+    @include mq($from: large) {
+      max-width: none;
+    }
   }
 }
 </style>

--- a/components/advocates/TheAdvocatesHeader.vue
+++ b/components/advocates/TheAdvocatesHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <ThePageHeader>
+  <ThePageHeader class="advocates-header">
     Connect with the
     <TypewriterEffect
       :values="[
@@ -22,3 +22,11 @@ import TypewriterEffect from '~/components/ui/TypewriterEffect.vue'
 @Component({ components: { ThePageHeader, TypewriterEffect } })
 export default class extends Vue { }
 </script>
+
+<style lang="scss">
+.advocates-header {
+  .page-header__title {
+    max-width: none;
+  }
+}
+</style>


### PR DESCRIPTION
No issue related.

This updates the Advocates header to match the designs, on full-screen