### PR TITLE
fix: mosaic image overflow

### DIFF
--- a/components/ui/AppMosaic.vue
+++ b/components/ui/AppMosaic.vue
@@ -132,7 +132,6 @@ export default class AppMosaic extends Vue {
         background-position: center top;
         background-size: cover;
         background-repeat: no-repeat;
-        min-height: 15rem;
 
         @include mq($until: large) {
           min-height: 12rem;


### PR DESCRIPTION
This PR prevents an image overflow in the second section of the mosaic.

<img width="1239" alt="Screenshot 2021-02-02 at 10 34 16" src="https://user-images.githubusercontent.com/22047320/106581745-81cf6900-6543-11eb-9972-553d36a8e9b1.png">
