### PR TITLE
fix: remove undesired overflow in mobile

### DIFF
--- a/components/learn/TheLearningResourceList.vue
+++ b/components/learn/TheLearningResourceList.vue
@@ -171,6 +171,7 @@ export default class TheLearningResourceList extends Vue {
   }
 
   &__results {
+    display: inline-block;
     flex: auto;
 
     @include mq($until: medium) {


### PR DESCRIPTION
This PR changes the display property of a wrapper element to avoid an undesired overflow that resulted in a black background being shown on mobile devices.

Here is a JSFiddle showing the basic concept of this change: https://jsfiddle.net/fsby7krt/

---

Closes #1194 