### PR TITLE
Replace master with main in the codebase

### DIFF
--- a/.github/workflows/deploy.workflow.yml
+++ b/.github/workflows/deploy.workflow.yml
@@ -3,9 +3,9 @@ name: build and deploy
 on:
   # run when action is manually triggered
   workflow_dispatch:
-  # run on pushes to master branch
+  # run on pushes to main branch
   push:
-    branches: [ master ]
+    branches: [ main ]
   # run daily at 08:00am UTC (on the default or base branch)
   # https://crontab.guru/#0_8_*_*_*
   schedule:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,7 +1,7 @@
 <!-- Copyright Contributors to the Qiskit project. -->
 
 # Code of Conduct
-All members of this project agree to adhere to the Qiskit Code of Conduct listed at [https://github.com/Qiskit/qiskit/blob/main/CODE_OF_CONDUCT.md](https://github.com/Qiskit/qiskit/blob/main/CODE_OF_CONDUCT.md)
+All members of this project agree to adhere to the Qiskit Code of Conduct listed at [https://github.com/Qiskit/qiskit/blob/master/CODE_OF_CONDUCT.md](https://github.com/Qiskit/qiskit/blob/master/CODE_OF_CONDUCT.md)
 
 ----
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,7 +1,7 @@
 <!-- Copyright Contributors to the Qiskit project. -->
 
 # Code of Conduct
-All members of this project agree to adhere to the Qiskit Code of Conduct listed at [https://github.com/Qiskit/qiskit/blob/master/CODE_OF_CONDUCT.md](https://github.com/Qiskit/qiskit/blob/master/CODE_OF_CONDUCT.md)
+All members of this project agree to adhere to the Qiskit Code of Conduct listed at [https://github.com/Qiskit/qiskit/blob/main/CODE_OF_CONDUCT.md](https://github.com/Qiskit/qiskit/blob/main/CODE_OF_CONDUCT.md)
 
 ----
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ need to know that qiskit.org follows the
 with [Feature Branches](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow).
 
 Regardless if you are a core contributor or not, the above means we expect you to fork
-the project on your own GitHub account and make your `master` branch to track this
+the project on your own GitHub account and make your `main` branch to track this
 repository. A typical Git setup after
 [forking the project](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo) is:
 
@@ -90,20 +90,20 @@ git clone https://github.com/<your_username>/qiskit.org.git
 cd qiskit.org
 git remote add upstream https://github.com/qiskit/qiskit.org.git
 git remote update upstream
-git checkout master
-git branch -u upstream/master
+git checkout main
+git branch -u upstream/main
 git pull
 ```
 
 ### Working on an issue
 
-When you are going to start working on an issue, make sure you are in your `master`
+When you are going to start working on an issue, make sure you are in your `main`
 branch and that it is entirely up to date and create a new branch with a
 meaningful name. The typical terminal code for this is:
 
 ```sh
-git checkout master
-git pull upstream master
+git checkout main
+git pull upstream main
 git checkout -b issue-1234-new-header
 ```
 
@@ -121,16 +121,16 @@ Create a new header layout.
 Includes a new component factoring out the header of this new page and others.
 ```
 
-From time to time, you want to check if your `master` branch is still up to
+From time to time, you want to check if your `main` branch is still up to
 date. If not, you will need to merge
 (or [rebase](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase)),
 then continue working:
 
 ```sh
-git checkout master
+git checkout main
 git pull
 git checkout issue-1234-new-header
-git merge master
+git merge main
 ```
 
 ### Pull requests
@@ -148,7 +148,7 @@ git push origin issue-1234-new-header
 
 And
 [create a pull request](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request)
-against `master` (or a feature branch).
+against `main` (or a feature branch).
 When creating the pull request, provide a description and
 [link with the issue that is being solved](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue).
 
@@ -175,7 +175,7 @@ The repository also contains some automated checks such as tests and
 **pass automatic checks and have, at least, one positive review**.
 
 During code reviews, there are two prominent roles: the reviewer and the contributor.
-The reviewer acts as the keeper of best-practices and code quality, asking 
+The reviewer acts as the keeper of best-practices and code quality, asking
 clarifying questions, highlighting implementation errors and recommending changes.
 We expect the contributor to take recommendations seriously and be willing to
 implement suggested changes or take some other action instead.
@@ -278,7 +278,7 @@ export default _factory()
 ## Final words
 
 Thank you for reading until the end of the document! Abiding by these guidelines you
-express your willing in collaborating and contributing in a healthy way. Thanks for 
+express your willing in collaborating and contributing in a healthy way. Thanks for
 that too!
 
 Now if you are a core contributor, perhaps you're interested in knowing more about

--- a/README.md
+++ b/README.md
@@ -1,13 +1,3 @@
-**IMPORTANT NOTE:**
-
-We renamed the `master` branch to `main` and GitHub is displaying a notice for the contributors visiting the repository. However, this is not compatible with the [Forking Workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/forking-workflow) we follow in the team. If you are contributing to qiskit.org, chances are that you have a fork of this project and your `origin` remote is pointing to it. The [Qiskit/qiskit.org](https://github.com/Qiskit/qiskit.org) repository should be your `upstream` remote and so, the instructions provided by GitHub should be directed towards your `upstream` remote:
-
-```
-git branch -m master main
-git fetch upstream
-git branch -u upstream/main main
-```
-
 <p align="center">
   <a href="https://qiskit.org/">
     <img alt="Qiskit" src="https://qiskit.org/images/qiskit-logo.png" width="70" />
@@ -20,6 +10,19 @@ git branch -u upstream/main main
 <h3 align="center">
   ⚛️ 💻
 </h3>
+
+<h3 align="center">
+  ⚠️ IMPORTANT UPDATE
+</h3>
+
+We renamed the `master` branch to `main` and GitHub is displaying a notice for the contributors visiting the repository. However, this is not compatible with the [Forking Workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/forking-workflow) we follow in the team. If you are contributing to qiskit.org, chances are that you have a fork of this project and your `origin` remote is pointing to it. The [Qiskit/qiskit.org](https://github.com/Qiskit/qiskit.org) repository should be your `upstream` remote and so, the instructions provided by GitHub should be directed towards your `upstream` remote:
+
+```
+git branch -m master main
+git fetch upstream
+git branch -u upstream/main main
+```
+
 <h3 align="center">
   Welcome to Quantum
 </h3>

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@
   Qiskit is an open-source quantum computing software development framework for leveraging today's quantum processors in research, education, and business.
 </p>
 <p align="center">
-  <a href="https://github.com/Qiskit/qiskit.org/blob/master/LICENSE.txt">
+  <a href="https://github.com/Qiskit/qiskit.org/blob/main/LICENSE.txt">
     <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="Qiskit.org is released under the Apache 2.0 License." />
   </a>
   <a href="https://github.com/Qiskit/qiskit.org/actions">
-    <img src="https://github.com/Qiskit/qiskit.org/workflows/build%20and%20deploy/badge.svg?branch=master" alt="Current GitHub Action build status." />
+    <img src="https://github.com/Qiskit/qiskit.org/workflows/build%20and%20deploy/badge.svg?branch=main" alt="Current GitHub Action build status." />
   </a>
-  <a href="https://github.com/Qiskit/qiskit.org/blob/master/CONTRIBUTING.rst">
+  <a href="https://github.com/Qiskit/qiskit.org/blob/main/CONTRIBUTING.rst">
     <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs welcome!" />
   </a>
   <a href="https://twitter.com/intent/follow?screen_name=qiskit">

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+**IMPORTANT NOTE:**
+
+We renamed the `master` branch to `main` and GitHub is displaying a notice for the contributors visiting the repository. However, this is not compatible with the [Forking Workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/forking-workflow) we follow in the team. If you are contributing to qiskit.org, chances are that you have a fork of this project and your `origin` remote is pointing to it. The [Qiskit/qiskit.org](https://github.com/Qiskit/qiskit.org) repository should be your `upstream` remote and so, the instructions provided by GitHub should be directed towards your `upstream` remote:
+
+```
+git branch -m master main
+git fetch upstream
+git branch -u upstream/main main
+```
+
 <p align="center">
   <a href="https://qiskit.org/">
     <img alt="Qiskit" src="https://qiskit.org/images/qiskit-logo.png" width="70" />


### PR DESCRIPTION
Fix #828 

This PR is a follow-up to the action of renaming `master` to `main` on GitHub. It replaces the apparitions of `master` in the codebase. We need to review the wiki pages too.

Vercel should not be affected and the GitHub workflows have been updated accordingly, although I would appreciate a review here @vabarbosa since you set them up.

