### PR TITLE
feat: display past Seminar Series events table

### DIFF
--- a/components/events/seminar-series/PastSeminarSeriesSection.vue
+++ b/components/events/seminar-series/PastSeminarSeriesSection.vue
@@ -1,0 +1,74 @@
+<template>
+  <section class="past-seminar-series-section">
+    <h2 class="copy__title">
+      Past Seminars
+    </h2>
+    <SeminarSeriesDataTable :columns="tableData.columns" :data-per-row="tableData.dataPerRow" />
+    <AppCta
+      class="past-seminar-series-section__cta"
+      kind="ghost"
+      v-bind="showMoreCta"
+    />
+  </section>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { Component } from 'vue-property-decorator'
+import { SEMINAR_SERIES_ALL_EPISODES_CTA } from '~/constants/appLinks.ts'
+import events from '~/content/events/past-seminar-series-events.json'
+
+@Component
+export default class PastSeminarSeriesSection extends Vue {
+  tableDataPerRow = events.map(event => ([
+    {
+      component: 'span',
+      styles: 'min-width: 8rem; display: inline-block;',
+      data: event.speaker
+    },
+    {
+      component: 'span',
+      styles: 'min-width: 9rem; display: inline-block;',
+      data: event.institution
+    },
+    {
+      component: 'span',
+      styles: 'min-width: 19rem; display: inline-block;',
+      data: event.title
+    },
+    {
+      component: 'span',
+      styles: 'min-width: 8rem; display: inline-block;',
+      data: event.date
+    },
+    {
+      component: 'AppCta',
+      styles: 'min-width: 6rem;',
+      data: {
+        url: event.to,
+        label: 'Join the event'
+      }
+    }
+  ]));
+
+  tableData = {
+    columns: ['Speaker', 'Institution', 'Seminar title', 'Date of talk', 'Link to talk'],
+    dataPerRow: this.tableDataPerRow
+  }
+
+  showMoreCta = {
+    ...SEMINAR_SERIES_ALL_EPISODES_CTA,
+    label: 'Show more'
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@import "~/assets/scss/blocks/copy.scss";
+
+.past-seminar-series-section {
+  &__cta {
+    margin-top: $spacing-03;
+  }
+}
+</style>

--- a/components/events/seminar-series/PastSeminarSeriesSection.vue
+++ b/components/events/seminar-series/PastSeminarSeriesSection.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="past-seminar-series-section">
     <h2 class="copy__title">
-      Past Seminars
+      Past Quantum Seminars
     </h2>
     <SeminarSeriesDataTable :columns="tableData.columns" :data-per-row="tableData.dataPerRow" />
     <AppCta
@@ -23,7 +23,7 @@ export default class PastSeminarSeriesSection extends Vue {
   tableDataPerRow = events.map(event => ([
     {
       component: 'span',
-      styles: 'min-width: 8rem; display: inline-block;',
+      styles: 'min-width: 9rem; display: inline-block;',
       data: event.speaker
     },
     {
@@ -43,22 +43,22 @@ export default class PastSeminarSeriesSection extends Vue {
     },
     {
       component: 'AppCta',
-      styles: 'min-width: 6rem;',
+      styles: 'min-width: 5rem;',
       data: {
         url: event.to,
-        label: 'Join the event'
+        label: 'Join event'
       }
     }
   ]));
 
   tableData = {
-    columns: ['Speaker', 'Institution', 'Seminar title', 'Date of talk', 'Link to talk'],
+    columns: ['Speaker', 'Institution', 'Name of talk', 'Date of talk', 'Link to talk'],
     dataPerRow: this.tableDataPerRow
   }
 
   showMoreCta = {
     ...SEMINAR_SERIES_ALL_EPISODES_CTA,
-    label: 'Show more'
+    label: 'Explore Full Seminar Archive'
   }
 }
 </script>

--- a/components/events/seminar-series/PastSeminarSeriesSection.vue
+++ b/components/events/seminar-series/PastSeminarSeriesSection.vue
@@ -15,7 +15,7 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
-import { SEMINAR_SERIES_ALL_EPISODES_CTA } from '~/constants/appLinks.ts'
+import { SEMINAR_SERIES_FULL_ARCHIVE_CTA } from '~/constants/appLinks.ts'
 import events from '~/content/events/past-seminar-series-events.json'
 
 @Component
@@ -56,10 +56,7 @@ export default class PastSeminarSeriesSection extends Vue {
     dataPerRow: this.tableDataPerRow
   }
 
-  showMoreCta = {
-    ...SEMINAR_SERIES_ALL_EPISODES_CTA,
-    label: 'Explore Full Seminar Archive'
-  }
+  showMoreCta = SEMINAR_SERIES_FULL_ARCHIVE_CTA
 }
 </script>
 

--- a/components/events/seminar-series/UpcomingSeminarSeriesSection.vue
+++ b/components/events/seminar-series/UpcomingSeminarSeriesSection.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="upcoming-seminar-series-section">
     <h2 class="copy__title">
-      Upcoming Seminar Schedule
+      Upcoming Quantum Seminar Schedule
     </h2>
     <SeminarSeriesDataTable :columns="tableData.columns" :data-per-row="tableData.dataPerRow" />
   </section>
@@ -17,7 +17,7 @@ export default class UpcomingSeminarSeriesSection extends Vue {
   tableDataPerRow = events.map(event => ([
     {
       component: 'span',
-      styles: 'min-width: 8rem; display: inline-block;',
+      styles: 'min-width: 9rem; display: inline-block;',
       data: event.speaker
     },
     {
@@ -37,16 +37,16 @@ export default class UpcomingSeminarSeriesSection extends Vue {
     },
     {
       component: 'AppCta',
-      styles: 'min-width: 6rem;',
+      styles: 'min-width: 5rem;',
       data: {
         url: event.to,
-        label: 'Join the event'
+        label: 'Join event'
       }
     }
   ]));
 
   tableData = {
-    columns: ['Speaker', 'Institution', 'Seminar title', 'Date of talk', 'Link to talk'],
+    columns: ['Speaker', 'Institution', 'Name of talk', 'Date of talk', 'Link to talk'],
     dataPerRow: this.tableDataPerRow
   }
 }
@@ -54,4 +54,10 @@ export default class UpcomingSeminarSeriesSection extends Vue {
 
 <style lang="scss" scoped>
 @import "~/assets/scss/blocks/copy.scss";
+
+.upcoming-seminar-series-section {
+  .copy__title {
+    max-width: initial;
+  }
+}
 </style>

--- a/constants/appLinks.ts
+++ b/constants/appLinks.ts
@@ -41,6 +41,11 @@ const YOUTUBE_ALL_EPISODES_CTA: GeneralLink = {
   label: 'View all episodes'
 }
 
+const SEMINAR_SERIES_ALL_EPISODES_CTA: GeneralLink = {
+  url: 'https://www.youtube.com/playlist?list=PLOFEBzvs-Vvr0uEoGFo08n4-WrM_8fft2',
+  label: 'Go to series'
+}
+
 const DISCOVER_TEXTBOOK_CTA: GeneralLink = {
   url: 'https://qiskit.org/textbook',
   label: 'Discover more'
@@ -64,5 +69,6 @@ export {
   YOUTUBE_ALL_EPISODES_CTA,
   DISCOVER_TEXTBOOK_CTA,
   REQUEST_AN_EVENT_CTA,
+  SEMINAR_SERIES_ALL_EPISODES_CTA,
   IBM_Q_EXPERIENCE
 }

--- a/constants/appLinks.ts
+++ b/constants/appLinks.ts
@@ -41,9 +41,16 @@ const YOUTUBE_ALL_EPISODES_CTA: GeneralLink = {
   label: 'View all episodes'
 }
 
+const seminarSeriesPlaylistUrl = 'https://www.youtube.com/playlist?list=PLOFEBzvs-Vvr0uEoGFo08n4-WrM_8fft2'
+
 const SEMINAR_SERIES_ALL_EPISODES_CTA: GeneralLink = {
-  url: 'https://www.youtube.com/playlist?list=PLOFEBzvs-Vvr0uEoGFo08n4-WrM_8fft2',
+  url: seminarSeriesPlaylistUrl,
   label: 'Go to series'
+}
+
+const SEMINAR_SERIES_FULL_ARCHIVE_CTA: GeneralLink = {
+  url: seminarSeriesPlaylistUrl,
+  label: 'Explore Full Seminar Archive'
 }
 
 const DISCOVER_TEXTBOOK_CTA: GeneralLink = {
@@ -70,5 +77,6 @@ export {
   DISCOVER_TEXTBOOK_CTA,
   REQUEST_AN_EVENT_CTA,
   SEMINAR_SERIES_ALL_EPISODES_CTA,
+  SEMINAR_SERIES_FULL_ARCHIVE_CTA,
   IBM_Q_EXPERIENCE
 }

--- a/pages/events/seminar-series.vue
+++ b/pages/events/seminar-series.vue
@@ -2,6 +2,7 @@
   <main class="seminar-series-page">
     <WhatIsThisEventSection class="seminar-series-page__section" />
     <UpcomingSeminarSeriesSection class="seminar-series-page__section" />
+    <PastSeminarSeriesSection class="seminar-series-page__section" />
     <HelpfulResourcesSection class="seminar-series-page__section" :resources="helpfulResources" />
   </main>
 </template>


### PR DESCRIPTION
This PR displays the past Seminar Series events in the Seminar Series event page, with data fetched from Airtable.

It also makes some copy changes to the tables, based on the [latest version of the Figma design](https://www.figma.com/file/nqFBhDOUq6Dknbw9pM92AE/1263-individual-event-pages?node-id=331%3A1931).

To test is on Vercel, go to the route `/events/seminar-series`.

For some reason, this PR shows changes in 13 files in GitHub, but when using the [_compare_ function](https://github.com/Qiskit/qiskit.org/compare/feature/seminar-series-new-layout...eddybrando:ev-issue-1300-past-seminar-series-events-table), changes in 4 files are shown.

This PR actually just changes files in those 4 files. The rest are already in the target branch.

---

Closes #1300