### PR TITLE
feat: emit "mouseenter" event

### DIFF
--- a/components/ui/BasicLink.vue
+++ b/components/ui/BasicLink.vue
@@ -7,6 +7,7 @@
     :rel="isExternal && 'noopener'"
     :target="isExternal && '_blank'"
     @click="segment && $trackClickEvent(segment)"
+    @mouseenter="$emit('mouseenter')"
   >
     <slot />
   </component>


### PR DESCRIPTION
Propagate emission of the _mouseenter_ event to allow for more mouse interactions while still leveraging the tracking functionalities of this component.