### PR TITLE
Updates affiliation on the india week of women in quantum page

### DIFF
--- a/pages/events/india-week-of-women-in-quantum.vue
+++ b/pages/events/india-week-of-women-in-quantum.vue
@@ -258,7 +258,7 @@ export default class IndiaWeekOfWomenInQuantumPage extends QiskitPage {
       </ul>`,
       affiliation: `<ul>
         <li>Coimbatore Institute of Technology</li>
-        <li>IBM Research, India</li>
+        <li>IBM GBS India</li>
         <li>University of Barcelona</li>
       </ul>`
     }


### PR DESCRIPTION
Update requested by the India's team:

On the https://qiskit.org/events/india-week-of-women-in-quantum/ page, update
Day 2 Event Schedule for Speaker Kavitha Yogaraj’s Affiliation:
IBM Research, India   →   IBM GBS India