### PR TITLE
feat: create "Helpful Resources" section for Textbook LP

### DIFF
--- a/pages/textbook-demo/index.vue
+++ b/pages/textbook-demo/index.vue
@@ -1,0 +1,21 @@
+<template>
+  <main>
+    <!-- TODO: Add page content -->
+  </main>
+</template>
+
+<script lang="ts">
+import { Component } from "vue-property-decorator";
+import QiskitPage from "~/components/logic/QiskitPage.vue";
+
+@Component({
+  head() {
+    return {
+      title: "Qiskit Textbook",
+    };
+  },
+})
+export default class TextbookPage extends QiskitPage {
+  routeName: string = "textbook-demo";
+}
+</script>

--- a/pages/textbook-demo/index.vue
+++ b/pages/textbook-demo/index.vue
@@ -5,17 +5,17 @@
 </template>
 
 <script lang="ts">
-import { Component } from "vue-property-decorator";
-import QiskitPage from "~/components/logic/QiskitPage.vue";
+import { Component } from 'vue-property-decorator'
+import QiskitPage from '~/components/logic/QiskitPage.vue'
 
 @Component({
-  head() {
+  head () {
     return {
-      title: "Qiskit Textbook",
-    };
-  },
+      title: 'Qiskit Textbook'
+    }
+  }
 })
 export default class TextbookPage extends QiskitPage {
-  routeName: string = "textbook-demo";
+  routeName: string = 'textbook-demo'
 }
 </script>

--- a/pages/textbook-demo/index.vue
+++ b/pages/textbook-demo/index.vue
@@ -1,7 +1,7 @@
 <template>
-  <main class="textbook-page">
+  <main class="textbook-demo-page">
     <HelpfulResourcesSection
-      class="textbook-page__section"
+      class="textbook-demo-page__section"
       :resources="helpfulResources"
     />
   </main>
@@ -64,7 +64,7 @@ export default class TextbookPage extends QiskitPage {
 </script>
 
 <style lang="scss" scoped>
-.textbook-page {
+.textbook-demo-page {
   &__section {
     @include contained();
     margin-bottom: $layout-03;

--- a/pages/textbook-demo/index.vue
+++ b/pages/textbook-demo/index.vue
@@ -28,8 +28,7 @@ export default class TextbookPage extends QiskitPage {
       description:
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Molestie ipsum eget id id hendrerit quis euismod eleifend urna.',
       cta: {
-        url:
-          '#',
+        url: '#',
         label: 'Lorem ipsum'
       }
     },

--- a/pages/textbook-demo/index.vue
+++ b/pages/textbook-demo/index.vue
@@ -1,12 +1,16 @@
 <template>
-  <main>
-    <!-- TODO: Add page content -->
+  <main class="textbook-page">
+    <HelpfulResourcesSection
+      class="textbook-page__section"
+      :resources="helpfulResources"
+    />
   </main>
 </template>
 
 <script lang="ts">
 import { Component } from 'vue-property-decorator'
 import QiskitPage from '~/components/logic/QiskitPage.vue'
+import { DescriptionCard } from '~/components/ui/AppDescriptionCard.vue'
 
 @Component({
   head () {
@@ -17,5 +21,55 @@ import QiskitPage from '~/components/logic/QiskitPage.vue'
 })
 export default class TextbookPage extends QiskitPage {
   routeName: string = 'textbook-demo'
+
+  helpfulResources: DescriptionCard[] = [
+    {
+      title: 'Other learning material',
+      description:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Molestie ipsum eget id id hendrerit quis euismod eleifend urna.',
+      cta: {
+        url:
+          'https://calendar.google.com/calendar/ical/c12g9fqo0mkvp9bo26dhm3u1rs%40group.calendar.google.com/public/basic.ics',
+        label: 'Lorem ipsum'
+      }
+    },
+    {
+      title: 'Docs',
+      description:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Risus morbi sodales euismod faucibus ut turpis sem.',
+      cta: {
+        url: 'https://airtable.com/shrB5wy8SCaMMtKop',
+        label: 'Lorem ipsum'
+      }
+    },
+    {
+      title: 'Slack',
+      description:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mollis turpis pulvinar morbi consequat pulvinar sit.',
+      cta: {
+        url: 'https://qiskit.org/learn',
+        label: 'Lorem ipsum'
+      }
+    },
+    {
+      title: 'Games and Demos',
+      description:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Justo vestibulum urna sit est pellentesque tincidunt nisi, enim tincidunt.',
+      cta: {
+        url: 'https://github.com/Qiskit/qiskit/blob/master/CODE_OF_CONDUCT.md',
+        label: 'Lorem ipsum'
+      }
+    }
+  ]
 }
 </script>
+
+<style lang="scss" scoped>
+.textbook-page {
+  &__section {
+    @include contained();
+    margin-bottom: $layout-03;
+    margin-top: $layout-05;
+  }
+}
+</style>

--- a/pages/textbook-demo/index.vue
+++ b/pages/textbook-demo/index.vue
@@ -29,7 +29,7 @@ export default class TextbookPage extends QiskitPage {
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Molestie ipsum eget id id hendrerit quis euismod eleifend urna.',
       cta: {
         url:
-          'https://calendar.google.com/calendar/ical/c12g9fqo0mkvp9bo26dhm3u1rs%40group.calendar.google.com/public/basic.ics',
+          '#',
         label: 'Lorem ipsum'
       }
     },
@@ -38,7 +38,7 @@ export default class TextbookPage extends QiskitPage {
       description:
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Risus morbi sodales euismod faucibus ut turpis sem.',
       cta: {
-        url: 'https://airtable.com/shrB5wy8SCaMMtKop',
+        url: '#',
         label: 'Lorem ipsum'
       }
     },
@@ -47,7 +47,7 @@ export default class TextbookPage extends QiskitPage {
       description:
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mollis turpis pulvinar morbi consequat pulvinar sit.',
       cta: {
-        url: 'https://qiskit.org/learn',
+        url: '#',
         label: 'Lorem ipsum'
       }
     },
@@ -56,7 +56,7 @@ export default class TextbookPage extends QiskitPage {
       description:
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Justo vestibulum urna sit est pellentesque tincidunt nisi, enim tincidunt.',
       cta: {
-        url: 'https://github.com/Qiskit/qiskit/blob/master/CODE_OF_CONDUCT.md',
+        url: '#',
         label: 'Lorem ipsum'
       }
     }


### PR DESCRIPTION
This PR creates the "Helpful Resources" section for the new Textbook landing page.

**Note:** This section currently contains placeholder content. When the final content is ready, it will be updated in #1448. The same goes for the "segments" for link events tracking.

**Note 2:** Please wait until #1446 is merged before merging this PR.

<img width="1189" alt="Screenshot 2021-02-17 at 14 28 45" src="https://user-images.githubusercontent.com/22047320/108210965-7330a680-712c-11eb-921a-c6999d914e34.png">

---

Closes #1447