### PR TITLE
Add AIRTABLE_API_KEY env variable where needed

### DIFF
--- a/.github/workflows/deploy.workflow.yml
+++ b/.github/workflows/deploy.workflow.yml
@@ -32,12 +32,15 @@ jobs:
             ${{ runner.os }}-node-
 
       - run: npm ci
-      - run: npm run generate
+
+      - name: Generate
+        run: npm run generate
+        env:
+          AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
 
       - name: Deploy
         run: cd deploy && ./deploy_cos.sh
         shell: bash
         env:
-          AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
           encrypted_rclone_iv: ${{ secrets.ENCRYPTED_RCLONE_IV }}
           encrypted_rclone_key: ${{ secrets.ENCRYPTED_RCLONE_KEY }}


### PR DESCRIPTION
Fix #872 

Environment variables in GitHub actions seem to be set per each individual run, not globally. The environment variable needed for fetching the correct events should be set during generation.