### PR TITLE
Reuse filters and results layout

### DIFF
--- a/components/advocates/MeetTheAdvocates.vue
+++ b/components/advocates/MeetTheAdvocates.vue
@@ -19,7 +19,7 @@
         </p>
       </div>
     </div>
-    <AppFiltersResultsLayout>
+    <AppFiltersResultsLayout class="meet-the-advocates__filters-result-section">
       <template slot="filters-on-m-l-screen">
         <AppFieldset :label="filter.label">
           <client-only>
@@ -126,5 +126,9 @@ export default class MeetTheAdvocates extends Vue {
   @include contained();
 
   margin-top: $layout-06;
+
+  &__filters-result-section {
+    margin-top: $layout-05;
+  }
 }
 </style>

--- a/components/learn/TheLearningResourceList.vue
+++ b/components/learn/TheLearningResourceList.vue
@@ -128,16 +128,6 @@ export default class TheLearningResourceList extends Vue {
       margin-bottom: $layout-01;
     }
   }
-
-  &__results {
-    & > * {
-      margin-bottom: $layout-02;
-
-      @include mq($until: large) {
-        margin-bottom: $layout-01;
-      }
-    }
-  }
 }
 </style>
 

--- a/components/learn/TheLearningResourceList.vue
+++ b/components/learn/TheLearningResourceList.vue
@@ -33,19 +33,29 @@
           />
         </cv-tabs>
       </client-only>
-      <div class="bx--row">
-        <fieldset class="bx--col-lg-4 bx--col-md-2 the-learning-resources-list__filter-time">
-          <legend
-            class="
-                the-learning-resources-list__filter-time-label
-                the-learning-resources-list__medium-large-only
-              "
-          >
-            Time to spend learning
-          </legend>
+
+      <AppFiltersResultsLayout>
+        <template slot="filters-on-m-l-screen">
+          <AppFieldset label="Time to spend learning">
+            <client-only>
+              <cv-radio-group vertical>
+                <cv-radio-button
+                  v-for="filter in asideFilters"
+                  :key="filter"
+                  name="aside-filter"
+                  :value="filter"
+                  :label="filter"
+                  :checked="filter === activeAsideFilter"
+                  :aria-checked="filter === activeAsideFilter"
+                  @change="selectAsideFilter(filter)"
+                />
+              </cv-radio-group>
+            </client-only>
+          </AppFieldset>
+        </template>
+        <template slot="filters-on-s-screen">
           <client-only>
             <cv-dropdown
-              class="the-learning-resources-list__small-only"
               :value="activeAsideFilter"
               @change="selectAsideFilter($event)"
             >
@@ -57,27 +67,12 @@
                 {{ filter }}
               </cv-dropdown-item>
             </cv-dropdown>
-            <cv-radio-group
-              class="the-learning-resources-list__medium-large-only"
-              vertical
-            >
-              <cv-radio-button
-                v-for="filter in asideFilters"
-                :key="filter"
-                name="aside-filter"
-                :value="filter"
-                :label="filter"
-                :checked="filter === activeAsideFilter"
-                :aria-checked="filter === activeAsideFilter"
-                @change="selectAsideFilter(filter)"
-              />
-            </cv-radio-group>
           </client-only>
-        </fieldset>
-        <section class="bx--col-lg-12 bx--col-md-6 the-learning-resources-list__results">
+        </template>
+        <template slot="results">
           <slot />
-        </section>
-      </div>
+        </template>
+      </AppFiltersResultsLayout>
     </div>
   </section>
 </template>
@@ -134,29 +129,6 @@ export default class TheLearningResourceList extends Vue {
     }
   }
 
-  &__filter-time {
-    @include mq($until: medium) {
-      margin-bottom: $layout-03;
-    }
-  }
-
-  &__filter-time-label {
-    margin-bottom: $layout-01;
-    white-space: nowrap;
-  }
-
-  &__small-only {
-    @include mq($from: medium) {
-      display: none;
-    }
-  }
-
-  &__medium-large-only {
-    @include mq($until: medium) {
-      display: none;
-    }
-  }
-
   &__results {
     & > * {
       margin-bottom: $layout-02;
@@ -179,37 +151,35 @@ export default class TheLearningResourceList extends Vue {
  * and CSS specificity to override the internal CSS.
  */
 .the-learning-resources-list {
-  &__filter-time {
-    & .bx--dropdown,
-    & .bx--dropdown-item {
-      background-color: $background-color-white;
+  & .bx--dropdown,
+  & .bx--dropdown-item {
+    background-color: $background-color-white;
 
-        svg {
-          fill: $text-color;
-        }
-    }
+      svg {
+        fill: $text-color;
+      }
+  }
 
-    & .bx--dropdown-item:hover,
-    & .bx--dropdown--show-selected .bx--dropdown--selected:hover {
-      // To match default light theme UI hover, which is not among the Carbon
-      // palette. 🤦
-      background-color: #e5e5e5;
-    }
+  & .bx--dropdown-item:hover,
+  & .bx--dropdown--show-selected .bx--dropdown--selected:hover {
+    // To match default light theme UI hover, which is not among the Carbon
+    // palette. 🤦
+    background-color: #e5e5e5;
+  }
 
-    & .bx--dropdown-link,
-    & .bx--dropdown-text {
-      color: $text-color;
-      border-top-color: #dde1e6;
-    }
+  & .bx--dropdown-link,
+  & .bx--dropdown-text {
+    color: $text-color;
+    border-top-color: #dde1e6;
+  }
 
-    & .bx--dropdown-link:hover {
-      border-bottom-color: #dde1e6;
-    }
+  & .bx--dropdown-link:hover {
+    border-bottom-color: #dde1e6;
+  }
 
-    & .bx--dropdown--show-selected .bx--dropdown--selected .bx--dropdown-link {
-      border-top-color: #dde1e6;
-      border-bottom-color: #dde1e6;
-    }
+  & .bx--dropdown--show-selected .bx--dropdown--selected .bx--dropdown-link {
+    border-top-color: #dde1e6;
+    border-bottom-color: #dde1e6;
   }
 
   &__filter-level {

--- a/components/ui/AppFiltersResultsLayout.vue
+++ b/components/ui/AppFiltersResultsLayout.vue
@@ -1,11 +1,9 @@
 <template>
   <div class="bx--row app-filters-results-layout">
-    <div
-      class="bx--col-lg-4 bx--col-md-2 bx--col-sm-0 app-filters-results-layout__filters"
-    >
+    <div class="bx--col-lg-4 bx--col-md-2 bx--col-sm-0">
       <slot name="filters-on-m-l-screen" />
     </div>
-    <div class="bx--col-sm-4 bx--col-md-0 app-filters-results-layout__filters">
+    <div class="bx--col-sm-4 bx--col-md-0">
       <slot name="filters-on-s-screen" />
     </div>
     <div class="bx--col-lg-12 bx--col-md-6 app-filters-results-layout__results">
@@ -24,12 +22,6 @@ export default class AppFiltersResultsLayouts extends Vue {}
 
 <style lang="scss">
 .app-filters-results-layout {
-  margin-top: $layout-05;
-
-  &__filters {
-    color: $text-color;
-  }
-
   &__results {
     @include mq($until: medium) {
       margin-top: $layout-04;

--- a/components/ui/AppFiltersResultsLayout.vue
+++ b/components/ui/AppFiltersResultsLayout.vue
@@ -29,4 +29,12 @@ export default class AppFiltersResultsLayouts extends Vue {}
     }
   }
 }
+
+.results-item {
+  margin-bottom: $layout-02;
+
+  @include mq($until: large) {
+    margin-bottom: $layout-01;
+  }
+}
 </style>

--- a/components/ui/AppFiltersResultsLayout.vue
+++ b/components/ui/AppFiltersResultsLayout.vue
@@ -28,13 +28,14 @@ export default class AppFiltersResultsLayouts extends Vue {}
       margin-top: $layout-04;
     }
   }
-}
 
-.results-item {
-  margin-bottom: $layout-02;
+  &__results-item {
+    margin-bottom: $layout-02;
 
-  @include mq($until: large) {
-    margin-bottom: $layout-01;
+    @include mq($until: large) {
+      margin-bottom: $layout-01;
+    }
   }
 }
+
 </style>

--- a/components/ui/AppFiltersResultsLayout.vue
+++ b/components/ui/AppFiltersResultsLayout.vue
@@ -6,7 +6,7 @@
     <div class="bx--col-sm-4 bx--col-md-0">
       <slot name="filters-on-s-screen" />
     </div>
-    <div class="bx--col-lg-12 bx--col-md-6 app-filters-results-layout__results-section">
+    <div class="bx--col-lg-12 bx--col-md-6 app-filters-results-layout__main-section">
       <slot name="results" />
       <slot name="extra-info" />
     </div>
@@ -23,7 +23,7 @@ export default class AppFiltersResultsLayouts extends Vue {}
 
 <style lang="scss">
 .app-filters-results-layout {
-  &__results-section {
+  &__main-section {
     @include mq($until: medium) {
       margin-top: $layout-04;
     }

--- a/components/ui/AppFiltersResultsLayout.vue
+++ b/components/ui/AppFiltersResultsLayout.vue
@@ -6,8 +6,9 @@
     <div class="bx--col-sm-4 bx--col-md-0">
       <slot name="filters-on-s-screen" />
     </div>
-    <div class="bx--col-lg-12 bx--col-md-6 app-filters-results-layout__results">
+    <div class="bx--col-lg-12 bx--col-md-6 app-filters-results-layout__results-section">
       <slot name="results" />
+      <slot name="extra-info" />
     </div>
   </div>
 </template>
@@ -22,7 +23,7 @@ export default class AppFiltersResultsLayouts extends Vue {}
 
 <style lang="scss">
 .app-filters-results-layout {
-  &__results {
+  &__results-section {
     @include mq($until: medium) {
       margin-top: $layout-04;
     }

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -68,7 +68,7 @@
             v-for="event in filteredEvents"
             v-else
             :key="`${event.title}-${event.place}-${event.date}`"
-            class="event-page__event-card"
+            class="results-item"
             :types="event.types"
             :title="event.title"
             :image="event.image"
@@ -198,14 +198,6 @@ export default class EventsPage extends QiskitPage {
 .event-page {
   &__container {
     @include contained();
-  }
-
-  &__event-card {
-    margin-bottom: $layout-02;
-
-    @include mq($until: large) {
-      margin-bottom: $layout-01;
-    }
   }
 
   &__time-filters {

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -68,7 +68,7 @@
             v-for="event in filteredEvents"
             v-else
             :key="`${event.title}-${event.place}-${event.date}`"
-            class="results-item"
+            class="app-filters-results-layout__results-item"
             :types="event.types"
             :title="event.title"
             :image="event.image"

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -21,7 +21,6 @@
           </cv-tabs>
         </client-only>
       </div>
-
       <AppFiltersResultsLayout>
         <template slot="filters-on-m-l-screen">
           <AppFieldset
@@ -56,29 +55,29 @@
           </div>
         </template>
         <template slot="results">
-          <div>
-            <AppCard
-              v-if="noEvents"
-              :image="emptyCard.img"
-              :title="emptyCard.title"
-            >
-              <div class="event-page__empty-card-description">
-                {{ emptyCard.description }}
-              </div>
-            </AppCard>
-            <EventCard
-              v-for="event in filteredEvents"
-              v-else
-              :key="`${event.title}-${event.place}-${event.date}`"
-              class="event-page__event-card"
-              :types="event.types"
-              :title="event.title"
-              :image="event.image"
-              :location="event.location"
-              :date="event.date"
-              :to="event.to"
-            />
-          </div>
+          <AppCard
+            v-if="noEvents"
+            :image="emptyCard.img"
+            :title="emptyCard.title"
+          >
+            <div class="event-page__empty-card-description">
+              {{ emptyCard.description }}
+            </div>
+          </AppCard>
+          <EventCard
+            v-for="event in filteredEvents"
+            v-else
+            :key="`${event.title}-${event.place}-${event.date}`"
+            class="event-page__event-card"
+            :types="event.types"
+            :title="event.title"
+            :image="event.image"
+            :location="event.location"
+            :date="event.date"
+            :to="event.to"
+          />
+        </template>
+        <template slot="extra-info">
           <div class="event-page__start-an-event">
             <h3>Start an event</h3>
             <p class="event-page__start-an-event__description">

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -21,20 +21,9 @@
           </cv-tabs>
         </client-only>
       </div>
-      <div class="bx--row">
-        <div
-          v-for="filter in extraFilters"
-          :key="filter.label"
-          class="bx--col-md-0"
-        >
-          <AppMultiSelect
-            :label="filter.label"
-            :options="filter.options"
-            :value="getCheckedFilters(filter.filterType)"
-            @change-selection="updateWholeFilter(filter.filterType, $event)"
-          />
-        </div>
-        <div class="bx--col-lg-4 bx--col-md-2 bx--col-sm-0">
+
+      <AppFiltersResultsLayout>
+        <template slot="filters-on-m-l-screen">
           <AppFieldset
             v-for="filter in extraFilters"
             :key="filter.label"
@@ -52,8 +41,21 @@
               />
             </client-only>
           </AppFieldset>
-        </div>
-        <div class="bx--col-lg-12 bx--col-md-6 event-page__main-content">
+        </template>
+        <template slot="filters-on-s-screen">
+          <div
+            v-for="filter in extraFilters"
+            :key="filter.label"
+          >
+            <AppMultiSelect
+              :label="filter.label"
+              :options="filter.options"
+              :value="getCheckedFilters(filter.filterType)"
+              @change-selection="updateWholeFilter(filter.filterType, $event)"
+            />
+          </div>
+        </template>
+        <template slot="results">
           <div>
             <AppCard
               v-if="noEvents"
@@ -85,8 +87,8 @@
             </p>
             <AppCta v-bind="eventRequestLink" />
           </div>
-        </div>
-      </div>
+        </template>
+      </AppFiltersResultsLayout>
     </div>
   </div>
 </template>

--- a/pages/learn/index.vue
+++ b/pages/learn/index.vue
@@ -41,7 +41,7 @@
         :title="resource.title"
         :to="resource.to"
         :cta-label="resource.ctaLabel"
-        class="results-item"
+        class="app-filters-results-layout__results-item"
       >
         <nuxt-content :document="resource" />
       </AppCard>

--- a/pages/learn/index.vue
+++ b/pages/learn/index.vue
@@ -41,7 +41,7 @@
         :title="resource.title"
         :to="resource.to"
         :cta-label="resource.ctaLabel"
-        class="learn-page__card"
+        class="results-item"
       >
         <nuxt-content :document="resource" />
       </AppCard>
@@ -153,15 +153,3 @@ export default class LearnPage extends QiskitPage {
   }
 }
 </script>
-
-<style lang="scss" scoped>
-.learn-page {
-  &__card {
-    margin-bottom: $layout-02;
-
-    @include mq($until: large) {
-      margin-bottom: $layout-01;
-    }
-  }
-}
-</style>

--- a/pages/learn/index.vue
+++ b/pages/learn/index.vue
@@ -41,6 +41,7 @@
         :title="resource.title"
         :to="resource.to"
         :cta-label="resource.ctaLabel"
+        class="learn-page__card"
       >
         <nuxt-content :document="resource" />
       </AppCard>
@@ -152,3 +153,15 @@ export default class LearnPage extends QiskitPage {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+.learn-page {
+  &__card {
+    margin-bottom: $layout-02;
+
+    @include mq($until: large) {
+      margin-bottom: $layout-01;
+    }
+  }
+}
+</style>


### PR DESCRIPTION
Fixes #944 

On this PR, the Learn, Advocates and Events pages share the same component for creating the layout of the aside filters and the results container