### PR TITLE
feat(textbook): sticky mega menu

### DIFF
--- a/components/textbook-demo/TextbookDemoContentMenuSection.vue
+++ b/components/textbook-demo/TextbookDemoContentMenuSection.vue
@@ -25,5 +25,7 @@ export default class TextbookDemoContentMenuSection extends Vue {
   background: $background-color-lighter;
   border-top: 1px solid $border-color;
   border-bottom: 1px solid $border-color;
+  position: sticky;
+  top: 0;
 }
 </style>

--- a/components/textbook-demo/TextbookDemoContentMenuSection.vue
+++ b/components/textbook-demo/TextbookDemoContentMenuSection.vue
@@ -27,5 +27,6 @@ export default class TextbookDemoContentMenuSection extends Vue {
   border-bottom: 1px solid $border-color;
   position: sticky;
   top: 0;
+  z-index: 100;
 }
 </style>

--- a/components/textbook-demo/TextbookDemoContentMenuSection.vue
+++ b/components/textbook-demo/TextbookDemoContentMenuSection.vue
@@ -25,8 +25,5 @@ export default class TextbookDemoContentMenuSection extends Vue {
   background: $background-color-lighter;
   border-top: 1px solid $border-color;
   border-bottom: 1px solid $border-color;
-  position: sticky;
-  top: 0;
-  z-index: 100;
 }
 </style>

--- a/components/textbook-demo/TextbookDemoHeader.vue
+++ b/components/textbook-demo/TextbookDemoHeader.vue
@@ -125,9 +125,8 @@ export default class TextbookDemoHeader extends (Vue as VueConstructor<VueCompon
     margin-top: $layout-03;
 
     &_fixed {
-      position: fixed;
+      position: fixed !important;
       transition: .3s ease-in-out;
-      top: 0;
       width: 100%;
     }
   }

--- a/components/textbook-demo/TextbookDemoHeader.vue
+++ b/components/textbook-demo/TextbookDemoHeader.vue
@@ -20,7 +20,7 @@
     <transition name="scroll-in">
       <TextbookDemoContentMenuSection
         v-if="!appMegaDropdownMenuIsVisible"
-        class="textbook-demo-header__dropdown_fixed"
+        class="textbook-demo-header__dropdown-fixed"
       />
     </transition>
   </header>
@@ -123,12 +123,14 @@ export default class TextbookDemoHeader extends (Vue as VueConstructor<VueCompon
 
   &__dropdown {
     margin-top: $layout-03;
+  }
 
-    &_fixed {
-      position: fixed !important;
-      transition: .3s ease-in-out;
-      width: 100%;
-    }
+  &__dropdown-fixed {
+    position: fixed;
+    top: 0;
+    transition: .3s ease-in-out;
+    width: 100%;
+    z-index: 100;
   }
 
   &__cta {

--- a/components/ui/AppMegaDropdownMenu.vue
+++ b/components/ui/AppMegaDropdownMenu.vue
@@ -335,7 +335,7 @@ export default class AppMegaDropdownMenu extends Vue {
     @include mq($until: medium) {
       left: 0;
       right: 0;
-      height: initial;
+      height: 80vh;
     }
   }
 

--- a/pages/textbook-demo/course/introduction-course.vue
+++ b/pages/textbook-demo/course/introduction-course.vue
@@ -1,6 +1,8 @@
 <template>
   <main class="introduction-course-page">
-    <TextbookDemoContentMenuSection />
+    <TextbookDemoContentMenuSection
+      class="introduction-course-page__content-menu"
+    />
     <AppPageHeaderWithImage :cta="startLearningCTA" :back-link="backToTextbookHomeLink">
       <template slot="title">
         {{ headerTitle }}
@@ -98,6 +100,12 @@ export default class IntroductionCoursePage extends QiskitPage {
     max-width: $max-size;
     margin-bottom: $layout-03;
     margin-top: $layout-05;
+  }
+
+  &__content-menu {
+    position: sticky;
+    top: 0;
+    z-index: 100;
   }
 }
 </style>


### PR DESCRIPTION
This PR makes the Textbook Mega Menu component stick to the top when scrolling down in the courses pages.

To test it, go to a course page in the Vercel preview, like `/textbook-demo/course/introduction-course`.

https://user-images.githubusercontent.com/22047320/122562829-c74c8880-d043-11eb-9010-9271984fc1da.mov

---

Closes #1891