### PR TITLE
Create Storybook showcase story

### DIFF
--- a/components/ui/AppCard.stories.ts
+++ b/components/ui/AppCard.stories.ts
@@ -15,7 +15,10 @@ export default {
 const Template: Story = (args, { argTypes }) => ({
   components: { AppCard },
   props: Object.keys(argTypes),
-  template: '<AppCard :cta-label="ctaLabel" :image="image" :tags="tags" :title="title" :to="to">{{ vSlot }}</AppCard>'
+  template: `
+    <AppCard :cta-label="ctaLabel" :image="image" :tags="tags" :title="title" :to="to">
+      {{slotDefault}}
+    </AppCard>`
 })
 
 export const Default = Template.bind({})
@@ -25,5 +28,5 @@ Default.args = {
   tags: ['documentation', 'news'],
   title: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
   to: 'https://example.com',
-  vSlot: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
+  slotDefault: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
 }

--- a/components/ui/AppCard.stories.ts
+++ b/components/ui/AppCard.stories.ts
@@ -24,7 +24,7 @@ const Template: Story = (args, { argTypes }) => ({
 export const Default = Template.bind({})
 Default.args = {
   ctaLabel: 'Learn more',
-  image: 'https://via.placeholder.com/300',
+  image: '/images/events/no-events.svg',
   tags: ['documentation', 'news'],
   title: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
   to: 'https://example.com',

--- a/components/ui/AppCard.vue
+++ b/components/ui/AppCard.vue
@@ -19,6 +19,7 @@
         </div>
       </header>
       <div class="app-card__description">
+        <!-- @slot Card description. -->
         <slot />
       </div>
       <AppCta v-if="to" :url="to" class="app-card__link">

--- a/components/ui/AppCard.vue
+++ b/components/ui/AppCard.vue
@@ -36,10 +36,10 @@ import AppCta from '~/components/ui/AppCta.vue'
 
 /**
  * Card component.
- * 
+ *
  * A card is a flexible content container that includes an image, a title and a
  * description.
- * 
+ *
  * Optionally, a card can also include a list of tags and a CTA button.
  */
 @Component({ components: { AppCta } })


### PR DESCRIPTION
**Note:** This is only one part of https://github.com/Qiskit/qiskit.org/issues/884#issuecomment-733034345

---

Make the necessary adjustments to the **AppCard** Storybook story to showcase the various Storybook functionalities.

Only the card's image is currently not showing due to _lazy-background_ not loading the image. I tried to dig deeper into this but couldn't make it work. But I personally believe that this should not be an impediment for the scope of this PR.

---

Closes #1155