### PR TITLE
feat(textbook): display fixed mega menu on scroll

### DIFF
--- a/components/textbook-demo/TextbookDemoHeader.vue
+++ b/components/textbook-demo/TextbookDemoHeader.vue
@@ -49,7 +49,7 @@ export default class TextbookDemoHeader extends (Vue as VueConstructor<VueCompon
     this.disconnectAppMegaDropdownMenuObserver()
   }
 
-  private connectAppMegaDropdownMenuObserver () {
+  connectAppMegaDropdownMenuObserver () {
     const appMegaDropdownMenuElement = this.$el.querySelector(`#${this.appMegaDropdownMenuId}`)
 
     if (appMegaDropdownMenuElement) {
@@ -58,7 +58,7 @@ export default class TextbookDemoHeader extends (Vue as VueConstructor<VueCompon
     }
   }
 
-  private disconnectAppMegaDropdownMenuObserver () {
+  disconnectAppMegaDropdownMenuObserver () {
     if (this.appMegaDropdownMenuObserver) {
       this.appMegaDropdownMenuObserver.disconnect()
     }

--- a/components/textbook-demo/TextbookDemoHeader.vue
+++ b/components/textbook-demo/TextbookDemoHeader.vue
@@ -7,6 +7,7 @@
             Qiskit Textbook (beta)
           </h1>
           <AppMegaDropdownMenu
+            :id="appMegaDropdownMenuId"
             class="textbook-demo-header__dropdown"
             kind="secondary"
             :content="dropdownMenuContent"
@@ -19,15 +20,55 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import Vue, { VueConstructor } from 'vue'
 import { Component } from 'vue-property-decorator'
 import { TEXTBOOK_DEMO_START_LEARNING } from '~/constants/appLinks'
 import { TEXTBOOK_DEMO_MEGA_MENU } from '~/constants/megaMenuLinks'
 
+interface VueComponent extends Vue {
+  $el: HTMLElement
+  _uid: number
+}
+
 @Component
-export default class TextbookDemoHeader extends Vue {
+export default class TextbookDemoHeader extends (Vue as VueConstructor<VueComponent>) {
   startLearningCTA = TEXTBOOK_DEMO_START_LEARNING
   dropdownMenuContent = TEXTBOOK_DEMO_MEGA_MENU
+  appMegaDropdownMenuIsVisible = true
+  appMegaDropdownMenuObserver: IntersectionObserver | undefined
+
+  get appMegaDropdownMenuId () {
+    return `app-mega-dropdown-menu-${this._uid}`
+  }
+
+  mounted () {
+    this.connectAppMegaDropdownMenuObserver()
+  }
+
+  beforeDestroy () {
+    this.disconnectAppMegaDropdownMenuObserver()
+  }
+
+  private connectAppMegaDropdownMenuObserver () {
+    const appMegaDropdownMenuElement = this.$el.querySelector(`#${this.appMegaDropdownMenuId}`)
+
+    if (appMegaDropdownMenuElement) {
+      this.appMegaDropdownMenuObserver = new IntersectionObserver(this.updateAppMegaDropdownMenuLayout)
+      this.appMegaDropdownMenuObserver.observe(appMegaDropdownMenuElement)
+    }
+  }
+
+  private disconnectAppMegaDropdownMenuObserver () {
+    if (this.appMegaDropdownMenuObserver) {
+      this.appMegaDropdownMenuObserver.disconnect()
+    }
+  }
+
+  updateAppMegaDropdownMenuLayout (entries: Array<IntersectionObserverEntry>) {
+    entries.forEach(({ isIntersecting }) => {
+      this.appMegaDropdownMenuIsVisible = isIntersecting
+    })
+  }
 }
 </script>
 

--- a/components/textbook-demo/TextbookDemoHeader.vue
+++ b/components/textbook-demo/TextbookDemoHeader.vue
@@ -139,6 +139,9 @@ export default class TextbookDemoHeader extends (Vue as VueConstructor<VueCompon
 .scroll-in-enter,
 .scroll-in-leave-to {
   margin-top: -40px;
+}
+
+.scroll-in-leave-to {
   opacity: 0;
 }
 </style>

--- a/components/textbook-demo/TextbookDemoHeader.vue
+++ b/components/textbook-demo/TextbookDemoHeader.vue
@@ -16,6 +16,12 @@
         <AppCta v-bind="startLearningCTA" class="textbook-demo-header__cta" />
       </div>
     </div>
+    <transition name="scroll-in">
+      <TextbookDemoContentMenuSection
+        v-if="!appMegaDropdownMenuIsVisible"
+        class="textbook-demo-header__dropdown_fixed"
+      />
+    </transition>
   </header>
 </template>
 
@@ -116,10 +122,22 @@ export default class TextbookDemoHeader extends (Vue as VueConstructor<VueCompon
 
   &__dropdown {
     margin-top: $layout-03;
+
+    &_fixed {
+      position: fixed;
+      transition: .3s ease-in-out;
+      top: 0;
+      width: 100%;
+    }
   }
 
   &__cta {
     align-self: flex-end;
   }
+}
+
+.scroll-in-enter,
+.scroll-in-leave-to {
+  margin-top: -40px;
 }
 </style>

--- a/components/textbook-demo/TextbookDemoHeader.vue
+++ b/components/textbook-demo/TextbookDemoHeader.vue
@@ -139,5 +139,6 @@ export default class TextbookDemoHeader extends (Vue as VueConstructor<VueCompon
 .scroll-in-enter,
 .scroll-in-leave-to {
   margin-top: -40px;
+  opacity: 0;
 }
 </style>


### PR DESCRIPTION
This PR implements the logic to display and hide a _fixed to the top_ version of the **mega menu dropdown** when the _regular_ **mega menu dropdown** toggles its visible state.

The _fixed to the top_ **mega menu dropdown**'s transition is animated with two effects:

1. It moves vertically when appearing / disappearing
2. It fades out when disappearing to avoid a too harsh of an effect when the dropdown is opened whilst scrolling to the top

**Note:** To test it, go to the URL `/textbook-demo` in the Vercel preview.

---

Closes #1855