### PR TITLE
fix: reject Promise on error to solve TS issue

### DIFF
--- a/plugins/segment-analytics.ts
+++ b/plugins/segment-analytics.ts
@@ -58,7 +58,7 @@ function configureAnalytics () {
 }
 
 function installAnalyticsOnce () {
-  window._analyticsReady = window._analyticsReady || new Promise<Event>((resolve) => {
+  window._analyticsReady = window._analyticsReady || new Promise<Event>((resolve, reject) => {
     const script = document.createElement('script')
     script.async = true
     script.src = process.env.analyticsScriptUrl || ''
@@ -66,7 +66,7 @@ function installAnalyticsOnce () {
     script.onload = resolve
     script.onerror = (err) => {
       console.warn('Error loading Bluemix Analytics script:', err)
-      resolve()
+      reject(err)
     }
   })
 }


### PR DESCRIPTION
This PR rejects a Promise on error properly, in order to support [@nuxt/typescript-build's upgrade to version 2.0.4](https://github.com/Qiskit/qiskit.org/pull/1318), which uses TypeScript 4.1.

---

Related to #1318 