### PR TITLE
Global registration of components

### DIFF
--- a/components/events/EventCard.vue
+++ b/components/events/EventCard.vue
@@ -23,11 +23,8 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component, Prop } from 'vue-property-decorator'
-import AppCard from '~/components/ui/AppCard.vue'
 
-@Component({
-  components: { AppCard }
-})
+@Component
 export default class EventCard extends Vue {
   @Prop(Array) types!: any
   @Prop(String) title!: any

--- a/components/events/EventMenu.vue
+++ b/components/events/EventMenu.vue
@@ -23,11 +23,8 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
-import AppLink from '~/components/ui/AppLink.vue'
 
-@Component({
-  components: { AppLink }
-})
+@Component
 export default class EventMenu extends Vue {}
 </script>
 

--- a/components/events/TheEventsHeader.vue
+++ b/components/events/TheEventsHeader.vue
@@ -16,9 +16,7 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
-import ThePageHeader from '~/components/ui/ThePageHeader.vue'
-import TypewriterEffect from '~/components/ui/TypewriterEffect.vue'
 
-@Component({ components: { ThePageHeader, TypewriterEffect } })
+@Component
 export default class TheEventsHeader extends Vue { }
 </script>

--- a/components/landing/TheFeatures/index.vue
+++ b/components/landing/TheFeatures/index.vue
@@ -35,12 +35,8 @@
 import Vue from 'vue'
 
 import { Component } from 'vue-property-decorator'
-import TheFeatureMosaic from '~/components/landing/TheFeatures/TheFeatureMosaic.vue'
-import LandingCta from '~/components/landing/LandingCta.vue'
 
-@Component({
-  components: { TheFeatureMosaic, LandingCta }
-})
+@Component
 export default class TheFeatures extends Vue { }
 </script>
 

--- a/components/landing/TheHeroMoment/VersionInfo.vue
+++ b/components/landing/TheHeroMoment/VersionInfo.vue
@@ -29,12 +29,9 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component, Prop } from 'vue-property-decorator'
-import AppLink from '~/components/ui/AppLink.vue'
 import { GITHUB_REPOSITORY } from '~/constants/menuLinks'
 
-@Component({
-  components: { AppLink }
-})
+@Component
 export default class VersionInfo extends Vue {
   githubRepoLink = GITHUB_REPOSITORY
 

--- a/components/landing/TheHeroMoment/index.vue
+++ b/components/landing/TheHeroMoment/index.vue
@@ -31,13 +31,8 @@
 import Vue from 'vue'
 
 import { Prop, Component } from 'vue-property-decorator'
-import VersionInfo from '~/components/landing/TheHeroMoment/VersionInfo.vue'
-import LandingCta from '~/components/landing/LandingCta.vue'
-import MetalGrid from '~/components/metal/MetalGrid.vue'
 
-@Component({
-  components: { VersionInfo, LandingCta, MetalGrid }
-})
+@Component
 export default class TheHeroMoment extends Vue {
   @Prop({ type: String, required: true }) version!: string
 

--- a/components/landing/TheLearnSection/LearnCard.vue
+++ b/components/landing/TheLearnSection/LearnCard.vue
@@ -22,11 +22,8 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
-import AppCta from '~/components/ui/AppCta.vue'
 
-@Component({
-  components: { AppCta }
-})
+@Component
 export default class LearnCard extends Vue {}
 </script>
 

--- a/components/landing/TheLearnSection/index.vue
+++ b/components/landing/TheLearnSection/index.vue
@@ -18,9 +18,8 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
-import LearnCard from '~/components/landing/TheLearnSection/LearnCard.vue'
 
-@Component({ components: { LearnCard } })
+@Component
 export default class TheLearnSection extends Vue {}
 </script>
 

--- a/components/landing/TheQuickStart/PrerequisitesForMac.vue
+++ b/components/landing/TheQuickStart/PrerequisitesForMac.vue
@@ -27,9 +27,7 @@
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
 
-import AppLink from '~/components/ui/AppLink.vue'
-
-@Component({ components: { AppLink } })
+@Component
 export default class PrerequisitesForMac extends Vue { }
 </script>
 

--- a/components/landing/TheQuickStart/StartLocally.vue
+++ b/components/landing/TheQuickStart/StartLocally.vue
@@ -69,11 +69,6 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
-import PrerequisitesForLinux from '~/components/landing/TheQuickStart/PrerequisitesForLinux.vue'
-import PrerequisitesForMac from '~/components/landing/TheQuickStart/PrerequisitesForMac.vue'
-import PrerequisitesForWindows from '~/components/landing/TheQuickStart/PrerequisitesForWindows.vue'
-import SyntaxHighlight from '~/components/ui/SyntaxHighlight.vue'
-import AppLink from '~/components/ui/AppLink.vue'
 
 type ChoicesGroup = {
   title: string,
@@ -83,15 +78,7 @@ type ChoicesGroup = {
 
 type InstallChoices = Array<ChoicesGroup>
 
-@Component({
-  components: {
-    PrerequisitesForLinux,
-    PrerequisitesForMac,
-    PrerequisitesForWindows,
-    SyntaxHighlight,
-    AppLink
-  }
-})
+@Component
 export default class StartLocally extends Vue {
   OPERATING_SYSTEMS = {
     linux: 'Linux',

--- a/components/landing/TheQuickStart/StartOnTheCloud.vue
+++ b/components/landing/TheQuickStart/StartOnTheCloud.vue
@@ -20,11 +20,8 @@
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
 import { IBM_Q_EXPERIENCE } from '~/constants/appLinks'
-import AppCta from '~/components/ui/AppCta.vue'
 
-@Component({
-  components: { AppCta }
-})
+@Component
 export default class StartOnTheCloud extends Vue {
   ibmQExperienceLink = IBM_Q_EXPERIENCE
 }

--- a/components/landing/TheQuickStart/index.vue
+++ b/components/landing/TheQuickStart/index.vue
@@ -18,15 +18,8 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
-import StartLocally from './StartLocally.vue'
-import StartOnTheCloud from './StartOnTheCloud.vue'
 
-@Component({
-  components: {
-    StartLocally,
-    StartOnTheCloud
-  }
-})
+@Component
 export default class TheQuickStart extends Vue {}
 </script>
 

--- a/components/layouts/PageFooter/FooterSection.vue
+++ b/components/layouts/PageFooter/FooterSection.vue
@@ -27,11 +27,8 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component, Prop } from 'vue-property-decorator'
-import AppLink from '~/components/ui/AppLink.vue'
 
-@Component({
-  components: { AppLink }
-})
+@Component
 export default class FooterSection extends Vue {
   @Prop(String) title!: any
   @Prop(Array) elements!: any

--- a/components/layouts/PageFooter/index.vue
+++ b/components/layouts/PageFooter/index.vue
@@ -50,9 +50,6 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component, Prop } from 'vue-property-decorator'
-import FooterSection from './FooterSection.vue'
-import AppLink from '~/components/ui/AppLink.vue'
-import AppLogo from '~/components/ui/AppLogo.vue'
 
 import {
   FOOTER_ELEMENTS,
@@ -60,13 +57,7 @@ import {
   STAY_CONNECTED_LINKS
 } from '~/constants/menuLinks'
 
-@Component({
-  components: {
-    FooterSection,
-    AppLink,
-    AppLogo
-  }
-})
+@Component
 export default class PageFooter extends Vue {
   @Prop({ type: String, default: 'light' }) theme!: string
 

--- a/components/layouts/TheMenu/MobileMenu.vue
+++ b/components/layouts/TheMenu/MobileMenu.vue
@@ -45,12 +45,9 @@
 
 <script lang="ts">
 import { Component, Mixins } from 'vue-property-decorator'
-import AppLink from '~/components/ui/AppLink.vue'
 import MenuMixin from '~/mixins/menu'
 
-@Component({
-  components: { AppLink }
-})
+@Component
 export default class MobileMenu extends Mixins(MenuMixin) {}
 </script>
 

--- a/components/layouts/TheMenu/index.vue
+++ b/components/layouts/TheMenu/index.vue
@@ -81,14 +81,9 @@
 
 <script lang="ts">
 import { Watch, Component, Mixins } from 'vue-property-decorator'
-import MobileMenu from '~/components/layouts/TheMenu/MobileMenu.vue'
-import AppLogo from '~/components/ui/AppLogo.vue'
-import AppLink from '~/components/ui/AppLink.vue'
 import MenuMixin from '~/mixins/menu'
 
-@Component({
-  components: { MobileMenu, AppLink, AppLogo }
-})
+@Component
 export default class TheMenu extends Mixins(MenuMixin) {
   isMobileMenuVisible: boolean = false
 

--- a/components/layouts/banners/TheBlackLivesMatterBanner.vue
+++ b/components/layouts/banners/TheBlackLivesMatterBanner.vue
@@ -15,10 +15,8 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
-import TheBanner from '~/components/layouts/TheBanner.vue'
-import AppLink from '~/components/ui/AppLink.vue'
 
-@Component({ components: { AppLink, TheBanner } })
+@Component
 export default class TheBlackLivesMatterBanner extends Vue {}
 </script>
 

--- a/components/learn/CarefulExplanation.vue
+++ b/components/learn/CarefulExplanation.vue
@@ -13,9 +13,8 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component, Prop } from 'vue-property-decorator'
-import AppCta from '~/components/ui/AppCta.vue'
 
-@Component({ components: { AppCta } })
+@Component
 export default class CarefulExplanation extends Vue {
   @Prop({ type: Boolean, default: false }) compact!: boolean
   @Prop({ type: String, default: '#' }) url!: string

--- a/components/learn/TheCarefulExplanationForBeginners.vue
+++ b/components/learn/TheCarefulExplanationForBeginners.vue
@@ -20,9 +20,8 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
-import CarefulExplanation from '~/components/learn/CarefulExplanation.vue'
 
-@Component({ components: { CarefulExplanation } })
+@Component
 export default class TheCarefulExplanationForBeginners extends Vue {}
 </script>
 

--- a/components/learn/TheCarefulExplanationForExperts.vue
+++ b/components/learn/TheCarefulExplanationForExperts.vue
@@ -26,8 +26,7 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
-import CarefulExplanation from '~/components/learn/CarefulExplanation.vue'
 
-@Component({ components: { CarefulExplanation } })
+@Component
 export default class TheCarefulExplanationForExperts extends Vue { }
 </script>

--- a/components/learn/TheLearnHeader.vue
+++ b/components/learn/TheLearnHeader.vue
@@ -18,9 +18,7 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
-import ThePageHeader from '~/components/ui/ThePageHeader.vue'
-import TypewriterEffect from '~/components/ui/TypewriterEffect.vue'
 
-@Component({ components: { ThePageHeader, TypewriterEffect } })
+@Component
 export default class TheLearnHeader extends Vue { }
 </script>

--- a/components/learn/TheLearningResourceList.vue
+++ b/components/learn/TheLearningResourceList.vue
@@ -85,9 +85,8 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component, Prop } from 'vue-property-decorator'
-import AppLink from '~/components/ui/AppLink.vue'
 
-@Component({ components: { AppLink } })
+@Component
 export default class TheLearningResourceList extends Vue {
   @Prop({ type: Array, default: [] }) topFilters!: Array<string>
   @Prop(String) activeTopFilter!: string

--- a/components/metal/AppCtaBtn.vue
+++ b/components/metal/AppCtaBtn.vue
@@ -10,9 +10,8 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
-import AppCta from '~/components/ui/AppCta.vue'
 
-@Component({ components: { AppCta } })
+@Component
 export default class AppCtaBtn extends Vue {}
 </script>
 

--- a/components/metal/BuildingSection.vue
+++ b/components/metal/BuildingSection.vue
@@ -56,10 +56,8 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
-import AppLink from '~/components/ui/AppLink.vue'
 
-@Component({ components: { AppLink } })
-
+@Component
 export default class BuildingSection extends Vue {}
 </script>
 

--- a/components/metal/CapabilitiesSection.vue
+++ b/components/metal/CapabilitiesSection.vue
@@ -56,13 +56,10 @@
 
 <script lang="ts">
 import { Component, Mixins } from 'vue-property-decorator'
-import CapabilityCard from '~/components/metal/CapabilityCard.vue'
 import { MetalCapability, METAL_CAPABILITIES } from '~/constants/metalContent'
 import ScrollSectionsMixin from '~/mixins/scrollBetweenSections'
 
-@Component({
-  components: { CapabilityCard }
-})
+@Component
 export default class CapabilitiesSection extends Mixins(ScrollSectionsMixin) {
   capabilities = METAL_CAPABILITIES
 

--- a/components/metal/EarlyAccessSection.vue
+++ b/components/metal/EarlyAccessSection.vue
@@ -17,12 +17,8 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
-import AppCtaBtn from '~/components/metal/AppCtaBtn.vue'
 
-@Component({
-  components: { AppCtaBtn }
-})
-
+@Component
 export default class EarlyAccessSection extends Vue {
   stayInTouchLink = {
     url: 'http://qisk.it/metal',

--- a/components/metal/FeaturesSection.vue
+++ b/components/metal/FeaturesSection.vue
@@ -24,12 +24,9 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
-import FeatureCard from '~/components/metal/FeatureCard.vue'
 import { METAL_FEATURES } from '~/constants/metalContent'
 
-@Component({
-  components: { FeatureCard }
-})
+@Component
 export default class FeaturesSection extends Vue {
   metalFeatures = METAL_FEATURES
 }

--- a/components/metal/IntroSection.vue
+++ b/components/metal/IntroSection.vue
@@ -31,9 +31,8 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
-import AppCtaBtn from '~/components/metal/AppCtaBtn.vue'
 
-@Component({ components: { AppCtaBtn } })
+@Component
 export default class IntroSection extends Vue {
   accessRequest = {
     url: 'http://qisk.it/metal',

--- a/components/metal/MetalGrid.vue
+++ b/components/metal/MetalGrid.vue
@@ -37,15 +37,12 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
-import TheDarkHeader from './TheDarkHeader.vue'
 
 type CellCoordinates = { x: number, y: number }
 type CellSpecification = { c: number, r: number, isDecoherent?: boolean }
 type Decoherences = { [key: number]: number }
 
-@Component({
-  components: { TheDarkHeader }
-})
+@Component
 export default class MetalGrid extends Vue {
   timeToRemoveNextCell: number = 5 // in ms
   timeToLoadMetal: number = 50 // in ms

--- a/components/metal/TheDarkHeader.vue
+++ b/components/metal/TheDarkHeader.vue
@@ -63,12 +63,8 @@
 import Vue from 'vue'
 
 import { Component } from 'vue-property-decorator'
-import LandingCta from '~/components/landing/LandingCta.vue'
-import AppLink from '~/components/ui/AppLink.vue'
 
-@Component({
-  components: { LandingCta, AppLink }
-})
+@Component
 export default class TheDarkHeader extends Vue {}
 </script>
 

--- a/components/overview/AccordionLayout.vue
+++ b/components/overview/AccordionLayout.vue
@@ -13,7 +13,6 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component, Prop } from 'vue-property-decorator'
-import AppCta from '~/components/ui/AppCta.vue'
 
 // TODO: It is not possible to extract the interface of the component props
 // so we need this redundant interface to do it. Explore if it is worth
@@ -30,9 +29,7 @@ interface AccordionLayoutProps {
 
 export { AccordionLayoutProps }
 
-@Component({
-  components: { AppCta }
-})
+@Component
 export default class AccordionLayout extends Vue implements AccordionLayoutProps {
   @Prop(String) image!: string
   @Prop(String) description!: string

--- a/components/overview/ContentAccordion.vue
+++ b/components/overview/ContentAccordion.vue
@@ -27,7 +27,7 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component, Prop } from 'vue-property-decorator'
-import AccordionLayout, { AccordionLayoutProps } from '~/components/overview/AccordionLayout.vue'
+import { AccordionLayoutProps } from '~/components/overview/AccordionLayout.vue'
 
 type ContentAccordionTab = {
   title: string,
@@ -36,9 +36,7 @@ type ContentAccordionTab = {
 
 export { ContentAccordionTab }
 
-@Component({
-  components: { AccordionLayout }
-})
+@Component
 export default class ContentAccordion extends Vue {
   @Prop(Array) tabs!: Array<ContentAccordionTab>
 

--- a/components/overview/ContentSection.vue
+++ b/components/overview/ContentSection.vue
@@ -24,11 +24,8 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component, Prop } from 'vue-property-decorator'
-import AppCta from '~/components/ui/AppCta.vue'
 
-@Component({
-  components: { AppCta }
-})
+@Component
 export default class ContentSection extends Vue {
   @Prop(String) title!: any
   @Prop(String) description!: any

--- a/components/overview/TheTableOfContents.vue
+++ b/components/overview/TheTableOfContents.vue
@@ -19,12 +19,9 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component, Prop } from 'vue-property-decorator'
-import AppLink from '~/components/ui/AppLink.vue'
 import { TableOfContentEntry } from '~/constants/overviewContent'
 
-@Component({
-  components: { AppLink }
-})
+@Component
 export default class TheTableOfContents extends Vue {
   @Prop({ type: Array, default: [] }) entries!: Array<TableOfContentEntry>
   @Prop(String) activeSection!: string

--- a/components/ui/AppCard.vue
+++ b/components/ui/AppCard.vue
@@ -31,9 +31,8 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component, Prop } from 'vue-property-decorator'
-import AppCta from '~/components/ui/AppCta.vue'
 
-@Component({ components: { AppCta } })
+@Component
 export default class AppCard extends Vue {
   @Prop(String) image!: any
   @Prop(String) title!: any

--- a/components/ui/AppCta.vue
+++ b/components/ui/AppCta.vue
@@ -23,9 +23,7 @@ import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
 import AppLink from '~/components/ui/AppLink.vue'
 
-@Component({
-  components: { AppLink }
-})
+@Component
 export default class AppCta extends Vue {
   get isExternal () {
     return AppLink.isExternal(this.$attrs.url)

--- a/components/ui/InnerNavigation.vue
+++ b/components/ui/InnerNavigation.vue
@@ -20,11 +20,8 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component, Prop } from 'vue-property-decorator'
-import AppLink from '~/components/ui/AppLink.vue'
 
-@Component({
-  components: { AppLink }
-})
+@Component
 export default class InnerNavigation extends Vue {
   @Prop({ type: Array, default: [] }) sections!: any
 }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -15,17 +15,8 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
-import TheMenu from '~/components/layouts/TheMenu/index.vue'
-import TheBlackLivesMatterBanner from '~/components/layouts/banners/TheBlackLivesMatterBanner.vue'
-import PageFooter from '~/components/layouts/PageFooter/index.vue'
 
-@Component({
-  components: {
-    TheMenu,
-    TheBlackLivesMatterBanner,
-    PageFooter
-  }
-})
+@Component
 export default class DefaultLayout extends Vue {
   isMenuShown: boolean = false
 }

--- a/layouts/metal.vue
+++ b/layouts/metal.vue
@@ -9,15 +9,8 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
-import TheBlackLivesMatterBanner from '~/components/layouts/banners/TheBlackLivesMatterBanner.vue'
-import PageFooter from '~/components/layouts/PageFooter/index.vue'
 
-@Component({
-  components: {
-    TheBlackLivesMatterBanner,
-    PageFooter
-  }
-})
+@Component
 export default class MetalLayout extends Vue {
   isMenuShown: boolean = false
 }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -109,6 +109,8 @@ const config: NuxtConfig = {
     'nuxt-lazy-load'
   ],
 
+  components: true,
+
   styleResources: {
     /*
     ** Do not include styles! Only variables, mixins and functions.

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -127,7 +127,6 @@ const config: NuxtConfig = {
   ** https://typescript.nuxtjs.org/migration.html
   */
   buildModules: [
-    '@nuxt/components',
     ['@nuxt/typescript-build', {
       typeCheck: true,
       ignoreNotFoundWarnings: true

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -127,6 +127,7 @@ const config: NuxtConfig = {
   ** https://typescript.nuxtjs.org/migration.html
   */
   buildModules: [
+    '@nuxt/components',
     ['@nuxt/typescript-build', {
       typeCheck: true,
       ignoreNotFoundWarnings: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -2909,15 +2909,15 @@
       }
     },
     "@nuxt/components": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@nuxt/components/-/components-1.0.6.tgz",
-      "integrity": "sha512-ltXOL/ez3AMjluu3L+YI6hHwzJF+IQ5H2+ijUXPBswsDT/uSHZNe0PxnRrykj11IcpMqudQqBz713fakX7MvNg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@nuxt/components/-/components-1.1.1.tgz",
+      "integrity": "sha512-Cw3QznmGjdT42xcpdID7jb/jvOeTo7gBX4en+nUJs3/O53O8lr9Xcc8XUzyu/MJVrvTy5sjUeuugfwy8AW84OQ==",
       "requires": {
         "chalk": "^4.1.0",
-        "chokidar": "^3.4.0",
+        "chokidar": "^3.4.3",
         "glob": "^7.1.6",
         "globby": "^11.0.1",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.20",
         "semver": "^7.3.2"
       },
       "dependencies": {
@@ -2936,9 +2936,9 @@
           }
         },
         "chokidar": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
-          "integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
+          "version": "3.4.3",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
+          "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
           "requires": {
             "anymatch": "~3.1.1",
             "braces": "~3.0.2",
@@ -2947,7 +2947,7 @@
             "is-binary-path": "~2.1.0",
             "is-glob": "~4.0.1",
             "normalize-path": "~3.0.0",
-            "readdirp": "~3.4.0"
+            "readdirp": "~3.5.0"
           }
         },
         "globby": {
@@ -2963,15 +2963,20 @@
             "slash": "^3.0.0"
           }
         },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        },
         "picomatch": {
           "version": "2.2.2",
           "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
           "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
         },
         "readdirp": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
-          "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+          "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
           "requires": {
             "picomatch": "^2.2.1"
           }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ts-node": "^8.10.2"
   },
   "devDependencies": {
+    "@nuxt/components": "^1.1.1",
     "@nuxt/content": "^1.4.1",
     "@nuxt/types": "^2.13.3",
     "@nuxt/typescript-build": "^0.3.10",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "ts-node": "^8.10.2"
   },
   "devDependencies": {
-    "@nuxt/components": "^1.1.1",
     "@nuxt/content": "^1.4.1",
     "@nuxt/types": "^2.13.3",
     "@nuxt/typescript-build": "^0.3.10",

--- a/pages/advocates/index.vue
+++ b/pages/advocates/index.vue
@@ -66,27 +66,11 @@
 <script lang="ts">
 import { Component } from 'vue-property-decorator'
 import QiskitPage from '~/components/logic/QiskitPage.vue'
-import InnerNavigation from '~/components/ui/InnerNavigation.vue'
-import CommunityHeader from '~/components/ui/CommunityHeader.vue'
-import PageSection from '~/components/ui/PageSection.vue'
-import MapSection from '~/components/advocates/MapSection.vue'
-import AdvocateCard from '~/components/advocates/AdvocateCard.vue'
 import CompactFeature from '~/components/ui/CompactFeature.vue'
-import AppCta from '~/components/ui/AppCta.vue'
 
 type Benefit = Pick<CompactFeature, 'icon'|'title'|'description'>
 
 @Component({
-  components: {
-    InnerNavigation,
-    CommunityHeader,
-    PageSection,
-    MapSection,
-    AdvocateCard,
-    CompactFeature,
-    AppCta
-  },
-
   head () {
     return {
       title: 'Qiskit Advocates'

--- a/pages/events/_slug.vue
+++ b/pages/events/_slug.vue
@@ -37,8 +37,6 @@
 import { Component } from 'vue-property-decorator'
 import { Context } from '@nuxt/types'
 import QiskitPage from '~/components/logic/QiskitPage.vue'
-import EventMenu from '~/components/events/EventMenu.vue'
-import EventFooter from '~/components/events/EventFooter.vue'
 
 function getBackgroundUris (background: string): [string, string] {
   const bgRoute = '/images/events/headers/'
@@ -49,10 +47,6 @@ function getBackgroundUris (background: string): [string, string] {
 
 @Component({
   layout: 'event',
-  components: {
-    EventMenu,
-    EventFooter
-  },
   head () {
     const self = this as any
 

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -90,13 +90,6 @@
 import { mapGetters, mapActions } from 'vuex'
 import { Component } from 'vue-property-decorator'
 import QiskitPage from '~/components/logic/QiskitPage.vue'
-import EventCard from '~/components/events/EventCard.vue'
-import AppCard from '~/components/ui/AppCard.vue'
-import TheEventsHeader from '~/components/events/TheEventsHeader.vue'
-import AppCta from '~/components/ui/AppCta.vue'
-import LandingCta from '~/components/landing/LandingCta.vue'
-import AppMultiSelect from '~/components/ui/AppMultiSelect.vue'
-import AppFieldset from '~/components/ui/AppFieldset.vue'
 
 import {
   CommunityEvent,
@@ -107,16 +100,6 @@ import {
 import { EVENT_REQUEST_LINK } from '~/constants/appLinks'
 
 @Component({
-  components: {
-    EventCard,
-    AppCta,
-    LandingCta,
-    AppCard,
-    TheEventsHeader,
-    AppMultiSelect,
-    AppFieldset
-  },
-
   head () {
     return {
       title: 'Qiskit Events'

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -12,18 +12,8 @@ import axios from 'axios'
 
 import { Component } from 'vue-property-decorator'
 import QiskitPage from '~/components/logic/QiskitPage.vue'
-import TheHeroMoment from '~/components/landing/TheHeroMoment/index.vue'
-import TheFeatures from '~/components/landing/TheFeatures/index.vue'
-import TheQuickStart from '~/components/landing/TheQuickStart/index.vue'
-import TheLearnSection from '~/components/landing/TheLearnSection/index.vue'
 
 @Component({
-  components: {
-    TheHeroMoment,
-    TheFeatures,
-    TheQuickStart,
-    TheLearnSection
-  },
   head () {
     return { title: 'Qiskit' }
   },

--- a/pages/learn/index.vue
+++ b/pages/learn/index.vue
@@ -39,11 +39,6 @@
 import { mapGetters } from 'vuex'
 import { Component } from 'vue-property-decorator'
 import QiskitPage from '~/components/logic/QiskitPage.vue'
-import TheLearnHeader from '~/components/learn/TheLearnHeader.vue'
-import TheLearningResourceList from '~/components/learn/TheLearningResourceList.vue'
-import AppCard from '~/components/ui/AppCard.vue'
-import TheCarefulExplanationForBeginners from '~/components/learn/TheCarefulExplanationForBeginners.vue'
-import TheCarefulExplanationForExperts from '~/components/learn/TheCarefulExplanationForExperts.vue'
 import {
   TimeScale,
   LearnLevel,
@@ -54,14 +49,6 @@ import {
 } from '~/store/modules/learning-resources.ts'
 
 @Component({
-  components: {
-    TheLearnHeader,
-    TheLearningResourceList,
-    TheCarefulExplanationForExperts,
-    TheCarefulExplanationForBeginners,
-    AppCard
-  },
-
   head () {
     return {
       title: 'Qiskit Learn'

--- a/pages/metal.vue
+++ b/pages/metal.vue
@@ -12,15 +12,8 @@
 <script lang="ts">
 import { Component } from 'vue-property-decorator'
 import QiskitPage from '~/components/logic/QiskitPage.vue'
-import TheDarkHeader from '~/components/metal/TheDarkHeader.vue'
-import IntroSection from '~/components/metal/IntroSection.vue'
-import FeaturesSection from '~/components/metal/FeaturesSection.vue'
-import BuildingSection from '~/components/metal/BuildingSection.vue'
-import CapabilitiesSection from '~/components/metal/CapabilitiesSection.vue'
-import EarlyAccessSection from '~/components/metal/EarlyAccessSection.vue'
 
 @Component({
-  components: { TheDarkHeader, IntroSection, CapabilitiesSection, FeaturesSection, EarlyAccessSection, BuildingSection },
   layout: 'metal',
   head () {
     return {

--- a/pages/overview.vue
+++ b/pages/overview.vue
@@ -58,13 +58,7 @@
 <script lang="ts">
 import { Component } from 'vue-property-decorator'
 import QiskitPage from '~/components/logic/QiskitPage.vue'
-import ThePageHeader from '~/components/ui/ThePageHeader.vue'
-import TypewriterEffect from '~/components/ui/TypewriterEffect.vue'
-import TheTableOfContents from '~/components/overview/TheTableOfContents.vue'
-import TheQuickStart from '~/components/landing/TheQuickStart/index.vue'
-import ContentSection from '~/components/overview/ContentSection.vue'
-import ContentAccordion, { ContentAccordionTab } from '~/components/overview/ContentAccordion.vue'
-import AppCta from '~/components/ui/AppCta.vue'
+import { ContentAccordionTab } from '~/components/overview/ContentAccordion.vue'
 import {
   TABLE_OF_CONTENTS,
   CONTENT_SECTIONS,
@@ -74,15 +68,6 @@ import ScrollSectionsMixin from '~/mixins/scrollBetweenSections'
 
 @Component({
   mixins: [ScrollSectionsMixin],
-  components: {
-    ThePageHeader,
-    TypewriterEffect,
-    TheTableOfContents,
-    ContentSection,
-    ContentAccordion,
-    TheQuickStart,
-    AppCta
-  },
   head () {
     return {
       title: 'Qiskit Overview'


### PR DESCRIPTION
Fix #820 

This module is used to avoid `import` declaration in the script section and component registration in the `@Component { components: [ ... ] }`

I will sum up what I consider the most interesting features of the `@nuxt/components` package

- **[Dynamic Imports/Lazy Load](https://github.com/nuxt/components#dynamic-imports)**: Lazy load any component. I don't know the tech details about this.
- **[Directory based features](https://github.com/nuxt/components#directories)**: Can be configurated in the nuxt.config. 
  - We can choose a list of files/directories to include ([path](https://github.com/nuxt/components#path), [file extensions](https://github.com/nuxt/components#extensions), [pattern](https://github.com/nuxt/components#pattern)). Default is `components` folder.
  - [Ignore](https://github.com/nuxt/components#ignore) some files in the specified path using a pattern.
  - Establish a [prefix](https://github.com/nuxt/components#prefix) to the components in a specific path. For example: `components/app/button.vue` could be prefixed with `app` to be instanced with `<AppButton>`.
- A new [hook](https://github.com/nuxt/components#library-authors) for creating/importing component libraries.
