### PR TITLE
feat: add link to "Textbook demo"

### DIFF
--- a/constants/menuLinks.ts
+++ b/constants/menuLinks.ts
@@ -122,6 +122,14 @@ const LEARN_LINK: NavLink = {
   }
 }
 
+const TEXTBOOK_DEMO_LINK: NavLink = {
+  label: 'Textbook',
+  url: '/textbook-demo',
+  segment: {
+    action: 'Textbook demo'
+  }
+}
+
 const DOCUMENTATION_LINK: NavLink = {
   label: 'Documentation',
   url: 'https://qiskit.org/documentation/'
@@ -260,6 +268,7 @@ export {
   STAY_CONNECTED_LINKS,
   LEARN_LINK,
   OVERVIEW_LINK,
+  TEXTBOOK_DEMO_LINK,
   NavLink,
   InnerNavLink
 }

--- a/mixins/menu.ts
+++ b/mixins/menu.ts
@@ -9,6 +9,7 @@ import {
   DOCUMENTATION_LINK,
   LEARN_LINK,
   OVERVIEW_LINK,
+  TEXTBOOK_DEMO_LINK,
   NavLink
 } from '~/constants/menuLinks'
 
@@ -21,6 +22,7 @@ export default class Menu extends Vue {
   mainLevelLinks: Array<NavLink> = [
     OVERVIEW_LINK,
     LEARN_LINK,
+    TEXTBOOK_DEMO_LINK,
     { ...COMMUNITY_LINK, sublinks: ORDERED_COMMUNITY_SUB_LINKS },
     DOCUMENTATION_LINK
   ]


### PR DESCRIPTION
This PR adds a link in the navbar that points to the demo Textbook page.

This is only needed during development for testing purposes.

**Note:** There is a small design bug in the _big screen_ view (the margin between "Learn" and "Textbook" is small, and the margin between "Textbook" and "Community" is big) due to a CSS rule targeting a _nth:child_. But for the purpose of this issue (just having the link to test the page easily), it can be ignored.

<img width="1099" alt="Screenshot 2021-02-17 at 13 23 25" src="https://user-images.githubusercontent.com/22047320/108203849-5348b500-7123-11eb-923c-e0304dbde50c.png">

---

Closes https://github.com/Qiskit/qiskit.org/issues/1443