### PR TITLE
Remove @abdonrd as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-* @delapuente @y4izus @techtolentino @korgan00 @eddybrando @abdonrd
+* @delapuente @y4izus @techtolentino @korgan00 @eddybrando
 content/advocates/*   @lerongil @aasfaw
 content/events/*      @justjosie @KallieFerguson @delapuente @lerongil @aasfaw


### PR DESCRIPTION
I still watch the repository (so I get GitHub notifications from each PR).
But since I'm not working daily on qiskit.org, I avoid receiving emails from each PR.