### PR TITLE
Provide the absolute URL to for browser navigation.

### DIFF
--- a/components/landing/TheHeroMoment/index.vue
+++ b/components/landing/TheHeroMoment/index.vue
@@ -31,7 +31,7 @@ import { Prop, Component } from 'vue-property-decorator'
 export default class TheHeroMoment extends Vue {
   @Prop({ type: String, required: true }) version!: string
   getStartedLink = {
-    url: 'documentation/install.html',
+    url: 'https://qiskit.org/documentation/install.html',
     label: 'Get started',
     segment: { action: 'Get started' }
   }


### PR DESCRIPTION
Fix #1226 

The component uses Vue router navigation by default. However, some
URLs are not part of the Nuxt project and cannot be navigated using
the default Nuxt mechanism. One of them is `/documentation`

Passing the complete URL, we are forcing the component to use
native navigation when jumping to this URL.