### PR TITLE
Modifies AppPageHeaderWithCard to pass description through slots

### DIFF
--- a/components/ui/AppPageHeaderWithCard.vue
+++ b/components/ui/AppPageHeaderWithCard.vue
@@ -8,12 +8,7 @@
               <slot name="title" />
             </h1>
             <div class="app-page-header__description">
-              <p
-                v-for="(paragraph, index) in description"
-                :key="index"
-                class="copy__paragraph"
-                v-text="paragraph"
-              />
+              <slot name="description" />
             </div>
           </div>
           <AppCta v-if="cta" v-bind="cta" />
@@ -43,7 +38,6 @@ import { GeneralLink } from '~/constants/appLinks'
 export default class AppPageHeaderWithCard extends Vue {
   @Prop({ type: String, required: true }) cardTitle!: string
   @Prop({ type: Object, required: true }) cta!: GeneralLink
-  @Prop({ type: Array, required: true }) description!: string[]
 }
 </script>
 

--- a/pages/events/physics-of-computation.vue
+++ b/pages/events/physics-of-computation.vue
@@ -1,7 +1,6 @@
 <template>
   <main class="physics-of-computation-page">
     <AppPageHeaderWithCard
-      :description="headerDescription"
       :cta="headerCTA"
       :card-title="headerCardTitle"
     >
@@ -9,6 +8,14 @@
         {{ headerPrimaryTitle }}
         <br>
         {{ headerSecondaryTitle }}
+      </template>
+      <template slot="description">
+        <p
+          v-for="(paragraph, index) in headerDescription"
+          :key="index"
+          class="copy__paragraph"
+          v-text="paragraph"
+        />
       </template>
       <template slot="card">
         <EventCard v-bind="headerCardContent" vertical-layout>

--- a/pages/events/seminar-series.vue
+++ b/pages/events/seminar-series.vue
@@ -1,8 +1,8 @@
 <template>
   <main class="event-page seminar-series-page">
     <AppPageHeaderWithCard
-      :description="headerDescription"
       :cta="headerCTA"
+      :card-title="headerCardTitle"
     >
       <template slot="title">
         {{ headerTitle }}

--- a/pages/events/seminar-series.vue
+++ b/pages/events/seminar-series.vue
@@ -3,10 +3,17 @@
     <AppPageHeaderWithCard
       :description="headerDescription"
       :cta="headerCTA"
-      :card-title="headerCardTitle"
     >
       <template slot="title">
         {{ headerTitle }}
+      </template>
+      <template slot="description">
+        <p
+          v-for="(paragraph, index) in headerDescription"
+          :key="index"
+          class="copy__paragraph"
+          v-text="paragraph"
+        />
       </template>
       <template slot="card">
         <EventCard v-bind="cardContent" vertical-layout>


### PR DESCRIPTION
With the recent changes on the Summer School page, we need to be more flexible with the header description to allow having links. With this PRs we will be able to do it by passing the description through slots