### PR TITLE
feat: display past Seminar Series events table

### DIFF
--- a/components/events/event/HelpfulResourcesSection.vue
+++ b/components/events/event/HelpfulResourcesSection.vue
@@ -1,0 +1,46 @@
+<template>
+  <section class="helpful-resources-section">
+    <h2 class="copy__title" v-text="title" />
+    <div class="helpful-resources-section__resources">
+      <AppDescriptionCard
+        v-for="resource in resources"
+        :key="resource.title"
+        v-bind="resource"
+      />
+    </div>
+  </section>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { Component, Prop } from 'vue-property-decorator'
+import { DescriptionCard } from '~/components/ui/AppDescriptionCard.vue'
+
+@Component
+export default class HelpfulResourcesSection extends Vue {
+  @Prop(Array) resources!: DescriptionCard[]
+
+  title = 'Helpful Resources';
+}
+</script>
+
+<style lang="scss" scoped>
+@import "~/assets/scss/blocks/copy.scss";
+
+.helpful-resources-section {
+  &__resources {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    column-gap: 2rem;
+    row-gap: 2rem;
+
+    @include mq($from: medium, $until: large) {
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    @include mq($until: medium) {
+      grid-template-columns: repeat(1, 1fr);
+    }
+  }
+}
+</style>

--- a/components/events/seminar-series/PastSeminarSeriesSection.vue
+++ b/components/events/seminar-series/PastSeminarSeriesSection.vue
@@ -1,0 +1,74 @@
+<template>
+  <section class="past-seminar-series-section">
+    <h2 class="copy__title">
+      Past Seminars
+    </h2>
+    <SeminarSeriesDataTable :columns="tableData.columns" :data-per-row="tableData.dataPerRow" />
+    <AppCta
+      class="past-seminar-series-section__cta"
+      kind="ghost"
+      v-bind="showMoreCta"
+    />
+  </section>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { Component } from 'vue-property-decorator'
+import { SEMINAR_SERIES_ALL_EPISODES_CTA } from '~/constants/appLinks.ts'
+import events from '~/content/events/past-seminar-series-events.json'
+
+@Component
+export default class PastSeminarSeriesSection extends Vue {
+  tableDataPerRow = events.map(event => ([
+    {
+      component: 'span',
+      styles: 'min-width: 8rem; display: inline-block;',
+      data: event.speaker
+    },
+    {
+      component: 'span',
+      styles: 'min-width: 9rem; display: inline-block;',
+      data: event.institution
+    },
+    {
+      component: 'span',
+      styles: 'min-width: 19rem; display: inline-block;',
+      data: event.title
+    },
+    {
+      component: 'span',
+      styles: 'min-width: 8rem; display: inline-block;',
+      data: event.date
+    },
+    {
+      component: 'AppCta',
+      styles: 'min-width: 6rem;',
+      data: {
+        url: event.to,
+        label: 'Join the event'
+      }
+    }
+  ]));
+
+  tableData = {
+    columns: ['Speaker', 'Institution', 'Seminar title', 'Date of talk', 'Link to talk'],
+    dataPerRow: this.tableDataPerRow
+  }
+
+  showMoreCta = {
+    ...SEMINAR_SERIES_ALL_EPISODES_CTA,
+    label: 'Show more'
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@import "~/assets/scss/blocks/copy.scss";
+
+.past-seminar-series-section {
+  &__cta {
+    margin-top: $spacing-03;
+  }
+}
+</style>

--- a/components/events/seminar-series/PastSeminarSeriesSection.vue
+++ b/components/events/seminar-series/PastSeminarSeriesSection.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="past-seminar-series-section">
     <h2 class="copy__title">
-      Past Seminars
+      Past Quantum Seminars
     </h2>
     <SeminarSeriesDataTable :columns="tableData.columns" :data-per-row="tableData.dataPerRow" />
     <AppCta
@@ -23,7 +23,7 @@ export default class PastSeminarSeriesSection extends Vue {
   tableDataPerRow = events.map(event => ([
     {
       component: 'span',
-      styles: 'min-width: 8rem; display: inline-block;',
+      styles: 'min-width: 9rem; display: inline-block;',
       data: event.speaker
     },
     {
@@ -43,22 +43,22 @@ export default class PastSeminarSeriesSection extends Vue {
     },
     {
       component: 'AppCta',
-      styles: 'min-width: 6rem;',
+      styles: 'min-width: 5rem;',
       data: {
         url: event.to,
-        label: 'Join the event'
+        label: 'Join event'
       }
     }
   ]));
 
   tableData = {
-    columns: ['Speaker', 'Institution', 'Seminar title', 'Date of talk', 'Link to talk'],
+    columns: ['Speaker', 'Institution', 'Name of talk', 'Date of talk', 'Link to talk'],
     dataPerRow: this.tableDataPerRow
   }
 
   showMoreCta = {
     ...SEMINAR_SERIES_ALL_EPISODES_CTA,
-    label: 'Show more'
+    label: 'Explore Full Seminar Archive'
   }
 }
 </script>

--- a/components/events/seminar-series/UpcomingSeminarSeriesSection.vue
+++ b/components/events/seminar-series/UpcomingSeminarSeriesSection.vue
@@ -10,73 +10,44 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
+import events from '~/content/events/upcoming-seminar-series-events.json'
 
 @Component
 export default class UpcomingSeminarSeriesSection extends Vue {
+  tableDataPerRow = events.map(event => ([
+    {
+      component: 'span',
+      styles: 'min-width: 8rem; display: inline-block;',
+      data: event.speaker
+    },
+    {
+      component: 'span',
+      styles: 'min-width: 9rem; display: inline-block;',
+      data: event.institution
+    },
+    {
+      component: 'span',
+      styles: 'min-width: 19rem; display: inline-block;',
+      data: event.title
+    },
+    {
+      component: 'span',
+      styles: 'min-width: 8rem; display: inline-block;',
+      data: event.date
+    },
+    {
+      component: 'AppCta',
+      styles: 'min-width: 6rem;',
+      data: {
+        url: event.to,
+        label: 'Join the event'
+      }
+    }
+  ]));
+
   tableData = {
     columns: ['Speaker', 'Institution', 'Seminar title', 'Date of talk', 'Link to talk'],
-    dataPerRow: [
-      [
-        {
-          component: 'span',
-          styles: 'min-width: 8rem; display: inline-block;',
-          data: 'Javad Shabani'
-        },
-        {
-          component: 'span',
-          styles: 'min-width: 9rem; display: inline-block;',
-          data: 'University of Waterloo'
-        },
-        {
-          component: 'span',
-          styles: 'min-width: 21rem; display: inline-block;',
-          data: 'Progress in Realizing Novel Qubits with Josephson Field Effect Transistors'
-        },
-        {
-          component: 'span',
-          styles: 'min-width: 5rem; display: inline-block;',
-          data: '2021/01/25'
-        },
-        {
-          component: 'AppCta',
-          styles: 'min-width: 6rem;',
-          data: {
-            url: 'https://qiskit.org',
-            label: 'Join the event'
-          }
-        }
-      ],
-      [
-        {
-          component: 'span',
-          styles: 'min-width: 8rem; display: inline-block;',
-          data: 'Javad Shabani'
-        },
-        {
-          component: 'span',
-          styles: 'min-width: 9rem; display: inline-block;',
-          data: 'MIT'
-        },
-        {
-          component: 'span',
-          styles: 'min-width: 21rem; display: inline-block;',
-          data: 'Progress in Realizing Novel Qubits with Josephson Field Effect Transistors'
-        },
-        {
-          component: 'span',
-          styles: 'min-width: 5rem; display: inline-block;',
-          data: '2021/01/25'
-        },
-        {
-          component: 'AppCta',
-          styles: 'min-width: 6rem;',
-          data: {
-            url: 'https://qiskit.org',
-            label: 'Join the event'
-          }
-        }
-      ]
-    ]
+    dataPerRow: this.tableDataPerRow
   }
 }
 </script>

--- a/components/events/seminar-series/UpcomingSeminarSeriesSection.vue
+++ b/components/events/seminar-series/UpcomingSeminarSeriesSection.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="upcoming-seminar-series-section">
     <h2 class="copy__title">
-      Upcoming Seminar Schedule
+      Upcoming Quantum Seminar Schedule
     </h2>
     <SeminarSeriesDataTable :columns="tableData.columns" :data-per-row="tableData.dataPerRow" />
   </section>
@@ -17,7 +17,7 @@ export default class UpcomingSeminarSeriesSection extends Vue {
   tableDataPerRow = events.map(event => ([
     {
       component: 'span',
-      styles: 'min-width: 8rem; display: inline-block;',
+      styles: 'min-width: 9rem; display: inline-block;',
       data: event.speaker
     },
     {
@@ -37,16 +37,16 @@ export default class UpcomingSeminarSeriesSection extends Vue {
     },
     {
       component: 'AppCta',
-      styles: 'min-width: 6rem;',
+      styles: 'min-width: 5rem;',
       data: {
         url: event.to,
-        label: 'Join the event'
+        label: 'Join event'
       }
     }
   ]));
 
   tableData = {
-    columns: ['Speaker', 'Institution', 'Seminar title', 'Date of talk', 'Link to talk'],
+    columns: ['Speaker', 'Institution', 'Name of talk', 'Date of talk', 'Link to talk'],
     dataPerRow: this.tableDataPerRow
   }
 }
@@ -54,4 +54,10 @@ export default class UpcomingSeminarSeriesSection extends Vue {
 
 <style lang="scss" scoped>
 @import "~/assets/scss/blocks/copy.scss";
+
+.upcoming-seminar-series-section {
+  .copy__title {
+    max-width: initial;
+  }
+}
 </style>

--- a/components/ui/AppDescriptionCard.vue
+++ b/components/ui/AppDescriptionCard.vue
@@ -1,15 +1,18 @@
 <template>
   <article class="app-description-card">
-    <h2 class="copy__subtitle">
-      {{ title }}
-    </h2>
-    <p class="copy__paragraph">
-      {{ description }}
-    </p>
+    <div>
+      <h2 class="copy__subtitle">
+        {{ title }}
+      </h2>
+      <p class="copy__paragraph">
+        {{ description }}
+      </p>
+    </div>
     <AppCta
       v-if="cta && cta.url"
       v-bind="cta"
       kind="ghost"
+      class="app-description-card__cta"
     />
   </article>
 </template>
@@ -18,6 +21,12 @@
 import Vue from 'vue'
 import { Component, Prop } from 'vue-property-decorator'
 import { GeneralLink } from '~/constants/appLinks'
+
+export type DescriptionCard = {
+  title: string,
+  description: string,
+  cta: GeneralLink
+}
 
 @Component
 export default class AppDescriptionCard extends Vue {
@@ -29,4 +38,14 @@ export default class AppDescriptionCard extends Vue {
 
 <style lang="scss" scoped>
 @import '~/assets/scss/blocks/copy.scss';
+
+.app-description-card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  &__cta {
+    width: 100%;
+  }
+}
 </style>

--- a/constants/appLinks.ts
+++ b/constants/appLinks.ts
@@ -41,6 +41,11 @@ const YOUTUBE_ALL_EPISODES_CTA: GeneralLink = {
   label: 'View all episodes'
 }
 
+const SEMINAR_SERIES_ALL_EPISODES_CTA: GeneralLink = {
+  url: 'https://www.youtube.com/playlist?list=PLOFEBzvs-Vvr0uEoGFo08n4-WrM_8fft2',
+  label: 'Go to series'
+}
+
 const DISCOVER_TEXTBOOK_CTA: GeneralLink = {
   url: 'https://qiskit.org/textbook',
   label: 'Discover more'
@@ -64,5 +69,6 @@ export {
   YOUTUBE_ALL_EPISODES_CTA,
   DISCOVER_TEXTBOOK_CTA,
   REQUEST_AN_EVENT_CTA,
+  SEMINAR_SERIES_ALL_EPISODES_CTA,
   IBM_Q_EXPERIENCE
 }

--- a/content/events/next-seminar-series-event.json
+++ b/content/events/next-seminar-series-event.json
@@ -1,0 +1,9 @@
+{
+  "date": "January 22, 2021",
+  "image": "https://dl.airtable.com/.attachmentThumbnails/49a702d8b04f71c43f0d4e08ac5cb1db/634f7076",
+  "institution": "Harvard University",
+  "location": "YouTube",
+  "speaker": "Alán Aspuru-Guzik",
+  "title": "What to do with a near-term quantum computer?",
+  "to": "https://youtu.be/I6_tHLAeBsI"
+}

--- a/content/events/past-community-events.json
+++ b/content/events/past-community-events.json
@@ -1,46 +1,24 @@
 [
   {
-    "title": "Qiskit Community Summer Jam - Midwest ",
+    "title": "Boson Sampling and Quantum Simulations in Circuit QED",
     "types": [
-      "Hackathon"
+      "Talks"
     ],
-    "image": "https://dl.airtable.com/.attachmentThumbnails/5fb60efc02b56ae0f4b336ef4f656682/382f1148",
-    "location": "HackerEarth.com",
-    "region": "Americas",
-    "date": "June 24 - July 1, 2020",
-    "to": "https://www.hackerearth.com/challenges/hackathon/qiskit-community-summer-jam-mid-west/"
+    "image": "https://dl.airtable.com/.attachmentThumbnails/1e1b501e69679ad462f7634891255817/f394afe9",
+    "location": "YouTube",
+    "region": "Online",
+    "date": "January 15, 2021",
+    "to": "https://youtu.be/miK5y8BYlwQ"
   },
   {
-    "title": "Qiskit Community Summer Jam - New England",
+    "title": "Quantum Engineering of Superconducting Qubits | Seminar Series with Will Oliver",
     "types": [
-      "Hackathon"
+      "Talks"
     ],
-    "image": "https://dl.airtable.com/.attachmentThumbnails/5fb60efc02b56ae0f4b336ef4f656682/382f1148",
-    "location": "HackerEarth.com",
-    "region": "Americas",
-    "date": "June 24 - July 1, 2020",
-    "to": "https://qiskit-community-summer-jam-new-england.hackerearth.com/"
-  },
-  {
-    "title": "Qiskit Community Summer Jam - California",
-    "types": [
-      "Hackathon"
-    ],
-    "image": "https://dl.airtable.com/.attachmentThumbnails/5fb60efc02b56ae0f4b336ef4f656682/382f1148",
-    "location": "HackerEarth.com",
-    "region": "Americas",
-    "date": "June 24 - July 1, 2020",
-    "to": "https://www.hackerearth.com/challenges/hackathon/qiskit-community-summer-jam-california/"
-  },
-  {
-    "title": "Qiskit Community Summer Jam - North Carolina",
-    "types": [
-      "Hackathon"
-    ],
-    "image": "https://dl.airtable.com/.attachmentThumbnails/5fb60efc02b56ae0f4b336ef4f656682/382f1148",
-    "location": "HackerEarth.com",
-    "region": "Americas",
-    "date": "June 24 - July 1, 2020",
-    "to": "https://www.hackerearth.com/challenges/hackathon/qiskit-community-summer-jam-north-carolina/"
+    "image": "https://dl.airtable.com/.attachmentThumbnails/f0daa554e731da5f87d13511546f3c77/6caa60ee",
+    "location": "YouTube",
+    "region": "Online",
+    "date": "December 18, 2020",
+    "to": "https://youtu.be/aGAb-GbrvMU"
   }
 ]

--- a/content/events/past-seminar-series-events.json
+++ b/content/events/past-seminar-series-events.json
@@ -1,0 +1,11 @@
+[
+  {
+    "date": "January 15, 2021",
+    "image": "https://dl.airtable.com/.attachmentThumbnails/1e1b501e69679ad462f7634891255817/f394afe9",
+    "institution": "Yale University",
+    "location": "YouTube",
+    "speaker": "Steve Girvin\n\t",
+    "title": "Boson Sampling and Quantum Simulations in Circuit QED",
+    "to": "https://youtu.be/miK5y8BYlwQ"
+  }
+]

--- a/content/events/upcoming-community-events.json
+++ b/content/events/upcoming-community-events.json
@@ -1,13 +1,64 @@
 [
   {
-    "title": "Qiskit Global Summer School",
+    "title": "What to do with a near-term quantum computer?",
     "types": [
-      "Online"
+      "Talks"
     ],
-    "image": "https://dl.airtable.com/.attachmentThumbnails/7de6fa69d8061d8f9e49e4505691338a/c067c96f",
-    "location": "Online",
+    "image": "https://dl.airtable.com/.attachmentThumbnails/49a702d8b04f71c43f0d4e08ac5cb1db/634f7076",
+    "location": "YouTube",
     "region": "Online",
-    "date": "July 20-30, 2020",
-    "to": "https://qiskit.org/events/summer-school/"
+    "date": "January 22, 2021",
+    "to": "https://youtu.be/I6_tHLAeBsI"
+  },
+  {
+    "title": "Compilation for Quantum Computing: Gap Analysis and Optimal Solution",
+    "types": [
+      "Talks"
+    ],
+    "image": "https://dl.airtable.com/.attachmentThumbnails/b81d53d95b7a02f156dedfa6b00e5c7a/3c652699",
+    "location": "YouTube",
+    "region": "Online",
+    "date": "January 29, 2021",
+    "to": "https://youtu.be/Z9R9a3hku9Y"
+  },
+  {
+    "title": "Qiskit Hackathon @ MIT",
+    "types": [
+      "Hackathon"
+    ],
+    "image": "https://dl.airtable.com/.attachmentThumbnails/22ce9a8acb5781f8991d908fb7c247d2/b666a5e3",
+    "location": "MIT",
+    "region": "Americas",
+    "date": "January 30-31, 2021"
+  },
+  {
+    "title": "Qiskit Hackathon @ McMaster University",
+    "types": [
+      "Hackathon"
+    ],
+    "image": "https://dl.airtable.com/.attachmentThumbnails/da755eac58a003a1ce054470b19bccf8/209a594e",
+    "location": "McMaster University",
+    "region": "Americas",
+    "date": "February 5-7, 2021"
+  },
+  {
+    "title": "Qiskit Hackathon @ NYU",
+    "types": [
+      "Hackathon"
+    ],
+    "image": "https://dl.airtable.com/.attachmentThumbnails/61994381e16351e2a3c5f0e293390b59/9dae0f09",
+    "location": "NYU",
+    "region": "Americas",
+    "date": "February 12-13, 2021"
+  },
+  {
+    "title": "Qiskit Hackathon Korea",
+    "types": [
+      "Hackathon"
+    ],
+    "image": "/images/events/no-picture.jpg",
+    "location": "Korea",
+    "region": "Asia Pacific",
+    "date": "February 18-19, 2021"
   }
 ]

--- a/content/events/upcoming-seminar-series-events.json
+++ b/content/events/upcoming-seminar-series-events.json
@@ -1,0 +1,20 @@
+[
+  {
+    "date": "January 22, 2021",
+    "image": "https://dl.airtable.com/.attachmentThumbnails/49a702d8b04f71c43f0d4e08ac5cb1db/634f7076",
+    "institution": "Harvard University",
+    "location": "YouTube",
+    "speaker": "Alán Aspuru-Guzik",
+    "title": "What to do with a near-term quantum computer?",
+    "to": "https://youtu.be/I6_tHLAeBsI"
+  },
+  {
+    "date": "January 29, 2021",
+    "image": "https://dl.airtable.com/.attachmentThumbnails/b81d53d95b7a02f156dedfa6b00e5c7a/3c652699",
+    "institution": "UCLA",
+    "location": "YouTube",
+    "speaker": "Jason Cong",
+    "title": "Compilation for Quantum Computing: Gap Analysis and Optimal Solution",
+    "to": "https://youtu.be/Z9R9a3hku9Y"
+  }
+]

--- a/hooks/update-events.ts
+++ b/hooks/update-events.ts
@@ -1,15 +1,25 @@
 import fs from 'fs'
 import util from 'util'
 
-import { fetchCommunityEvents } from './event-conversion-utils'
+import { fetchCommunityEvents, fetchSeminarSeriesEvents } from './event-conversion-utils'
 
 export default async function (apiKey: any, outputFolder: string) {
   const upcomingCommunityEvents = await fetchCommunityEvents(apiKey, { days: 31 })
   const pastCommunityEvents = await fetchCommunityEvents(apiKey, { days: -31 })
 
-  const writeFile = util.promisify(fs.writeFile)
-  const writeUpcomingEvents = writeFile(`${outputFolder}/upcoming-community-events.json`, JSON.stringify(upcomingCommunityEvents, null, 2))
-  const writePastEvents = writeFile(`${outputFolder}/past-community-events.json`, JSON.stringify(pastCommunityEvents, null, 2))
+  const upcomingSeminarSeriesEvents = await fetchSeminarSeriesEvents(apiKey, { days: 31 })
+  const pastSeminarSeriesEvents = await fetchSeminarSeriesEvents(apiKey, { days: -62 })
+  const nextSeminarSeriesEvent = upcomingSeminarSeriesEvents[0]
 
-  await Promise.all([writeUpcomingEvents, writePastEvents])
+  const writeFile = util.promisify(fs.writeFile)
+
+  const eventsAndOutputFilename = [
+    { events: upcomingCommunityEvents, outputFilename: 'upcoming-community-events.json' },
+    { events: pastCommunityEvents, outputFilename: 'past-community-events.json' },
+    { events: upcomingSeminarSeriesEvents, outputFilename: 'upcoming-seminar-series-events.json' },
+    { events: pastSeminarSeriesEvents, outputFilename: 'past-seminar-series-events.json' },
+    { events: nextSeminarSeriesEvent, outputFilename: 'next-seminar-series-event.json' }
+  ]
+
+  await Promise.all(eventsAndOutputFilename.map(curr => writeFile(`${outputFolder}/${curr.outputFilename}`, JSON.stringify(curr.events, null, 2))))
 }

--- a/pages/events/seminar-series.vue
+++ b/pages/events/seminar-series.vue
@@ -2,6 +2,7 @@
   <main class="seminar-series-page">
     <WhatIsThisEventSection class="seminar-series-page__section" />
     <UpcomingSeminarSeriesSection class="seminar-series-page__section" />
+    <PastSeminarSeriesSection class="seminar-series-page__section" />
     <HelpfulResourcesSection class="seminar-series-page__section" :resources="helpfulResources" />
   </main>
 </template>

--- a/pages/events/seminar-series.vue
+++ b/pages/events/seminar-series.vue
@@ -2,12 +2,14 @@
   <main class="seminar-series-page">
     <WhatIsThisEventSection class="seminar-series-page__section" />
     <UpcomingSeminarSeriesSection class="seminar-series-page__section" />
+    <HelpfulResourcesSection class="seminar-series-page__section" :resources="helpfulResources" />
   </main>
 </template>
 
 <script lang="ts">
 import { Component } from 'vue-property-decorator'
 import QiskitPage from '~/components/logic/QiskitPage.vue'
+import { DescriptionCard } from '~/components/ui/AppDescriptionCard.vue'
 
 @Component({
   head () {
@@ -18,12 +20,48 @@ import QiskitPage from '~/components/logic/QiskitPage.vue'
 })
 export default class SeminarSeriesPage extends QiskitPage {
   routeName = 'seminar-series';
+
+  helpfulResources: DescriptionCard[] = [
+    {
+      title: 'Stay informed',
+      description: 'Want to keep up to date with upcoming seminars? Click here to subscribe to our calendar for all upcoming events. This section needs copy review.',
+      cta: {
+        url: '',
+        label: 'Get calendar updates'
+      }
+    },
+    {
+      title: 'Nominate',
+      description: 'If you or someone you know might be interested in speaking in a future seminar, we would love to include them. Please include your name, topic and available dates.',
+      cta: {
+        url: '',
+        label: 'Contact us'
+      }
+    },
+    {
+      title: 'Get up to speed',
+      description: 'If the content of the seminar series is too dense or technical, we have a host of content to help you get up to speed.',
+      cta: {
+        url: 'https://qiskit.org/learn',
+        label: 'Start learning'
+      }
+    },
+    {
+      title: 'Code of conduct',
+      description: 'Qiskit is dedicated to providing an enjoyable and safe experience for all participants. We have a code of conduct that all events adhere to.',
+      cta: {
+        url: 'https://github.com/Qiskit/qiskit/blob/master/CODE_OF_CONDUCT.md',
+        label: 'See code of  conduct'
+      }
+    }
+  ]
 }
 </script>
 
 <style lang="scss" scoped>
 .seminar-series-page {
   background-color: $white;
+  color: $white-text-01;
 
   &__section {
     @include contained();


### PR DESCRIPTION
This PR display the past Seminar Series events in the Seminar Series event page.

To test is on Vercel, go to the route `/events/seminar-series`.

For some reason, this PR shows changes in 13 files in GitHub, but when using the [_compare_ function](https://github.com/Qiskit/qiskit.org/compare/feature/seminar-series-new-layout...eddybrando:ev-issue-1300-past-seminar-series-events-table), changes in 4 files are shown.

This PR actually just changes files in those 4 files. The rest are already in the target branch.

---

Closes #1300