### PR TITLE
Changed the content on landing page about python dependency

### DIFF
--- a/components/landing/TheQuickStart/StartLocally.vue
+++ b/components/landing/TheQuickStart/StartLocally.vue
@@ -9,7 +9,7 @@
         class="copy__link"
         url="https://www.python.org/downloads/"
       >
-        Python 3.5+.
+        Python 3.6+.
       </AppLink>
       Although it isn't required, we recommend using a
       <AppLink


### PR DESCRIPTION
Fixes #1046 

Changed the components/landing/TheQuickStart/StartLocally.vue file to reflect the correct version of Python required for qiskit.