### PR TITLE
feat: fetch Seminar Series events from Airtable

### DIFF
--- a/components/events/seminar-series/UpcomingSeminarSeriesSection.vue
+++ b/components/events/seminar-series/UpcomingSeminarSeriesSection.vue
@@ -10,73 +10,44 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
+import events from '~/content/events/upcoming-seminar-series-events.json'
 
 @Component
 export default class UpcomingSeminarSeriesSection extends Vue {
+  tableDataPerRow = events.map(event => ([
+    {
+      component: 'span',
+      styles: 'min-width: 8rem; display: inline-block;',
+      data: event.speaker
+    },
+    {
+      component: 'span',
+      styles: 'min-width: 9rem; display: inline-block;',
+      data: event.institution
+    },
+    {
+      component: 'span',
+      styles: 'min-width: 19rem; display: inline-block;',
+      data: event.title
+    },
+    {
+      component: 'span',
+      styles: 'min-width: 8rem; display: inline-block;',
+      data: event.date
+    },
+    {
+      component: 'AppCta',
+      styles: 'min-width: 6rem;',
+      data: {
+        url: event.to,
+        label: 'Join the event'
+      }
+    }
+  ]));
+
   tableData = {
     columns: ['Speaker', 'Institution', 'Seminar title', 'Date of talk', 'Link to talk'],
-    dataPerRow: [
-      [
-        {
-          component: 'span',
-          styles: 'min-width: 8rem; display: inline-block;',
-          data: 'Javad Shabani'
-        },
-        {
-          component: 'span',
-          styles: 'min-width: 9rem; display: inline-block;',
-          data: 'University of Waterloo'
-        },
-        {
-          component: 'span',
-          styles: 'min-width: 21rem; display: inline-block;',
-          data: 'Progress in Realizing Novel Qubits with Josephson Field Effect Transistors'
-        },
-        {
-          component: 'span',
-          styles: 'min-width: 5rem; display: inline-block;',
-          data: '2021/01/25'
-        },
-        {
-          component: 'AppCta',
-          styles: 'min-width: 6rem;',
-          data: {
-            url: 'https://qiskit.org',
-            label: 'Join the event'
-          }
-        }
-      ],
-      [
-        {
-          component: 'span',
-          styles: 'min-width: 8rem; display: inline-block;',
-          data: 'Javad Shabani'
-        },
-        {
-          component: 'span',
-          styles: 'min-width: 9rem; display: inline-block;',
-          data: 'MIT'
-        },
-        {
-          component: 'span',
-          styles: 'min-width: 21rem; display: inline-block;',
-          data: 'Progress in Realizing Novel Qubits with Josephson Field Effect Transistors'
-        },
-        {
-          component: 'span',
-          styles: 'min-width: 5rem; display: inline-block;',
-          data: '2021/01/25'
-        },
-        {
-          component: 'AppCta',
-          styles: 'min-width: 6rem;',
-          data: {
-            url: 'https://qiskit.org',
-            label: 'Join the event'
-          }
-        }
-      ]
-    ]
+    dataPerRow: this.tableDataPerRow
   }
 }
 </script>

--- a/content/events/next-seminar-series-event.json
+++ b/content/events/next-seminar-series-event.json
@@ -1,0 +1,9 @@
+{
+  "date": "January 22, 2021",
+  "image": "https://dl.airtable.com/.attachmentThumbnails/49a702d8b04f71c43f0d4e08ac5cb1db/634f7076",
+  "institution": "Harvard University",
+  "location": "YouTube",
+  "speaker": "Alán Aspuru-Guzik",
+  "title": "What to do with a near-term quantum computer?",
+  "to": "https://youtu.be/I6_tHLAeBsI"
+}

--- a/content/events/past-community-events.json
+++ b/content/events/past-community-events.json
@@ -1,46 +1,24 @@
 [
   {
-    "title": "Qiskit Community Summer Jam - Midwest ",
+    "title": "Boson Sampling and Quantum Simulations in Circuit QED",
     "types": [
-      "Hackathon"
+      "Talks"
     ],
-    "image": "https://dl.airtable.com/.attachmentThumbnails/5fb60efc02b56ae0f4b336ef4f656682/382f1148",
-    "location": "HackerEarth.com",
-    "region": "Americas",
-    "date": "June 24 - July 1, 2020",
-    "to": "https://www.hackerearth.com/challenges/hackathon/qiskit-community-summer-jam-mid-west/"
+    "image": "https://dl.airtable.com/.attachmentThumbnails/1e1b501e69679ad462f7634891255817/f394afe9",
+    "location": "YouTube",
+    "region": "Online",
+    "date": "January 15, 2021",
+    "to": "https://youtu.be/miK5y8BYlwQ"
   },
   {
-    "title": "Qiskit Community Summer Jam - New England",
+    "title": "Quantum Engineering of Superconducting Qubits | Seminar Series with Will Oliver",
     "types": [
-      "Hackathon"
+      "Talks"
     ],
-    "image": "https://dl.airtable.com/.attachmentThumbnails/5fb60efc02b56ae0f4b336ef4f656682/382f1148",
-    "location": "HackerEarth.com",
-    "region": "Americas",
-    "date": "June 24 - July 1, 2020",
-    "to": "https://qiskit-community-summer-jam-new-england.hackerearth.com/"
-  },
-  {
-    "title": "Qiskit Community Summer Jam - California",
-    "types": [
-      "Hackathon"
-    ],
-    "image": "https://dl.airtable.com/.attachmentThumbnails/5fb60efc02b56ae0f4b336ef4f656682/382f1148",
-    "location": "HackerEarth.com",
-    "region": "Americas",
-    "date": "June 24 - July 1, 2020",
-    "to": "https://www.hackerearth.com/challenges/hackathon/qiskit-community-summer-jam-california/"
-  },
-  {
-    "title": "Qiskit Community Summer Jam - North Carolina",
-    "types": [
-      "Hackathon"
-    ],
-    "image": "https://dl.airtable.com/.attachmentThumbnails/5fb60efc02b56ae0f4b336ef4f656682/382f1148",
-    "location": "HackerEarth.com",
-    "region": "Americas",
-    "date": "June 24 - July 1, 2020",
-    "to": "https://www.hackerearth.com/challenges/hackathon/qiskit-community-summer-jam-north-carolina/"
+    "image": "https://dl.airtable.com/.attachmentThumbnails/f0daa554e731da5f87d13511546f3c77/6caa60ee",
+    "location": "YouTube",
+    "region": "Online",
+    "date": "December 18, 2020",
+    "to": "https://youtu.be/aGAb-GbrvMU"
   }
 ]

--- a/content/events/past-seminar-series-events.json
+++ b/content/events/past-seminar-series-events.json
@@ -1,0 +1,11 @@
+[
+  {
+    "date": "January 15, 2021",
+    "image": "https://dl.airtable.com/.attachmentThumbnails/1e1b501e69679ad462f7634891255817/f394afe9",
+    "institution": "Yale University",
+    "location": "YouTube",
+    "speaker": "Steve Girvin\n\t",
+    "title": "Boson Sampling and Quantum Simulations in Circuit QED",
+    "to": "https://youtu.be/miK5y8BYlwQ"
+  }
+]

--- a/content/events/upcoming-community-events.json
+++ b/content/events/upcoming-community-events.json
@@ -1,13 +1,64 @@
 [
   {
-    "title": "Qiskit Global Summer School",
+    "title": "What to do with a near-term quantum computer?",
     "types": [
-      "Online"
+      "Talks"
     ],
-    "image": "https://dl.airtable.com/.attachmentThumbnails/7de6fa69d8061d8f9e49e4505691338a/c067c96f",
-    "location": "Online",
+    "image": "https://dl.airtable.com/.attachmentThumbnails/49a702d8b04f71c43f0d4e08ac5cb1db/634f7076",
+    "location": "YouTube",
     "region": "Online",
-    "date": "July 20-30, 2020",
-    "to": "https://qiskit.org/events/summer-school/"
+    "date": "January 22, 2021",
+    "to": "https://youtu.be/I6_tHLAeBsI"
+  },
+  {
+    "title": "Compilation for Quantum Computing: Gap Analysis and Optimal Solution",
+    "types": [
+      "Talks"
+    ],
+    "image": "https://dl.airtable.com/.attachmentThumbnails/b81d53d95b7a02f156dedfa6b00e5c7a/3c652699",
+    "location": "YouTube",
+    "region": "Online",
+    "date": "January 29, 2021",
+    "to": "https://youtu.be/Z9R9a3hku9Y"
+  },
+  {
+    "title": "Qiskit Hackathon @ MIT",
+    "types": [
+      "Hackathon"
+    ],
+    "image": "https://dl.airtable.com/.attachmentThumbnails/22ce9a8acb5781f8991d908fb7c247d2/b666a5e3",
+    "location": "MIT",
+    "region": "Americas",
+    "date": "January 30-31, 2021"
+  },
+  {
+    "title": "Qiskit Hackathon @ McMaster University",
+    "types": [
+      "Hackathon"
+    ],
+    "image": "https://dl.airtable.com/.attachmentThumbnails/da755eac58a003a1ce054470b19bccf8/209a594e",
+    "location": "McMaster University",
+    "region": "Americas",
+    "date": "February 5-7, 2021"
+  },
+  {
+    "title": "Qiskit Hackathon @ NYU",
+    "types": [
+      "Hackathon"
+    ],
+    "image": "https://dl.airtable.com/.attachmentThumbnails/61994381e16351e2a3c5f0e293390b59/9dae0f09",
+    "location": "NYU",
+    "region": "Americas",
+    "date": "February 12-13, 2021"
+  },
+  {
+    "title": "Qiskit Hackathon Korea",
+    "types": [
+      "Hackathon"
+    ],
+    "image": "/images/events/no-picture.jpg",
+    "location": "Korea",
+    "region": "Asia Pacific",
+    "date": "February 18-19, 2021"
   }
 ]

--- a/content/events/upcoming-seminar-series-events.json
+++ b/content/events/upcoming-seminar-series-events.json
@@ -1,0 +1,20 @@
+[
+  {
+    "date": "January 22, 2021",
+    "image": "https://dl.airtable.com/.attachmentThumbnails/49a702d8b04f71c43f0d4e08ac5cb1db/634f7076",
+    "institution": "Harvard University",
+    "location": "YouTube",
+    "speaker": "Alán Aspuru-Guzik",
+    "title": "What to do with a near-term quantum computer?",
+    "to": "https://youtu.be/I6_tHLAeBsI"
+  },
+  {
+    "date": "January 29, 2021",
+    "image": "https://dl.airtable.com/.attachmentThumbnails/b81d53d95b7a02f156dedfa6b00e5c7a/3c652699",
+    "institution": "UCLA",
+    "location": "YouTube",
+    "speaker": "Jason Cong",
+    "title": "Compilation for Quantum Computing: Gap Analysis and Optimal Solution",
+    "to": "https://youtu.be/Z9R9a3hku9Y"
+  }
+]

--- a/hooks/event-conversion-utils.ts
+++ b/hooks/event-conversion-utils.ts
@@ -44,14 +44,14 @@ function getEventsQuery (apiKey: string, days: number, view: string, filters: st
   const { startDate, published } = RECORD_FIELDS
   const base = new Airtable({ apiKey }).base('appkaaRF2QdwfusP1')
 
-  const standardFilters = [
+  const formulaFilters = [
     `DATETIME_DIFF({${startDate}}, TODAY(), 'days') ${days > 0 ? '<=' : '>='} ${days}`,
     `DATETIME_DIFF({${startDate}}, TODAY(), 'days') ${days > 0 ? '>=' : '<'} 0`,
     `{${published}}`,
     ...filters
   ]
 
-  const filterByFormula = `AND(${standardFilters.join(',')})`
+  const filterByFormula = `AND(${formulaFilters.join(',')})`
 
   return base('Events Main View').select({
     filterByFormula,

--- a/hooks/event-conversion-utils.ts
+++ b/hooks/event-conversion-utils.ts
@@ -35,19 +35,18 @@ const RECORD_FIELDS = Object.freeze({
   region: 'Region',
   image: 'Picture?',
   institution: 'Institution',
-  published: 'SUZIE - for website?',
+  showOnEventsPage: 'SUZIE - for website?',
   showOnSeminarSeriesPage: 'PAUL - Seminar Site',
   speaker: 'Speaker'
 } as const)
 
 function getEventsQuery (apiKey: string, days: number, view: string, filters: string[] = []): Airtable.Query<{}> {
-  const { startDate, published } = RECORD_FIELDS
+  const { startDate } = RECORD_FIELDS
   const base = new Airtable({ apiKey }).base('appkaaRF2QdwfusP1')
 
   const formulaFilters = [
     `DATETIME_DIFF({${startDate}}, TODAY(), 'days') ${days > 0 ? '<=' : '>='} ${days}`,
     `DATETIME_DIFF({${startDate}}, TODAY(), 'days') ${days > 0 ? '>=' : '<'} 0`,
-    `{${published}}`,
     ...filters
   ]
 
@@ -61,9 +60,10 @@ function getEventsQuery (apiKey: string, days: number, view: string, filters: st
 }
 
 async function fetchCommunityEvents (apiKey: string, { days }: { days: any }): Promise<CommunityEvent[]> {
+  const { showOnEventsPage } = RECORD_FIELDS
   const communityEvents: CommunityEvent[] = []
 
-  await getEventsQuery(apiKey, days, 'Main List').eachPage((records, nextPage) => {
+  await getEventsQuery(apiKey, days, 'Main List', [`{${showOnEventsPage}}`]).eachPage((records, nextPage) => {
     for (const record of records) {
       const communityEvent = convertToCommunityEvent(record)
       communityEvents.push(communityEvent)

--- a/hooks/update-events.ts
+++ b/hooks/update-events.ts
@@ -13,18 +13,11 @@ export default async function (apiKey: any, outputFolder: string) {
 
   const writeFile = util.promisify(fs.writeFile)
 
-  const writeUpcomingEvents = writeFile(`${outputFolder}/upcoming-community-events.json`, JSON.stringify(upcomingCommunityEvents, null, 2))
-  const writePastEvents = writeFile(`${outputFolder}/past-community-events.json`, JSON.stringify(pastCommunityEvents, null, 2))
-
-  const writeUpcomingSeminarSeriesEvents = writeFile(`${outputFolder}/upcoming-seminar-series-events.json`, JSON.stringify(upcomingSeminarSeriesEvents, null, 2))
-  const writePastSeminarSeriesEvents = writeFile(`${outputFolder}/past-seminar-series-events.json`, JSON.stringify(pastSeminarSeriesEvents, null, 2))
-  const writeNextSeminarSeriesEvents = writeFile(`${outputFolder}/next-seminar-series-event.json`, JSON.stringify(nextSeminarSeriesEvent, null, 2))
-
   await Promise.all([
-    writeUpcomingEvents,
-    writePastEvents,
-    writeUpcomingSeminarSeriesEvents,
-    writePastSeminarSeriesEvents,
-    writeNextSeminarSeriesEvents
-  ])
+    { events: upcomingCommunityEvents, outputFilename: 'upcoming-community-events.json' },
+    { events: pastCommunityEvents, outputFilename: 'past-community-events.json' },
+    { events: upcomingSeminarSeriesEvents, outputFilename: 'upcoming-seminar-series-events.json' },
+    { events: pastSeminarSeriesEvents, outputFilename: 'past-seminar-series-events.json' },
+    { events: nextSeminarSeriesEvent, outputFilename: 'next-seminar-series-event.json' }
+  ].map(curr => writeFile(`${outputFolder}/${curr.outputFilename}`, JSON.stringify(curr.events, null, 2))))
 }

--- a/hooks/update-events.ts
+++ b/hooks/update-events.ts
@@ -8,7 +8,7 @@ export default async function (apiKey: any, outputFolder: string) {
   const pastCommunityEvents = await fetchCommunityEvents(apiKey, { days: -31 })
 
   const upcomingSeminarSeriesEvents = await fetchSeminarSeriesEvents(apiKey, { days: 31 })
-  const pastSeminarSeriesEvents = await fetchSeminarSeriesEvents(apiKey, { days: -31 })
+  const pastSeminarSeriesEvents = await fetchSeminarSeriesEvents(apiKey, { days: -62 })
   const nextSeminarSeriesEvent = upcomingSeminarSeriesEvents[0]
 
   const writeFile = util.promisify(fs.writeFile)

--- a/hooks/update-events.ts
+++ b/hooks/update-events.ts
@@ -1,15 +1,30 @@
 import fs from 'fs'
 import util from 'util'
 
-import { fetchCommunityEvents } from './event-conversion-utils'
+import { fetchCommunityEvents, fetchSeminarSeriesEvents } from './event-conversion-utils'
 
 export default async function (apiKey: any, outputFolder: string) {
   const upcomingCommunityEvents = await fetchCommunityEvents(apiKey, { days: 31 })
   const pastCommunityEvents = await fetchCommunityEvents(apiKey, { days: -31 })
 
+  const upcomingSeminarSeriesEvents = await fetchSeminarSeriesEvents(apiKey, { days: 31 })
+  const pastSeminarSeriesEvents = await fetchSeminarSeriesEvents(apiKey, { days: -31 })
+  const nextSeminarSeriesEvent = upcomingSeminarSeriesEvents[0]
+
   const writeFile = util.promisify(fs.writeFile)
+
   const writeUpcomingEvents = writeFile(`${outputFolder}/upcoming-community-events.json`, JSON.stringify(upcomingCommunityEvents, null, 2))
   const writePastEvents = writeFile(`${outputFolder}/past-community-events.json`, JSON.stringify(pastCommunityEvents, null, 2))
 
-  await Promise.all([writeUpcomingEvents, writePastEvents])
+  const writeUpcomingSeminarSeriesEvents = writeFile(`${outputFolder}/upcoming-seminar-series-events.json`, JSON.stringify(upcomingSeminarSeriesEvents, null, 2))
+  const writePastSeminarSeriesEvents = writeFile(`${outputFolder}/past-seminar-series-events.json`, JSON.stringify(pastSeminarSeriesEvents, null, 2))
+  const writeNextSeminarSeriesEvents = writeFile(`${outputFolder}/next-seminar-series-event.json`, JSON.stringify(nextSeminarSeriesEvent, null, 2))
+
+  await Promise.all([
+    writeUpcomingEvents,
+    writePastEvents,
+    writeUpcomingSeminarSeriesEvents,
+    writePastSeminarSeriesEvents,
+    writeNextSeminarSeriesEvents
+  ])
 }

--- a/hooks/update-events.ts
+++ b/hooks/update-events.ts
@@ -13,11 +13,13 @@ export default async function (apiKey: any, outputFolder: string) {
 
   const writeFile = util.promisify(fs.writeFile)
 
-  await Promise.all([
+  const eventsAndOutputFilename = [
     { events: upcomingCommunityEvents, outputFilename: 'upcoming-community-events.json' },
     { events: pastCommunityEvents, outputFilename: 'past-community-events.json' },
     { events: upcomingSeminarSeriesEvents, outputFilename: 'upcoming-seminar-series-events.json' },
     { events: pastSeminarSeriesEvents, outputFilename: 'past-seminar-series-events.json' },
     { events: nextSeminarSeriesEvent, outputFilename: 'next-seminar-series-event.json' }
-  ].map(curr => writeFile(`${outputFolder}/${curr.outputFilename}`, JSON.stringify(curr.events, null, 2))))
+  ]
+
+  await Promise.all(eventsAndOutputFilename.map(curr => writeFile(`${outputFolder}/${curr.outputFilename}`, JSON.stringify(curr.events, null, 2))))
 }


### PR DESCRIPTION
With this PR, the Seminar Series events will be fetched from Airtable.

3 files will be generated:

- `next-seminar-series-event.json`
- `upcoming-seminar-series-events.json`
- `past-seminar-series-events.json`

This PR only includes displaying the data of the upcoming events in the page's table, since the past events (#1328) and next event (#1327) will be handled later, once those components are integrated into the feature branch.

---

Closes #1312