### PR TITLE
Removes min size for accordion content

### DIFF
--- a/components/overview/ContentAccordion.vue
+++ b/components/overview/ContentAccordion.vue
@@ -102,7 +102,6 @@ export default class ContentAccordion extends Vue {
   }
 
   & .bx--accordion__content {
-    min-height: 30.5rem;
     padding: $spacing-06 $spacing-07;
     background-color: $cool-gray-10;
     color: $gray-80;


### PR DESCRIPTION
Right now the accordion component has min-size set to 30.5rem. The consequence is that when we have small content, we can see a bigger space between the link and the bottom of the accordion element:
<img width="476" alt="Captura de pantalla 2021-04-07 a las 10 51 18" src="https://user-images.githubusercontent.com/17231966/113838655-434a6a80-978f-11eb-9e04-43bdd1131b1f.png">

This PR removes that min-size, so the accordion size change following the content size:
 
<img width="466" alt="Captura de pantalla 2021-04-07 a las 10 53 21" src="https://user-images.githubusercontent.com/17231966/113838851-7a208080-978f-11eb-89ae-be34a71b6cb1.png">
