### PR TITLE
feat: create "External Recommended Readings" section

### DIFF
--- a/components/textbook-demo/ExternalRecommendedReadings.vue
+++ b/components/textbook-demo/ExternalRecommendedReadings.vue
@@ -29,14 +29,9 @@ export default class ExternalRecommendedReadings extends Vue {
 
 .external-recommended-readings {
   &__headline {
-    @include type-style("productive-heading-01");
+    @include type-style("expressive-heading-04");
     color: $cool-gray-80;
-    margin-bottom: $spacing-05;
-
-    @include mq($until: x-large) {
-      @include type-style("expressive-heading-04");
-      margin-bottom: $spacing-06;
-    }
+    margin-bottom: $spacing-06;
   }
 
   &__link {

--- a/components/textbook-demo/ExternalRecommendedReadings.vue
+++ b/components/textbook-demo/ExternalRecommendedReadings.vue
@@ -1,12 +1,12 @@
 <template>
-  <section class="learning-path-external-recommended-readings">
-    <h2 class="learning-path-external-recommended-readings__headline">
+  <section class="external-recommended-readings">
+    <h2 class="external-recommended-readings__headline">
       External recommended readings
     </h2>
     <AppLink
       v-for="link in links"
       :key="link"
-      class="learning-path-external-recommended-readings__link"
+      class="external-recommended-readings__link"
       :url="link"
     >
       {{ link }}
@@ -19,7 +19,7 @@ import Vue from 'vue'
 import { Component, Prop } from 'vue-property-decorator'
 
 @Component
-export default class LearningPathExternalRecommendedReadings extends Vue {
+export default class ExternalRecommendedReadings extends Vue {
   @Prop({ type: Array, required: true }) links!: string[]
 }
 </script>
@@ -27,7 +27,7 @@ export default class LearningPathExternalRecommendedReadings extends Vue {
 <style lang="scss" scoped>
 @import "~carbon-components/scss/globals/scss/typography";
 
-.learning-path-external-recommended-readings {
+.external-recommended-readings {
   &__headline {
     @include type-style("productive-heading-01");
     color: $cool-gray-80;

--- a/components/textbook-demo/ExternalRecommendedReadings.vue
+++ b/components/textbook-demo/ExternalRecommendedReadings.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="external-recommended-readings">
-    <h2 class="external-recommended-readings__headline">
+    <h2 class="copy__title">
       External recommended readings
     </h2>
     <AppLink
@@ -25,15 +25,9 @@ export default class ExternalRecommendedReadings extends Vue {
 </script>
 
 <style lang="scss" scoped>
-@import "~carbon-components/scss/globals/scss/typography";
+@import '~/assets/scss/blocks/copy.scss';
 
 .external-recommended-readings {
-  &__headline {
-    @include type-style("expressive-heading-04");
-    color: $cool-gray-80;
-    margin-bottom: $spacing-06;
-  }
-
   &__link {
     display: block;
     margin-bottom: $spacing-01;

--- a/components/textbook-demo/LearningPathExternalRecommendedReadings.vue
+++ b/components/textbook-demo/LearningPathExternalRecommendedReadings.vue
@@ -16,14 +16,11 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import { Component } from 'vue-property-decorator'
+import { Component, Prop } from 'vue-property-decorator'
 
 @Component
 export default class LearningPathExternalRecommendedReadings extends Vue {
-  links = [
-    'https://math.mit.edu/~gs/linearalgebra/',
-    'https://machinelearningmastery.com/gentle-introduction-linear-algebra/'
-  ]
+  @Prop({ type: Array, required: true }) links!: string[]
 }
 </script>
 

--- a/components/textbook-demo/LearningPathExternalRecommendedReadings.vue
+++ b/components/textbook-demo/LearningPathExternalRecommendedReadings.vue
@@ -3,6 +3,14 @@
     <h2 class="learning-path-external-recommended-readings__headline">
       External recommended readings
     </h2>
+    <AppLink
+      v-for="link in links"
+      :key="link"
+      class="learning-path-external-recommended-readings__link"
+      :url="link"
+    >
+      {{ link }}
+    </AppLink>
   </section>
 </template>
 
@@ -11,7 +19,12 @@ import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
 
 @Component
-export default class LearningPathExternalRecommendedReadings extends Vue {}
+export default class LearningPathExternalRecommendedReadings extends Vue {
+  links = [
+    'https://math.mit.edu/~gs/linearalgebra/',
+    'https://machinelearningmastery.com/gentle-introduction-linear-algebra/'
+  ]
+}
 </script>
 
 <style lang="scss" scoped>
@@ -21,10 +34,18 @@ export default class LearningPathExternalRecommendedReadings extends Vue {}
   &__headline {
     @include type-style("productive-heading-01");
     color: $cool-gray-80;
+    margin-bottom: $spacing-05;
 
     @include mq($until: x-large) {
       @include type-style("expressive-heading-04");
+      margin-bottom: $spacing-06;
     }
+  }
+
+  &__link {
+    display: block;
+    margin-bottom: $spacing-01;
+    width: fit-content;
   }
 }
 </style>

--- a/components/textbook-demo/LearningPathExternalRecommendedReadings.vue
+++ b/components/textbook-demo/LearningPathExternalRecommendedReadings.vue
@@ -1,0 +1,30 @@
+<template>
+  <section class="learning-path-external-recommended-readings">
+    <h2 class="learning-path-external-recommended-readings__headline">
+      External recommended readings
+    </h2>
+  </section>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { Component } from 'vue-property-decorator'
+
+@Component
+export default class LearningPathExternalRecommendedReadings extends Vue {}
+</script>
+
+<style lang="scss" scoped>
+@import "~carbon-components/scss/globals/scss/typography";
+
+.learning-path-external-recommended-readings {
+  &__headline {
+    @include type-style("productive-heading-01");
+    color: $cool-gray-80;
+
+    @include mq($until: x-large) {
+      @include type-style("expressive-heading-04");
+    }
+  }
+}
+</style>

--- a/pages/textbook-demo/learning-paths/introduction-course.vue
+++ b/pages/textbook-demo/learning-paths/introduction-course.vue
@@ -1,6 +1,6 @@
 <template>
   <main class="learning-path-introduction-course-page">
-    <LearningPathExternalRecommendedReadings class="learning-path-introduction-course-page__section" />
+    <LearningPathExternalRecommendedReadings class="learning-path-introduction-course-page__section" :links="links" />
   </main>
 </template>
 
@@ -17,6 +17,10 @@ import QiskitPage from '~/components/logic/QiskitPage.vue'
 })
 export default class LearningPathIntroductionCoursePage extends QiskitPage {
   routeName: string = 'introduction-course'
+  links = [
+    'https://math.mit.edu/~gs/linearalgebra/',
+    'https://machinelearningmastery.com/gentle-introduction-linear-algebra/'
+  ]
 }
 </script>
 

--- a/pages/textbook-demo/learning-paths/introduction-course.vue
+++ b/pages/textbook-demo/learning-paths/introduction-course.vue
@@ -1,0 +1,31 @@
+<template>
+  <main class="learning-path-introduction-course-page">
+    <LearningPathExternalRecommendedReadings class="learning-path-introduction-course-page__section" />
+  </main>
+</template>
+
+<script lang="ts">
+import { Component } from 'vue-property-decorator'
+import QiskitPage from '~/components/logic/QiskitPage.vue'
+
+@Component({
+  head () {
+    return {
+      title: 'Introduction course'
+    }
+  }
+})
+export default class LearningPathIntroductionCoursePage extends QiskitPage {
+  routeName: string = 'introduction-course'
+}
+</script>
+
+<style lang="scss" scoped>
+.learning-path-introduction-course-page {
+  &__section {
+    @include contained();
+    margin-bottom: $layout-03;
+    margin-top: $layout-05;
+  }
+}
+</style>

--- a/pages/textbook-demo/learning-paths/introduction-course.vue
+++ b/pages/textbook-demo/learning-paths/introduction-course.vue
@@ -1,6 +1,6 @@
 <template>
-  <main class="learning-path-introduction-course-page">
-    <ExternalRecommendedReadings class="learning-path-introduction-course-page__section" :links="links" />
+  <main class="introduction-course-page">
+    <ExternalRecommendedReadings class="introduction-course-page__section" :links="links" />
   </main>
 </template>
 
@@ -15,7 +15,7 @@ import QiskitPage from '~/components/logic/QiskitPage.vue'
     }
   }
 })
-export default class LearningPathIntroductionCoursePage extends QiskitPage {
+export default class IntroductionCoursePage extends QiskitPage {
   routeName: string = 'introduction-course'
   links = [
     'https://math.mit.edu/~gs/linearalgebra/',
@@ -25,7 +25,7 @@ export default class LearningPathIntroductionCoursePage extends QiskitPage {
 </script>
 
 <style lang="scss" scoped>
-.learning-path-introduction-course-page {
+.introduction-course-page {
   &__section {
     @include contained();
     margin-bottom: $layout-03;

--- a/pages/textbook-demo/learning-paths/introduction-course.vue
+++ b/pages/textbook-demo/learning-paths/introduction-course.vue
@@ -1,6 +1,6 @@
 <template>
   <main class="learning-path-introduction-course-page">
-    <LearningPathExternalRecommendedReadings class="learning-path-introduction-course-page__section" :links="links" />
+    <ExternalRecommendedReadings class="learning-path-introduction-course-page__section" :links="links" />
   </main>
 </template>
 


### PR DESCRIPTION

This PR creates the **External Recommended Readings** section for the new Learning Path landing page.

<img width="1105" alt="Screenshot 2021-03-08 at 13 24 34" src="https://user-images.githubusercontent.com/22047320/110321208-a373b280-8011-11eb-920c-5681cf5d151d.png">

**Note:** Please first check #1514 and merge it into the feature branch. Then rebase this PR before merging.

---

Closes #1502