### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "fix-lint": "eslint --fix --ext .ts,.js,.vue . && npm run lint:style -- --fix"
   },
   "engines": {
-    "node": ">=14.x"
+    "node": "=14.x"
   },
   "dependencies": {
     "@carbon/colors": "^10.24.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "fix-lint": "eslint --fix --ext .ts,.js,.vue . && npm run lint:style -- --fix"
   },
   "engines": {
-    "node": "=14.x"
+    "node": "14.x"
   },
   "dependencies": {
     "@carbon/colors": "^10.24.0",


### PR DESCRIPTION
Fix #2044 

Related to #2022 

Follow log recommendation on not including free ranges for engine versions (avoid `>=X.x` and use `=X.x`).

Indeed, and according to the logs, leaving the range open triggered the installation of Node 16 for which the project does not seem to be compatible as pointed in the issue comments.