### PR TITLE
feat: add mega menu dropdown to "learn path" page

### DIFF
--- a/components/textbook-demo/TextbookDemoContentMenuSection.vue
+++ b/components/textbook-demo/TextbookDemoContentMenuSection.vue
@@ -1,0 +1,26 @@
+<template>
+  <section class="content-menu-section">
+    <div class="bx--grid">
+      <AppMegaDropdownMenu :content="dropdownMenuContent" />
+    </div>
+  </section>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { Component } from 'vue-property-decorator'
+import { TEXTBOOK_DEMO_MEGA_MENU } from '~/constants/megaMenuLinks'
+
+@Component
+export default class TextbookDemoContentMenuSection extends Vue {
+  dropdownMenuContent = TEXTBOOK_DEMO_MEGA_MENU
+}
+</script>
+
+<style lang="scss" scoped>
+.content-menu-section {
+  background: $background-color-lighter;
+  border-top: 1px solid $border-color;
+  border-bottom: 1px solid $border-color;
+}
+</style>

--- a/components/ui/AppMegaDropdownMenu.vue
+++ b/components/ui/AppMegaDropdownMenu.vue
@@ -2,7 +2,7 @@
   <article class="app-mega-dropdown">
     <label
       ref="filterWrapper"
-      class="app-mega-dropdown__filter-wrapper"
+      class="app-mega-dropdown__filter-wrapper bx--col-md-4 bx--col-lg-4"
       :class="`app-mega-dropdown__filter-wrapper_${kind}`"
     >
       <input
@@ -243,7 +243,6 @@ export default class AppMegaDropdownMenu extends Vue {
 
   &__filter-wrapper {
     display: flex;
-    width: 18rem;
     height: 2.5rem;
     justify-content: space-between;
     align-items: center;

--- a/pages/textbook-demo/learning-paths/introduction-course.vue
+++ b/pages/textbook-demo/learning-paths/introduction-course.vue
@@ -1,5 +1,6 @@
 <template>
   <main class="introduction-course-page">
+    <TextbookDemoContentMenuSection />
     <AppPageHeaderWithImage :cta="startLearningCTA" :back-link="backToTextbookHomeLink">
       <template slot="title">
         {{ headerTitle }}


### PR DESCRIPTION
This PR adds the "learning content mega dropdown" to the **learn path** page.

The width of the dropdown field is now no longer fixed but rather uses the Carbon columns as defined in Figma.

---

Closes #1864