### PR TITLE
Modifies typography for review purpose starting with `display-01`

### DIFF
--- a/assets/scss/blocks/copy.scss
+++ b/assets/scss/blocks/copy.scss
@@ -2,7 +2,7 @@
 
 .copy {
   &__page-title {
-    @include type-style('expressive-heading-05', true);
+    @include type-style('display-01', true);
     color: $white-text-01;
     max-width: 10 * $column-size-large;
 
@@ -16,41 +16,51 @@
   }
 
   &__title {
-    @include type-style('expressive-heading-05');
+    @include type-style('expressive-heading-05', true);
     margin-bottom: $layout-03;
     color: $cool-gray-80;
     max-width: 8 * $column-size-large;
 
     @include mq($from: medium, $until: large) {
-      @include type-style('expressive-heading-03');
-      font-weight: 300;
       margin-bottom: $layout-01;
       max-width: 4 * $column-size-medium;
     }
 
     @include mq($until: medium) {
-      @include type-style('expressive-heading-03');
-      font-weight: 300;
-      max-width: 4 * $column-size-small;
       margin-bottom: $layout-01;
+      max-width: 4 * $column-size-small;
     }
   }
 
   &__subtitle {
-    @include type-style('productive-heading-02');
+    @include type-style('expressive-heading-04', true);
     color: $cool-gray-80;
     margin-bottom: $spacing-05;
 
     @include mq($from: medium, $until: large) {
-      @include type-style('productive-heading-01');
-      max-width: 4 * $column-size-medium;
       margin-bottom: $spacing-03;
+      max-width: 4 * $column-size-medium;
     }
 
     @include mq($until: medium) {
-      @include type-style('productive-heading-01');
-      max-width: 4 * $column-size-small;
       margin-bottom: $spacing-03;
+      max-width: 4 * $column-size-small;
+    }
+  }
+
+  &__h4 {
+    @include type-style('expressive-heading-03', true);
+    color: $cool-gray-80;
+    margin-bottom: $spacing-05;
+
+    @include mq($from: medium, $until: large) {
+      margin-bottom: $spacing-03;
+      max-width: 4 * $column-size-medium;
+    }
+
+    @include mq($until: medium) {
+      margin-bottom: $spacing-03;
+      max-width: 4 * $column-size-small;
     }
   }
 

--- a/components/blockbuster/BlockbusterExplanationSection.vue
+++ b/components/blockbuster/BlockbusterExplanationSection.vue
@@ -26,14 +26,14 @@
           <h3 class="copy__subtitle">
             FAQs
           </h3>
-          <h4 class="copy__subtitle">
+          <h4 class="copy__h4">
             Are quantum computers real?
           </h4>
           <p class="copy__paragraph">
             Yes. Quantum computers are very much real and they are already
             available today but not at Blockbuster.
           </p>
-          <h4 class="copy__subtitle">
+          <h4 class="copy__h4">
             Is Blockbuster real?
           </h4>
           <p class="copy__paragraph">
@@ -42,7 +42,7 @@
             travel (safely) to Bend, Oregon - we highly recommend stopping by
             for some real nostalgia.
           </p>
-          <h4 class="copy__subtitle">
+          <h4 class="copy__h4">
             Do quantum computers provide speedups over classical computers?
           </h4>
           <p class="copy__paragraph">
@@ -53,7 +53,7 @@
             others working hard to study the limitations and applications of the
             quantum systems that exist today.
           </p>
-          <h4 class="copy__subtitle">
+          <h4 class="copy__h4">
             What’s a qubit? What’s quantum advantage?
           </h4>
           <p class="copy__paragraph">

--- a/components/landing/TheHeroMoment/index.vue
+++ b/components/landing/TheHeroMoment/index.vue
@@ -113,7 +113,7 @@ export default class TheHeroMoment extends Vue {
   }
 
   &__title {
-    @include type-style('productive-heading-07');
+    @include type-style('display-01', true);
     color: $white-text-01;
     margin: 0 0 $layout-05;
     max-width: 6 * $column-size-large;
@@ -122,7 +122,6 @@ export default class TheHeroMoment extends Vue {
     pointer-events: auto;
 
     @include mq($from: medium, $until: large) {
-      @include type-style('productive-heading-06');
       // Notice the difference with the small version. This space is much more
       // small since it is in the spacing scale.
       margin: 0 0 $spacing-03;
@@ -130,7 +129,6 @@ export default class TheHeroMoment extends Vue {
     }
 
     @include mq($until: medium) {
-      @include type-style('productive-heading-04');
       margin: 0 0 $layout-03;
       max-width: 4 * $column-size-medium;
     }


### PR DESCRIPTION
This PR is for review purpose, do not merge

This PR show how the typography will look like if we use:
- h1 = `display-01`
- h2 = `expressive-heading-05`
- h3 = `expressive-heading-04`
- h4 = `expressive-heading-03`

Have in mind that we didn't do the refactor yet, so, there are some `h*` that doesn't match the list below. To be sure you are watching the correct changes, take a look at:
- [Landing page](https://qiskitorg-git-fork-y4izus-yg-typography-h1-display-7a9827.vercel.app) : To see h1, h2, h3
- [Blockbuster page](https://qiskitorg-git-fork-y4izus-yg-typography-h1-display-7a9827.vercel.app/blockbuster): It's the only page with h1, h2, h3, **h4**
- [Overview page](https://qiskitorg-git-fork-y4izus-yg-typography-h1-display-7a9827.vercel.app/overview): To see h1, h2, h3

Also note that the PR uses the automatic responsive sizes of the carbon typography.