### PR TITLE
feat: create "Textbook Demo" page

### DIFF
--- a/pages/textbook-demo/index.vue
+++ b/pages/textbook-demo/index.vue
@@ -1,0 +1,21 @@
+<template>
+  <main>
+    <!-- TODO: Add page content -->
+  </main>
+</template>
+
+<script lang="ts">
+import { Component } from "vue-property-decorator";
+import QiskitPage from "~/components/logic/QiskitPage.vue";
+
+@Component({
+  head() {
+    return {
+      title: "Qiskit Textbook",
+    };
+  },
+})
+export default class TextbookPage extends QiskitPage {
+  routeName: string = "textbook-demo";
+}
+</script>

--- a/pages/textbook-demo/index.vue
+++ b/pages/textbook-demo/index.vue
@@ -5,17 +5,17 @@
 </template>
 
 <script lang="ts">
-import { Component } from "vue-property-decorator";
-import QiskitPage from "~/components/logic/QiskitPage.vue";
+import { Component } from 'vue-property-decorator'
+import QiskitPage from '~/components/logic/QiskitPage.vue'
 
 @Component({
-  head() {
+  head () {
     return {
-      title: "Qiskit Textbook",
-    };
-  },
+      title: 'Qiskit Textbook'
+    }
+  }
 })
 export default class TextbookPage extends QiskitPage {
-  routeName: string = "textbook-demo";
+  routeName: string = 'textbook-demo'
 }
 </script>


### PR DESCRIPTION
This PR creates an empty page with the Qiskit layout (including the navbar and footer) for the new **Textbook Demo**.

<img width="1354" alt="Screenshot 2021-02-17 at 13 46 51" src="https://user-images.githubusercontent.com/22047320/108206362-9b1d0b80-7126-11eb-8993-bf77712e6309.png">

---

Closes #1445
