### PR TITLE
Markdown changed to yaml

### DIFF
--- a/new-content/events/summer-school-2021.yaml
+++ b/new-content/events/summer-school-2021.yaml
@@ -1,4 +1,3 @@
----
 metadata:
   title: 'Qiskit Global Summer School 2021'
   description: 'The Qiskit Global Summer School 2021 is a two-week intensive summer school designed to empower the next generation of quantum researchers and developers with the skills and know-how to explore quantum applications on their own'
@@ -257,4 +256,3 @@ faq:
     answer: 'All of our announced <a href="" target="_blank" style="cursor:pointer; text-decoration: none; color: #0f62fe;">upcoming events are listed on qiskit.org</a>, which is continually updated as we roll out more events throughout the year. You can also <a href="" target="_blank" style="cursor:pointer; text-decoration: none; color: #0f62fe;">follow Qiskit on Twitter</a> for the latest announcements on new and upcoming events!'
   - question: 'Still have more questions?'
     answer: 'For any questions about the summer school, please submit your questions using the form below. For all other enquiries, feel free to email us directly at <a href="mailto:qiskit.events@us.ibm.com" target="_blank" style="cursor:pointer; text-decoration: none; color: #0f62fe;">qiskit.events@us.ibm.com</a>.'
----

--- a/new-content/events/summer-school-2021.yaml
+++ b/new-content/events/summer-school-2021.yaml
@@ -256,4 +256,3 @@ faq:
     answer: 'All of our announced <a href="" target="_blank" style="cursor:pointer; text-decoration: none; color: #0f62fe;">upcoming events are listed on qiskit.org</a>, which is continually updated as we roll out more events throughout the year. You can also <a href="" target="_blank" style="cursor:pointer; text-decoration: none; color: #0f62fe;">follow Qiskit on Twitter</a> for the latest announcements on new and upcoming events!'
   - question: 'Still have more questions?'
     answer: 'For any questions about the summer school, please submit your questions using the form below. For all other enquiries, feel free to email us directly at <a href="mailto:qiskit.events@us.ibm.com" target="_blank" style="cursor:pointer; text-decoration: none; color: #0f62fe;">qiskit.events@us.ibm.com</a>.'
-    

--- a/new-content/events/summer-school-2021.yaml
+++ b/new-content/events/summer-school-2021.yaml
@@ -256,3 +256,4 @@ faq:
     answer: 'All of our announced <a href="" target="_blank" style="cursor:pointer; text-decoration: none; color: #0f62fe;">upcoming events are listed on qiskit.org</a>, which is continually updated as we roll out more events throughout the year. You can also <a href="" target="_blank" style="cursor:pointer; text-decoration: none; color: #0f62fe;">follow Qiskit on Twitter</a> for the latest announcements on new and upcoming events!'
   - question: 'Still have more questions?'
     answer: 'For any questions about the summer school, please submit your questions using the form below. For all other enquiries, feel free to email us directly at <a href="mailto:qiskit.events@us.ibm.com" target="_blank" style="cursor:pointer; text-decoration: none; color: #0f62fe;">qiskit.events@us.ibm.com</a>.'
+    


### PR DESCRIPTION
We are only using the front-matter data of the markdown that is written in yaml.
To make the edition easier using GitHub editor and prevent mistakes, now the `.md` is `.yaml`. GitHub editor shows syntax coloring correctly.

Before:
![Captura de pantalla 2021-04-15 a las 10 20 38](https://user-images.githubusercontent.com/4138279/114837691-47503b00-9dd4-11eb-9db1-17b2574c4713.png)

After:
![Captura de pantalla 2021-04-15 a las 10 20 09](https://user-images.githubusercontent.com/4138279/114837708-4a4b2b80-9dd4-11eb-91d8-42cc732c4e4a.png)
