### PR TITLE
feat: align `AppIntroductoryContent`'s layout

### DIFF
--- a/components/ui/AppIntroductoryContent.vue
+++ b/components/ui/AppIntroductoryContent.vue
@@ -39,6 +39,11 @@ export default class AppIntroductoryContent extends Vue {
   grid-template-areas: 'overview main main main';
   grid-template-columns: repeat(4, 1fr);
 
+  &_narrow {
+    grid-template-areas: 'overview main';
+    grid-template-columns: (4.5 * $column-size-large) 1fr;
+  }
+
   @include mq($until: large) {
     display: block;
   }
@@ -65,15 +70,6 @@ export default class AppIntroductoryContent extends Vue {
   &__layout {
     grid-area: main;
     width: 100%;
-  }
-
-  &_narrow {
-    grid-template-areas: 'overview main';
-    grid-template-columns: (4.5 * $column-size-large) 1fr;
-
-    @include mq($until: large) {
-      display: block;
-    }
   }
 }
 </style>

--- a/components/ui/AppIntroductoryContent.vue
+++ b/components/ui/AppIntroductoryContent.vue
@@ -1,5 +1,5 @@
 <template>
-  <article class="app-introductory-content">
+  <article class="app-introductory-content" :class="{ 'app-introductory-content_narrow': narrow }">
     <div class="app-introductory-content__overview">
       <slot name="title" />
       <p class="app-introductory-content__description">
@@ -11,7 +11,7 @@
         kind="ghost"
       />
     </div>
-    <div class="app-introductory-content__layout">
+    <div class="app-introductory-content__main">
       <slot />
     </div>
   </article>
@@ -26,6 +26,7 @@ import { NavLink } from '~/constants/menuLinks'
 export default class AppIntroductoryContent extends Vue {
   @Prop(String) description!: string
   @Prop(Object) link!: NavLink
+  @Prop({ type: Boolean, default: false }) narrow!: boolean
 }
 </script>
 
@@ -33,19 +34,20 @@ export default class AppIntroductoryContent extends Vue {
 @import '~/assets/scss/blocks/copy.scss';
 
 .app-introductory-content {
-  display: flex;
+  display: grid;
+  column-gap: 2rem;
+  grid-template-areas: 'overview main main main';
+  grid-template-columns: repeat(4, 1fr);
 
   @include mq($until: large) {
     display: block;
   }
 
   &__overview {
-    flex: 0 0 (4.5 * $column-size-large);
-    padding-right: $spacing-07;
+    grid-area: overview;
     margin-bottom: $layout-03;
 
     @include mq($until: large) {
-      padding-right: 0;
       display: block;
     }
   }
@@ -60,8 +62,23 @@ export default class AppIntroductoryContent extends Vue {
     }
   }
 
-  &__layout {
+  &__main {
+    grid-area: main;
     width: 100%;
+  }
+
+  &_narrow {
+    display: flex;
+
+    @include mq($until: large) {
+      display: block;
+    }
+
+    .app-introductory-content {
+      &__overview {
+        flex: 0 0 (4.5 * $column-size-large);
+      }
+    }
   }
 }
 </style>

--- a/components/ui/AppIntroductoryContent.vue
+++ b/components/ui/AppIntroductoryContent.vue
@@ -68,7 +68,7 @@ export default class AppIntroductoryContent extends Vue {
   }
 
   &_narrow {
-    grid-template-areas: 'overview main main main';
+    grid-template-areas: 'overview main';
     grid-template-columns: (4.5 * $column-size-large) 1fr;
 
     @include mq($until: large) {

--- a/components/ui/AppIntroductoryContent.vue
+++ b/components/ui/AppIntroductoryContent.vue
@@ -11,7 +11,7 @@
         kind="ghost"
       />
     </div>
-    <div class="app-introductory-content__main">
+    <div class="app-introductory-content__layout">
       <slot />
     </div>
   </article>
@@ -62,22 +62,17 @@ export default class AppIntroductoryContent extends Vue {
     }
   }
 
-  &__main {
+  &__layout {
     grid-area: main;
     width: 100%;
   }
 
   &_narrow {
-    display: flex;
+    grid-template-areas: 'overview main main main';
+    grid-template-columns: (4.5 * $column-size-large) 1fr;
 
     @include mq($until: large) {
       display: block;
-    }
-
-    .app-introductory-content {
-      &__overview {
-        flex: 0 0 (4.5 * $column-size-large);
-      }
     }
   }
 }

--- a/pages/overview.vue
+++ b/pages/overview.vue
@@ -39,6 +39,7 @@
           :title="section.title"
           :description="section.description"
           :link="section.link"
+          narrow
         >
           <template #title>
             <h2 class="copy__title">

--- a/pages/textbook-demo/index.vue
+++ b/pages/textbook-demo/index.vue
@@ -2,7 +2,7 @@
   <main class="textbook-demo-page">
     <TextbookDemoHeader />
     <StartLearningSection class="textbook-demo-page__section" />
-    <HelpfulResourcesSection
+    <AppHelpfulResourcesSection
       class="textbook-demo-page__section"
       :resources="helpfulResources"
     />


### PR DESCRIPTION
This PR creates two layouts for the `AppIntroductoryContent` component, which adapts depending on its context:

- **Full width** (default) now aligns with the general layout by reserving 1/4 of the horizontal space for the description text and 3/4 for the slot content
- **Narrow** (by passing the `narrow` prop), which is the layout currently being used in https://qiskit.org/overview/

---

Closes #1551 