### PR TITLE
Ev issue 1859 track mega menu search terms

### DIFF
--- a/components/textbook-demo/TextbookDemoContentMenuSection.vue
+++ b/components/textbook-demo/TextbookDemoContentMenuSection.vue
@@ -1,7 +1,10 @@
 <template>
   <section class="content-menu-section">
     <div class="bx--grid">
-      <AppMegaDropdownMenu :content="dropdownMenuContent" />
+      <AppMegaDropdownMenu
+        :content="dropdownMenuContent"
+        segment-component-name="Textbook mega menu"
+      />
     </div>
   </section>
 </template>

--- a/components/textbook-demo/TextbookDemoHeader.vue
+++ b/components/textbook-demo/TextbookDemoHeader.vue
@@ -11,6 +11,7 @@
             class="textbook-demo-header__dropdown"
             kind="secondary"
             :content="dropdownMenuContent"
+            segment-component-name="Textbook mega menu"
           />
         </div>
         <AppCta v-bind="startLearningCTA" class="textbook-demo-header__cta" />

--- a/components/ui/AppMegaDropdownMenu.vue
+++ b/components/ui/AppMegaDropdownMenu.vue
@@ -79,6 +79,7 @@ interface HighlightTextState {
 export default class AppMegaDropdownMenu extends Vue {
   @Prop({ type: String, default: 'primary' }) kind!: 'primary'|'secondary'
   @Prop({ type: String, required: false, default: 'Browse all content' }) placeholder!: string
+  @Prop({ type: String, required: false, default: '' }) segmentComponentName!: string
   @Prop(Array) content!: MegaDropdownMenu
 
   showContent = false;
@@ -93,7 +94,9 @@ export default class AppMegaDropdownMenu extends Vue {
   }
 
   trackSearchTerm () {
-    // TODO: Call tracking event with the value of `this.textOnTheFilter`
+    if (this.segmentComponentName) {
+      this.$trackSearchTerm(this.segmentComponentName, this.textOnTheFilter)
+    }
   }
 
   onTextOnTheFilterChange () {

--- a/components/ui/AppMegaDropdownMenu.vue
+++ b/components/ui/AppMegaDropdownMenu.vue
@@ -11,6 +11,7 @@
         class="app-mega-dropdown__filter-wrapper__input"
         :placeholder="placeholder"
         @focus="onShowContent"
+        @keyup="onTextOnTheFilterChange"
       >
       <svg class="app-mega-dropdown__filter-wrapper__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><path d="M16 22L6 12l1.4-1.4 8.6 8.6 8.6-8.6L26 12z" /></svg>
     </label>
@@ -81,6 +82,27 @@ export default class AppMegaDropdownMenu extends Vue {
   @Prop(Array) content!: MegaDropdownMenu
 
   showContent = false;
+
+  searchTermTrackingTimeout: NodeJS.Timeout | null = null
+
+  removeSearchTermTrackingTimeout () {
+    if (this.searchTermTrackingTimeout) {
+      clearTimeout(this.searchTermTrackingTimeout)
+      this.searchTermTrackingTimeout = null
+    }
+  }
+
+  trackSearchTerm () {
+    // TODO: Call tracking event with the value of `this.textOnTheFilter`
+  }
+
+  onTextOnTheFilterChange () {
+    this.removeSearchTermTrackingTimeout()
+
+    this.searchTermTrackingTimeout = setTimeout(() => {
+      this.trackSearchTerm()
+    }, 750)
+  }
 
   onShowContent () {
     this.showContent = true
@@ -212,6 +234,8 @@ export default class AppMegaDropdownMenu extends Vue {
 
   beforeDestroy () {
     document.removeEventListener('mousedown', this.handleClick)
+
+    this.removeSearchTermTrackingTimeout()
   }
 
   handleClick (e: MouseEvent) {

--- a/components/ui/AppMegaDropdownMenu.vue
+++ b/components/ui/AppMegaDropdownMenu.vue
@@ -11,7 +11,7 @@
         class="app-mega-dropdown__filter-wrapper__input"
         :placeholder="placeholder"
         @focus="onShowContent"
-        @keyup="onTextOnTheFilterChange"
+        @keyup="onTextOnTheFilterChanged"
       >
       <svg class="app-mega-dropdown__filter-wrapper__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><path d="M16 22L6 12l1.4-1.4 8.6 8.6 8.6-8.6L26 12z" /></svg>
     </label>
@@ -99,7 +99,7 @@ export default class AppMegaDropdownMenu extends Vue {
     }
   }
 
-  onTextOnTheFilterChange () {
+  onTextOnTheFilterChanged () {
     this.removeSearchTermTrackingTimeout()
 
     this.searchTermTrackingTimeout = setTimeout(() => {

--- a/plugins/segment-analytics.ts
+++ b/plugins/segment-analytics.ts
@@ -117,6 +117,34 @@ function trackClickEvent (context: AnalyticsContext, params: ClickEventParams) {
   bluemixAnalytics.trackEvent('CTA Clicked', cta)
 }
 
+/**
+ * Send the information of an entered search term to Segment.
+ * @param context Bluemix Analytics configuration
+ * @param searchComponent Name of the search component
+ * @param searchTerm Search term
+ */
+function trackSearchTerm (
+  context: AnalyticsContext,
+  searchComponent: string,
+  searchTerm: string
+) {
+  const { bluemixAnalytics, digitalData } = context
+
+  if (!bluemixAnalytics || !digitalData) { return }
+
+  const productTitle = getOrFailProductTitle(digitalData)
+  const category = getOrFailCategory(digitalData)
+
+  const eventOptions = {
+    category,
+    location: searchComponent,
+    productTitle,
+    text: searchTerm
+  }
+
+  bluemixAnalytics.trackEvent('Searched Term', eventOptions)
+}
+
 function getOrFailProductTitle (digitalData: any): string {
   return assertCanGet(
     () => digitalData.page.pageInfo.productTitle,
@@ -158,6 +186,7 @@ declare module 'vue/types/vue' {
     $metaInfo: { title: string }
     $trackClickEvent(params: ClickEventParams): void
     $trackPage(routeName: string, title: string): void
+    $trackSearchTerm(searchComponent: string, searchTerm: string): void
   }
 }
 
@@ -166,6 +195,13 @@ export default (_: any, inject: any) => {
   installAnalyticsOnce()
   inject('trackPage', afterAnalyticsReady(trackPage))
   inject('trackClickEvent', afterAnalyticsReady(trackClickEvent))
+  inject('trackSearchTerm', afterAnalyticsReady(trackSearchTerm))
 }
 
-export { trackClickEvent, trackPage, ClickEventParams, AnalyticsContext }
+export {
+  trackClickEvent,
+  trackPage,
+  trackSearchTerm,
+  ClickEventParams,
+  AnalyticsContext
+}

--- a/tests/plugins/segment-analytics.spec.ts
+++ b/tests/plugins/segment-analytics.spec.ts
@@ -1,9 +1,15 @@
-import { trackClickEvent, trackPage, AnalyticsContext } from '~/plugins/segment-analytics'
+import {
+  trackClickEvent,
+  trackPage,
+  trackSearchTerm,
+  AnalyticsContext
+} from '~/plugins/segment-analytics'
 
 const window: AnalyticsContext = {
   bluemixAnalytics: {
     trackEvent: jest.fn(),
-    pageEvent: jest.fn()
+    pageEvent: jest.fn(),
+    trackSearchTermEvent: jest.fn()
   },
   digitalData: {
     page: {
@@ -22,12 +28,14 @@ const eventParams = {
 }
 
 const routeName = 'sample route'
-
 const title = 'sample title'
+const searchComponent = 'sample search component'
+const searchTerm = 'sample seach term'
 
 const commonSuite: [Function, any[], string][] = [
   [trackPage, [routeName, title], 'pageEvent'],
-  [trackClickEvent, [eventParams], 'trackEvent']
+  [trackClickEvent, [eventParams], 'trackEvent'],
+  [trackSearchTerm, [searchComponent, searchTerm], 'trackEvent']
 ]
 
 commonSuite.forEach(([fn, args, delegate]) => {
@@ -142,6 +150,25 @@ describe('trackPage', () => {
         navigationType: 'pushState',
         productTitle: window.digitalData.page.pageInfo.productTitle,
         title
+      }
+    )
+  })
+})
+
+describe('trackSearchTerm', () => {
+  beforeEach(() => {
+    window.bluemixAnalytics.trackEvent.mockClear()
+  })
+
+  it('translates the event into a Bluemix Analytics "Searched Term" event', () => {
+    trackSearchTerm(window, searchComponent, searchTerm)
+    expect(window.bluemixAnalytics.trackEvent).toHaveBeenCalledWith(
+      'Searched Term',
+      {
+        productTitle: window.digitalData.page.pageInfo.productTitle,
+        category: window.digitalData.page.pageInfo.analytics.category,
+        location: searchComponent,
+        text: searchTerm
       }
     )
   })


### PR DESCRIPTION
This PR implements the Segment analytics tracking for search terms in the **Textbook Mega Menu**.

The search terms are being tracked via the `trackEvent` function of Segment, similarly to the "Clicked CTA" events.

We're sending some additional event information to Segment with this event:

1. **Location:** The name of the component (for example: `Textbook mega menu`)
2. **Text:** The searched term (for example: `algorithm`)

The tracking event is triggered 750 milliseconds after the user stops typing something in the **Textbook Mega Menu** component.

---

Related to: #1847, #1857

Closes: #1859