### PR TITLE
feat(advocates): track clicks on "Join the program" CTA

### DIFF
--- a/components/advocates/AdvocatesJoinSection.vue
+++ b/components/advocates/AdvocatesJoinSection.vue
@@ -50,7 +50,8 @@ export default class JoinSection extends Vue {
 
   joinAction = {
     url: 'https://qisk.it/advocateapplication',
-    label: 'Join the program'
+    label: 'Join the program',
+    segment: { action: 'advocates > join-section > join-the-program' }
   }
 }
 </script>


### PR DESCRIPTION
This PR adds click events tracking to the "Join the program" CTA in the advocates page.

The `action` is in our current structure (`<page> > <section> > <cta-label>`). There is an ongoing conversation about restructuring this in https://github.com/Qiskit/qiskit.org/issues/1511#issuecomment-862284188, but until a conclusion is reached, we should keep using the current approach for consistency.

---

Closes #1883 