### PR TITLE
chore: type Promise return to support TS 4.1

### DIFF
--- a/plugins/segment-analytics.ts
+++ b/plugins/segment-analytics.ts
@@ -58,7 +58,7 @@ function configureAnalytics () {
 }
 
 function installAnalyticsOnce () {
-  window._analyticsReady = window._analyticsReady || new Promise((resolve) => {
+  window._analyticsReady = window._analyticsReady || new Promise<Event>((resolve) => {
     const script = document.createElement('script')
     script.async = true
     script.src = process.env.analyticsScriptUrl || ''


### PR DESCRIPTION
This PR adds a missing type to a Promise in order to support [`@nuxt/typescript-build`'s upgrade to version 2.0.4](https://github.com/Qiskit/qiskit.org/pull/1318), which uses TypeScript 4.1.

Related to #1318 