### PR TITLE
feat: check Seminar Series event's values

### DIFF
--- a/content/events/past-community-events.json
+++ b/content/events/past-community-events.json
@@ -1,24 +1,97 @@
 [
   {
-    "title": "Boson Sampling and Quantum Simulations in Circuit QED",
+    "title": "Non-Equilibrium Phenomena of Ultracold Quantum Gasses Trapped in Optical Lattice Potentials",
     "types": [
       "Talks"
     ],
-    "image": "https://dl.airtable.com/.attachmentThumbnails/1e1b501e69679ad462f7634891255817/f394afe9",
+    "image": "https://dl.airtable.com/.attachmentThumbnails/5da31d9215a09a1b7f00ec10aca693b9/5d695bd4",
     "location": "YouTube",
     "region": "Online",
-    "date": "January 15, 2021",
-    "to": "https://youtu.be/miK5y8BYlwQ"
+    "date": "February 26, 2021",
+    "to": "https://youtu.be/ZAo7_ilglzk"
   },
   {
-    "title": "Quantum Engineering of Superconducting Qubits | Seminar Series with Will Oliver",
+    "title": "Qiskit Hackathon @ Northwestern",
+    "types": [
+      "Hackathon"
+    ],
+    "image": "https://dl.airtable.com/.attachmentThumbnails/6e5c1b539c66afa0da463b388748539d/66d0fcb3",
+    "location": "Northwestern",
+    "region": "Americas",
+    "date": "February 25-26, 2021"
+  },
+  {
+    "title": "Quantum Tech Communities: From Open Source to a Global Community",
     "types": [
       "Talks"
     ],
-    "image": "https://dl.airtable.com/.attachmentThumbnails/f0daa554e731da5f87d13511546f3c77/6caa60ee",
+    "image": "https://dl.airtable.com/.attachmentThumbnails/d7c30417ba58e658cf915c112e40e2b8/75fca1eb",
     "location": "YouTube",
     "region": "Online",
-    "date": "December 18, 2020",
-    "to": "https://youtu.be/aGAb-GbrvMU"
+    "date": "February 19, 2021",
+    "to": "https://youtu.be/eDmIbJ_7i3c"
+  },
+  {
+    "title": "Qiskit Hackathon Korea",
+    "types": [
+      "Hackathon"
+    ],
+    "image": "https://dl.airtable.com/.attachmentThumbnails/9691363014f7ff02bc9b803c1bce1772/69cb0479",
+    "location": "Korea",
+    "region": "Asia Pacific",
+    "date": "February 18-19, 2021",
+    "to": "https://ibm.biz/qhack-korea-2021"
+  },
+  {
+    "title": "Qiskit Hackathon @ NYU",
+    "types": [
+      "Hackathon"
+    ],
+    "image": "https://dl.airtable.com/.attachmentThumbnails/61994381e16351e2a3c5f0e293390b59/9dae0f09",
+    "location": "NYU",
+    "region": "Americas",
+    "date": "February 12-13, 2021"
+  },
+  {
+    "title": "Quantum Mechanics Isn’t Weird, We’re Just Too Big",
+    "types": [
+      "Talks"
+    ],
+    "image": "https://dl.airtable.com/.attachmentThumbnails/5eed00e8c23484e96ea1be6710146d24/b0b5d1ab",
+    "location": "YouTube",
+    "region": "Online",
+    "date": "February 12, 2021",
+    "to": "https://youtu.be/q1O11kP6x1k"
+  },
+  {
+    "title": "Qiskit Hackathon @ McMaster University",
+    "types": [
+      "Hackathon"
+    ],
+    "image": "https://dl.airtable.com/.attachmentThumbnails/da755eac58a003a1ce054470b19bccf8/209a594e",
+    "location": "McMaster University",
+    "region": "Americas",
+    "date": "February 5-7, 2021"
+  },
+  {
+    "title": "Q&A Panel",
+    "types": [
+      "Talks"
+    ],
+    "image": "https://dl.airtable.com/.attachmentThumbnails/924b5c101e477a709cc260910cb76f84/9a4af1ff",
+    "location": "YouTube",
+    "region": "Online",
+    "date": "February 5, 2021",
+    "to": "https://youtu.be/rQp_NZMLNRk"
+  },
+  {
+    "title": "Qiskit Hackathon @ MIT",
+    "types": [
+      "Hackathon"
+    ],
+    "image": "https://dl.airtable.com/.attachmentThumbnails/22ce9a8acb5781f8991d908fb7c247d2/b666a5e3",
+    "location": "MIT",
+    "region": "Americas",
+    "date": "January 30-31, 2021"
   }
 ]

--- a/content/events/past-seminar-series-events.json
+++ b/content/events/past-seminar-series-events.json
@@ -1,5 +1,59 @@
 [
   {
+    "date": "February 26, 2021",
+    "image": "https://dl.airtable.com/.attachmentThumbnails/5da31d9215a09a1b7f00ec10aca693b9/5d695bd4",
+    "institution": "Berkeley",
+    "location": "YouTube",
+    "speaker": "Charles D. Brown",
+    "title": "Non-Equilibrium Phenomena of Ultracold Quantum Gasses Trapped in Optical Lattice Potentials",
+    "to": "https://youtu.be/ZAo7_ilglzk"
+  },
+  {
+    "date": "February 19, 2021",
+    "image": "https://dl.airtable.com/.attachmentThumbnails/d7c30417ba58e658cf915c112e40e2b8/75fca1eb",
+    "institution": "OneQuantum",
+    "location": "YouTube",
+    "speaker": "Farai Mazhandu",
+    "title": "Quantum Tech Communities: From Open Source to a Global Community",
+    "to": "https://youtu.be/eDmIbJ_7i3c"
+  },
+  {
+    "date": "February 12, 2021",
+    "image": "https://dl.airtable.com/.attachmentThumbnails/5eed00e8c23484e96ea1be6710146d24/b0b5d1ab",
+    "institution": "",
+    "location": "YouTube",
+    "speaker": "Philip Ball",
+    "title": "Quantum Mechanics Isn’t Weird, We’re Just Too Big",
+    "to": "https://youtu.be/q1O11kP6x1k"
+  },
+  {
+    "date": "February 5, 2021",
+    "image": "https://dl.airtable.com/.attachmentThumbnails/924b5c101e477a709cc260910cb76f84/9a4af1ff",
+    "institution": "Various",
+    "location": "YouTube",
+    "speaker": "Antonio Mezzacapo, Guillaume Verdon & more",
+    "title": "Q&A Panel",
+    "to": "https://youtu.be/rQp_NZMLNRk"
+  },
+  {
+    "date": "January 29, 2021",
+    "image": "https://dl.airtable.com/.attachmentThumbnails/b81d53d95b7a02f156dedfa6b00e5c7a/3c652699",
+    "institution": "UCLA",
+    "location": "YouTube",
+    "speaker": "Jason Cong",
+    "title": "Compilation for Quantum Computing: Gap Analysis and Optimal Solution",
+    "to": "https://youtu.be/Z9R9a3hku9Y"
+  },
+  {
+    "date": "January 22, 2021",
+    "image": "https://dl.airtable.com/.attachmentThumbnails/49a702d8b04f71c43f0d4e08ac5cb1db/634f7076",
+    "institution": "Harvard University",
+    "location": "YouTube",
+    "speaker": "Alán Aspuru-Guzik",
+    "title": "What to do with a near-term quantum computer?",
+    "to": "https://youtu.be/I6_tHLAeBsI"
+  },
+  {
     "date": "January 15, 2021",
     "image": "https://dl.airtable.com/.attachmentThumbnails/1e1b501e69679ad462f7634891255817/f394afe9",
     "institution": "Yale University",

--- a/content/events/upcoming-community-events.json
+++ b/content/events/upcoming-community-events.json
@@ -1,64 +1,45 @@
 [
   {
-    "title": "What to do with a near-term quantum computer?",
+    "title": "Improving the Quality Factor of Aluminum 3D Cavities",
     "types": [
       "Talks"
     ],
-    "image": "https://dl.airtable.com/.attachmentThumbnails/49a702d8b04f71c43f0d4e08ac5cb1db/634f7076",
+    "image": "https://dl.airtable.com/.attachmentThumbnails/0ac9c845268495a81e37568aeaca0d13/33a7fe60",
     "location": "YouTube",
     "region": "Online",
-    "date": "January 22, 2021",
-    "to": "https://youtu.be/I6_tHLAeBsI"
+    "date": "March 5, 2021",
+    "to": "https://youtu.be/fTdZlpgpkEQ"
   },
   {
-    "title": "Compilation for Quantum Computing: Gap Analysis and Optimal Solution",
+    "title": "Finite-Temperature Dynamics of Spin Systems on Near-Term Quantum Hardware",
     "types": [
       "Talks"
     ],
-    "image": "https://dl.airtable.com/.attachmentThumbnails/b81d53d95b7a02f156dedfa6b00e5c7a/3c652699",
+    "image": "https://dl.airtable.com/.attachmentThumbnails/b52731172b8c857241dba13b9638edeb/cfd1e6a3",
     "location": "YouTube",
     "region": "Online",
-    "date": "January 29, 2021",
-    "to": "https://youtu.be/Z9R9a3hku9Y"
+    "date": "March 12, 2021",
+    "to": "https://youtu.be/INVFwcbSq5s"
   },
   {
-    "title": "Qiskit Hackathon @ MIT",
+    "title": "NO SHOW - Due to March Meeting",
     "types": [
-      "Hackathon"
-    ],
-    "image": "https://dl.airtable.com/.attachmentThumbnails/22ce9a8acb5781f8991d908fb7c247d2/b666a5e3",
-    "location": "MIT",
-    "region": "Americas",
-    "date": "January 30-31, 2021"
-  },
-  {
-    "title": "Qiskit Hackathon @ McMaster University",
-    "types": [
-      "Hackathon"
-    ],
-    "image": "https://dl.airtable.com/.attachmentThumbnails/da755eac58a003a1ce054470b19bccf8/209a594e",
-    "location": "McMaster University",
-    "region": "Americas",
-    "date": "February 5-7, 2021"
-  },
-  {
-    "title": "Qiskit Hackathon @ NYU",
-    "types": [
-      "Hackathon"
-    ],
-    "image": "https://dl.airtable.com/.attachmentThumbnails/61994381e16351e2a3c5f0e293390b59/9dae0f09",
-    "location": "NYU",
-    "region": "Americas",
-    "date": "February 12-13, 2021"
-  },
-  {
-    "title": "Qiskit Hackathon Korea",
-    "types": [
-      "Hackathon"
+      "Talks"
     ],
     "image": "/images/events/no-picture.jpg",
-    "location": "Korea",
-    "region": "Asia Pacific",
-    "date": "February 18-19, 2021"
+    "location": "YouTube",
+    "region": "Online",
+    "date": "March 19, 2021"
+  },
+  {
+    "title": "Seminar Series with Daniel Campbell",
+    "types": [
+      "Talks"
+    ],
+    "image": "https://dl.airtable.com/.attachmentThumbnails/b90e7ae45553615649fc1d72c2d6688e/78829439",
+    "location": "YouTube",
+    "region": "Online",
+    "date": "March 26, 2021",
+    "to": "https://youtu.be/EwBHSaJgsGY"
   }
 ]

--- a/content/events/upcoming-seminar-series-events.json
+++ b/content/events/upcoming-seminar-series-events.json
@@ -1,20 +1,29 @@
 [
   {
-    "date": "January 22, 2021",
-    "image": "https://dl.airtable.com/.attachmentThumbnails/49a702d8b04f71c43f0d4e08ac5cb1db/634f7076",
-    "institution": "Harvard University",
+    "date": "March 5, 2021",
+    "image": "https://dl.airtable.com/.attachmentThumbnails/0ac9c845268495a81e37568aeaca0d13/33a7fe60",
+    "institution": "Chalmers",
     "location": "YouTube",
-    "speaker": "Alán Aspuru-Guzik",
-    "title": "What to do with a near-term quantum computer?",
-    "to": "https://youtu.be/I6_tHLAeBsI"
+    "speaker": "Marina Kudra",
+    "title": "Improving the Quality Factor of Aluminum 3D Cavities",
+    "to": "https://youtu.be/fTdZlpgpkEQ"
   },
   {
-    "date": "January 29, 2021",
-    "image": "https://dl.airtable.com/.attachmentThumbnails/b81d53d95b7a02f156dedfa6b00e5c7a/3c652699",
-    "institution": "UCLA",
+    "date": "March 12, 2021",
+    "image": "https://dl.airtable.com/.attachmentThumbnails/b52731172b8c857241dba13b9638edeb/cfd1e6a3",
+    "institution": "Caltech",
     "location": "YouTube",
-    "speaker": "Jason Cong",
-    "title": "Compilation for Quantum Computing: Gap Analysis and Optimal Solution",
-    "to": "https://youtu.be/Z9R9a3hku9Y"
+    "speaker": "Austin Minnich",
+    "title": "Finite-Temperature Dynamics of Spin Systems on Near-Term Quantum Hardware",
+    "to": "https://youtu.be/INVFwcbSq5s"
+  },
+  {
+    "date": "March 26, 2021",
+    "image": "https://dl.airtable.com/.attachmentThumbnails/b90e7ae45553615649fc1d72c2d6688e/78829439",
+    "institution": "MIT",
+    "location": "YouTube",
+    "speaker": "Daniel Campbell",
+    "title": "Seminar Series with Daniel Campbell",
+    "to": "https://youtu.be/EwBHSaJgsGY"
   }
 ]

--- a/hooks/event-conversion-utils.ts
+++ b/hooks/event-conversion-utils.ts
@@ -81,7 +81,10 @@ async function fetchSeminarSeriesEvents (apiKey: string, { days }: { days: any }
   await getEventsQuery(apiKey, days, 'Seminar Series Website DO NOT MODIFY', [`{${showOnSeminarSeriesPage}}`]).eachPage((records, nextPage) => {
     for (const record of records) {
       const seminarSeriesEvent = convertToSeminarSeriesEvent(record)
-      seminarSeriesEvents.push(seminarSeriesEvent)
+
+      if (seminarSeriesEvent !== null) {
+        seminarSeriesEvents.push(seminarSeriesEvent)
+      }
     }
     nextPage()
   })
@@ -101,8 +104,8 @@ function convertToCommunityEvent (record: any): CommunityEvent {
   }
 }
 
-function convertToSeminarSeriesEvent (record: any): SeminarSeriesEvent {
-  return {
+function convertToSeminarSeriesEvent (record: any): SeminarSeriesEvent|null {
+  const seminarSeriesEvent = {
     date: formatDates(...getDates(record)),
     image: getImage(record),
     institution: getInstitution(record),
@@ -111,6 +114,14 @@ function convertToSeminarSeriesEvent (record: any): SeminarSeriesEvent {
     title: getName(record),
     to: getWebsite(record)
   }
+
+  for (const value of Object.values(seminarSeriesEvent)) {
+    if (typeof (value) === 'undefined') {
+      return null
+    }
+  }
+
+  return seminarSeriesEvent
 }
 
 function getInstitution (record: any): string {


### PR DESCRIPTION
Check the Airtable Seminar Series Events entries to ensure that only those with all the values are included in the content JSON files.

This is needed to avoid trying to perform invalid operations on unexpected data structures (i.e. with missing data) that can cause runtime issues.