### PR TITLE
refactor: next event from events json

### DIFF
--- a/components/events/seminar-series/PastSeminarSeriesSection.vue
+++ b/components/events/seminar-series/PastSeminarSeriesSection.vue
@@ -3,7 +3,7 @@
     <h2 class="copy__title">
       Past Quantum Seminars
     </h2>
-    <SeminarSeriesDataTable :columns="tableData.columns" :data-per-row="tableData.dataPerRow" />
+    <SeminarSeriesDataTable :events="events" />
     <AppCta
       class="past-seminar-series-section__cta"
       kind="ghost"
@@ -21,42 +21,6 @@ import { SeminarSeriesEvent } from '~/hooks/event-conversion-utils.ts'
 @Component
 export default class PastSeminarSeriesSection extends Vue {
   @Prop({ type: Array, required: true }) events!: SeminarSeriesEvent[]
-
-  tableDataPerRow = this.events.map(event => ([
-    {
-      component: 'span',
-      styles: 'min-width: 9rem; display: inline-block;',
-      data: event.speaker
-    },
-    {
-      component: 'span',
-      styles: 'min-width: 9rem; display: inline-block;',
-      data: event.institution
-    },
-    {
-      component: 'span',
-      styles: 'min-width: 19rem; display: inline-block;',
-      data: event.title
-    },
-    {
-      component: 'span',
-      styles: 'min-width: 8rem; display: inline-block;',
-      data: event.date
-    },
-    {
-      component: 'AppCta',
-      styles: 'min-width: 5rem;',
-      data: {
-        url: event.to,
-        label: 'Join event'
-      }
-    }
-  ]));
-
-  tableData = {
-    columns: ['Speaker', 'Institution', 'Name of talk', 'Date of talk', 'Link to talk'],
-    dataPerRow: this.tableDataPerRow
-  }
 
   showMoreCta = SEMINAR_SERIES_FULL_ARCHIVE_CTA
 }

--- a/components/events/seminar-series/PastSeminarSeriesSection.vue
+++ b/components/events/seminar-series/PastSeminarSeriesSection.vue
@@ -20,9 +20,9 @@ import { SeminarSeriesEvent } from '~/hooks/event-conversion-utils.ts'
 
 @Component
 export default class PastSeminarSeriesSection extends Vue {
-  @Prop({ type: Array, required: true }) pastEvents!: SeminarSeriesEvent[]
+  @Prop({ type: Array, required: true }) events!: SeminarSeriesEvent[]
 
-  tableDataPerRow = this.pastEvents.map(event => ([
+  tableDataPerRow = this.events.map(event => ([
     {
       component: 'span',
       styles: 'min-width: 9rem; display: inline-block;',

--- a/components/events/seminar-series/PastSeminarSeriesSection.vue
+++ b/components/events/seminar-series/PastSeminarSeriesSection.vue
@@ -14,13 +14,15 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import { Component } from 'vue-property-decorator'
+import { Component, Prop } from 'vue-property-decorator'
 import { SEMINAR_SERIES_FULL_ARCHIVE_CTA } from '~/constants/appLinks.ts'
-import events from '~/content/events/past-seminar-series-events.json'
+import { SeminarSeriesEvent } from '~/hooks/event-conversion-utils.ts'
 
 @Component
 export default class PastSeminarSeriesSection extends Vue {
-  tableDataPerRow = events.map(event => ([
+  @Prop({ type: Array, required: true }) pastEvents!: SeminarSeriesEvent[]
+
+  tableDataPerRow = this.pastEvents.map(event => ([
     {
       component: 'span',
       styles: 'min-width: 9rem; display: inline-block;',

--- a/components/events/seminar-series/SeminarSeriesDataTable.vue
+++ b/components/events/seminar-series/SeminarSeriesDataTable.vue
@@ -24,19 +24,50 @@
 import Vue from 'vue'
 import { Component, Prop } from 'vue-property-decorator'
 import { GeneralLink } from '~/constants/appLinks'
+import { SeminarSeriesEvent } from '~/hooks/event-conversion-utils'
 
-type tableRow = [
-  {
-    component: string,
-    styles: string,
-    data: string | GeneralLink,
-  }
-]
+interface tableRowElement {
+  component: string,
+  styles: string,
+  data: string | GeneralLink,
+}
 
 @Component
 export default class SeminarSeriesDataTable extends Vue {
-  @Prop(Array) columns!: string[]
-  @Prop(Array) dataPerRow!: tableRow[]
+  @Prop({ type: Array, default: () => [] }) events!: SeminarSeriesEvent[]
+
+  dataPerRow: tableRowElement[][] = this.events.map(event => ([
+    {
+      component: 'span',
+      styles: 'min-width: 9rem; display: inline-block;',
+      data: event.speaker
+    },
+    {
+      component: 'span',
+      styles: 'min-width: 9rem; display: inline-block;',
+      data: event.institution
+    },
+    {
+      component: 'span',
+      styles: 'min-width: 19rem; display: inline-block;',
+      data: event.title
+    },
+    {
+      component: 'span',
+      styles: 'min-width: 8rem; display: inline-block;',
+      data: event.date
+    },
+    {
+      component: 'AppCta',
+      styles: 'min-width: 5rem;',
+      data: {
+        url: event.to,
+        label: 'Join event'
+      }
+    }
+  ]))
+
+  columns = ['Speaker', 'Institution', 'Name of talk', 'Date of talk', 'Link to talk']
 
   isAppCtaComponent (component: string) : boolean {
     return component === 'AppCta'

--- a/components/events/seminar-series/SeminarSeriesHeader.vue
+++ b/components/events/seminar-series/SeminarSeriesHeader.vue
@@ -32,16 +32,16 @@
 import Vue from 'vue'
 import { Component, Prop } from 'vue-property-decorator'
 import { SEMINAR_SERIES_ALL_EPISODES_CTA } from '~/constants/appLinks.ts'
-import pastEvents from '~/content/events/past-seminar-series-events.json'
 import { SeminarSeriesEvent } from '~/hooks/event-conversion-utils.ts'
 
 @Component
 export default class SeminarSeriesHeader extends Vue {
   @Prop({ type: Object, required: false }) nextEvent!: SeminarSeriesEvent|null
+  @Prop({ type: Array, required: true }) pastEvents!: SeminarSeriesEvent[]
 
   cta = SEMINAR_SERIES_ALL_EPISODES_CTA
   cardTitle = !this.nextEvent ? 'Featured seminar:' : 'Up next:'
-  cardContent = !this.nextEvent ? pastEvents[Math.floor(Math.random() * pastEvents.length)] : this.nextEvent
+  cardContent = !this.nextEvent ? this.pastEvents[Math.floor(Math.random() * this.pastEvents.length)] : this.nextEvent
 }
 </script>
 

--- a/components/events/seminar-series/SeminarSeriesHeader.vue
+++ b/components/events/seminar-series/SeminarSeriesHeader.vue
@@ -30,15 +30,15 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import { Component } from 'vue-property-decorator'
+import { Component, Prop } from 'vue-property-decorator'
 import { SEMINAR_SERIES_ALL_EPISODES_CTA } from '~/constants/appLinks.ts'
 import pastEvents from '~/content/events/past-seminar-series-events.json'
-import upcomingEvents from '~/content/events/upcoming-seminar-series-events.json'
 
 @Component
 export default class SeminarSeriesHeader extends Vue {
+  @Prop({ type: Object, required: false }) nextEvent!: Object|null
+
   cta = SEMINAR_SERIES_ALL_EPISODES_CTA
-  nextEvent = upcomingEvents[0] || null
   cardTitle = !this.nextEvent ? 'Featured seminar:' : 'Up next:'
   cardContent = !this.nextEvent ? pastEvents[Math.floor(Math.random() * pastEvents.length)] : this.nextEvent
 }

--- a/components/events/seminar-series/SeminarSeriesHeader.vue
+++ b/components/events/seminar-series/SeminarSeriesHeader.vue
@@ -33,10 +33,11 @@ import Vue from 'vue'
 import { Component, Prop } from 'vue-property-decorator'
 import { SEMINAR_SERIES_ALL_EPISODES_CTA } from '~/constants/appLinks.ts'
 import pastEvents from '~/content/events/past-seminar-series-events.json'
+import { SeminarSeriesEvent } from '~/hooks/event-conversion-utils.ts'
 
 @Component
 export default class SeminarSeriesHeader extends Vue {
-  @Prop({ type: Object, required: false }) nextEvent!: Object|null
+  @Prop({ type: Object, required: false }) nextEvent!: SeminarSeriesEvent|null
 
   cta = SEMINAR_SERIES_ALL_EPISODES_CTA
   cardTitle = !this.nextEvent ? 'Featured seminar:' : 'Up next:'

--- a/components/events/seminar-series/SeminarSeriesHeader.vue
+++ b/components/events/seminar-series/SeminarSeriesHeader.vue
@@ -32,16 +32,15 @@
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
 import { SEMINAR_SERIES_ALL_EPISODES_CTA } from '~/constants/appLinks.ts'
-import event from '~/content/events/next-seminar-series-event.json'
 import pastEvents from '~/content/events/past-seminar-series-events.json'
+import upcomingEvents from '~/content/events/upcoming-seminar-series-events.json'
 
 @Component
 export default class SeminarSeriesHeader extends Vue {
   cta = SEMINAR_SERIES_ALL_EPISODES_CTA
-  nextEvent = event
-  noNextEvent = JSON.stringify(this.nextEvent) === '{}'
-  cardTitle = this.noNextEvent ? 'Featured seminar:' : 'Up next:'
-  cardContent = this.noNextEvent ? pastEvents[Math.floor(Math.random() * pastEvents.length)] : this.nextEvent
+  nextEvent = upcomingEvents[0] || null
+  cardTitle = !this.nextEvent ? 'Featured seminar:' : 'Up next:'
+  cardContent = !this.nextEvent ? pastEvents[Math.floor(Math.random() * pastEvents.length)] : this.nextEvent
 }
 </script>
 

--- a/components/events/seminar-series/UpcomingSeminarSeriesSection.vue
+++ b/components/events/seminar-series/UpcomingSeminarSeriesSection.vue
@@ -3,7 +3,7 @@
     <h2 class="copy__title">
       Upcoming Quantum Seminar Schedule
     </h2>
-    <SeminarSeriesDataTable :columns="tableData.columns" :data-per-row="tableData.dataPerRow" />
+    <SeminarSeriesDataTable :events="events" />
   </section>
 </template>
 
@@ -15,42 +15,6 @@ import { SeminarSeriesEvent } from '~/hooks/event-conversion-utils'
 @Component
 export default class UpcomingSeminarSeriesSection extends Vue {
   @Prop({ type: Array, default: () => [] }) events!: SeminarSeriesEvent[]
-
-  tableDataPerRow = this.events.map(event => ([
-    {
-      component: 'span',
-      styles: 'min-width: 9rem; display: inline-block;',
-      data: event.speaker
-    },
-    {
-      component: 'span',
-      styles: 'min-width: 9rem; display: inline-block;',
-      data: event.institution
-    },
-    {
-      component: 'span',
-      styles: 'min-width: 19rem; display: inline-block;',
-      data: event.title
-    },
-    {
-      component: 'span',
-      styles: 'min-width: 8rem; display: inline-block;',
-      data: event.date
-    },
-    {
-      component: 'AppCta',
-      styles: 'min-width: 5rem;',
-      data: {
-        url: event.to,
-        label: 'Join event'
-      }
-    }
-  ]));
-
-  tableData = {
-    columns: ['Speaker', 'Institution', 'Name of talk', 'Date of talk', 'Link to talk'],
-    dataPerRow: this.tableDataPerRow
-  }
 }
 </script>
 

--- a/content/events/next-seminar-series-event.json
+++ b/content/events/next-seminar-series-event.json
@@ -1,9 +1,0 @@
-{
-  "date": "January 22, 2021",
-  "image": "https://dl.airtable.com/.attachmentThumbnails/49a702d8b04f71c43f0d4e08ac5cb1db/634f7076",
-  "institution": "Harvard University",
-  "location": "YouTube",
-  "speaker": "Alán Aspuru-Guzik",
-  "title": "What to do with a near-term quantum computer?",
-  "to": "https://youtu.be/I6_tHLAeBsI"
-}

--- a/hooks/update-events.ts
+++ b/hooks/update-events.ts
@@ -9,7 +9,6 @@ export default async function (apiKey: any, outputFolder: string) {
 
   const upcomingSeminarSeriesEvents = await fetchSeminarSeriesEvents(apiKey, { days: 31 })
   const pastSeminarSeriesEvents = await fetchSeminarSeriesEvents(apiKey, { days: -62 })
-  const nextSeminarSeriesEvent = upcomingSeminarSeriesEvents[0] || {}
 
   const writeFile = util.promisify(fs.writeFile)
 
@@ -17,8 +16,7 @@ export default async function (apiKey: any, outputFolder: string) {
     { events: upcomingCommunityEvents, outputFilename: 'upcoming-community-events.json' },
     { events: pastCommunityEvents, outputFilename: 'past-community-events.json' },
     { events: upcomingSeminarSeriesEvents, outputFilename: 'upcoming-seminar-series-events.json' },
-    { events: pastSeminarSeriesEvents, outputFilename: 'past-seminar-series-events.json' },
-    { events: nextSeminarSeriesEvent, outputFilename: 'next-seminar-series-event.json' }
+    { events: pastSeminarSeriesEvents, outputFilename: 'past-seminar-series-events.json' }
   ]
 
   await Promise.all(eventsAndOutputFilename.map(curr => writeFile(`${outputFolder}/${curr.outputFilename}`, JSON.stringify(curr.events, null, 2))))

--- a/pages/events/seminar-series.vue
+++ b/pages/events/seminar-series.vue
@@ -1,9 +1,9 @@
 <template>
   <main class="event-page seminar-series-page">
-    <SeminarSeriesHeader class="seminar-series-page__header" :next-event="nextEvent" />
+    <SeminarSeriesHeader class="seminar-series-page__header" :next-event="nextEvent" :past-events="pastEvents" />
     <WhatIsThisEventSection class="seminar-series-page__section" />
     <UpcomingSeminarSeriesSection v-if="hasUpcomingEvents" :events="upcomingEvents" class="seminar-series-page__section" />
-    <PastSeminarSeriesSection class="seminar-series-page__section" />
+    <PastSeminarSeriesSection class="seminar-series-page__section" :past-events="pastEvents" />
     <HelpfulResourcesSection class="seminar-series-page__section" :resources="helpfulResources" />
   </main>
 </template>
@@ -12,6 +12,7 @@
 import { Component } from 'vue-property-decorator'
 import QiskitPage from '~/components/logic/QiskitPage.vue'
 import { DescriptionCard } from '~/components/ui/AppDescriptionCard.vue'
+import pastSeminarSeriesEvents from '~/content/events/past-seminar-series-events.json'
 import upcomingSeminarSerieEvents from '~/content/events/upcoming-seminar-series-events.json'
 
 @Component({
@@ -24,6 +25,7 @@ import upcomingSeminarSerieEvents from '~/content/events/upcoming-seminar-series
 export default class SeminarSeriesPage extends QiskitPage {
   routeName = 'seminar-series'
   upcomingEvents = upcomingSeminarSerieEvents
+  pastEvents = pastSeminarSeriesEvents
   hasUpcomingEvents = JSON.stringify(this.upcomingEvents) !== '[]'
   nextEvent = upcomingSeminarSerieEvents[0] || null
 

--- a/pages/events/seminar-series.vue
+++ b/pages/events/seminar-series.vue
@@ -1,6 +1,6 @@
 <template>
   <main class="event-page seminar-series-page">
-    <SeminarSeriesHeader class="seminar-series-page__header" />
+    <SeminarSeriesHeader class="seminar-series-page__header" :next-event="nextEvent" />
     <WhatIsThisEventSection class="seminar-series-page__section" />
     <UpcomingSeminarSeriesSection v-if="hasUpcomingEvents" :events="upcomingEvents" class="seminar-series-page__section" />
     <PastSeminarSeriesSection class="seminar-series-page__section" />
@@ -25,6 +25,7 @@ export default class SeminarSeriesPage extends QiskitPage {
   routeName = 'seminar-series'
   upcomingEvents = upcomingSeminarSerieEvents
   hasUpcomingEvents = JSON.stringify(this.upcomingEvents) !== '[]'
+  nextEvent = upcomingSeminarSerieEvents[0] || null
 
   helpfulResources: DescriptionCard[] = [
     {

--- a/pages/events/seminar-series.vue
+++ b/pages/events/seminar-series.vue
@@ -3,7 +3,7 @@
     <SeminarSeriesHeader class="seminar-series-page__header" :next-event="nextEvent" :past-events="pastEvents" />
     <WhatIsThisEventSection class="seminar-series-page__section" />
     <UpcomingSeminarSeriesSection v-if="hasUpcomingEvents" :events="upcomingEvents" class="seminar-series-page__section" />
-    <PastSeminarSeriesSection class="seminar-series-page__section" :past-events="pastEvents" />
+    <PastSeminarSeriesSection class="seminar-series-page__section" :events="pastEvents" />
     <HelpfulResourcesSection class="seminar-series-page__section" :resources="helpfulResources" />
   </main>
 </template>


### PR DESCRIPTION
With this PR, the **next Seminar Series event** will be extracted from the list of **upcoming events** on the **Header** component directly, instead of being stored once as a JSON file with a hook event.