### PR TITLE
Update link and sticky preview frame

### DIFF
--- a/components/textbook-beta/CoursePagesSection.vue
+++ b/components/textbook-beta/CoursePagesSection.vue
@@ -106,6 +106,8 @@ export default class CoursePagesSection extends Vue {
     display: grid;
     grid-area: main;
     grid-template-rows: auto 1fr;
+    position: sticky;
+    top: -.5rem;
 
     @include mq($until: medium) {
       display: none;

--- a/components/textbook-beta/CoursePagesSection.vue
+++ b/components/textbook-beta/CoursePagesSection.vue
@@ -107,7 +107,7 @@ export default class CoursePagesSection extends Vue {
     grid-area: main;
     grid-template-rows: auto 1fr;
     position: sticky;
-    top: -.5rem;
+    top: -$spacing-03;
 
     @include mq($until: medium) {
       display: none;

--- a/pages/textbook-beta/summer-school/quantum-computing-and-quantum-learning-2021.vue
+++ b/pages/textbook-beta/summer-school/quantum-computing-and-quantum-learning-2021.vue
@@ -86,145 +86,145 @@ export default class SummerSchoolCoursePage extends QiskitPage {
       image: 'QGSS2021_Lecture1.1_CoverImage.png',
       label: 'Vector Spaces, Tensor Products, and Qubits',
       segment: { cta: 'lecture-1-1', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/summer-school/2021/lec1-1-vector-spaces-tensor-products-qubits'
+      url: 'https://learn.qiskit.org/course/qgss2021/lec1-1'
     },
     {
       image: 'QGSS2021_Lecture1.2_CoverImage.png',
       label: 'Introduction to Quantum Circuits',
       segment: { cta: 'lecture-1-2', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/summer-school/2021/lec1-2-introduction-quantum-circuits'
+      url: 'https://learn.qiskit.org/course/qgss2021/lec1-2'
     },
     {
       image: 'QGSS2021_Lecture2.1_CoverImage.png',
       label: 'Simple Quantum Algorithms I',
       segment: { cta: 'lecture-2-1', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/summer-school/2021/lec2-1-simple-quantum-algorithms-i'
+      url: 'https://learn.qiskit.org/course/qgss2021/lec2-1'
     },
     {
       image: 'QGSS2021_Lecture2.2_CoverImage.png',
       label: 'Simple Quantum Algorithms II',
       segment: { cta: 'lecture-2-2', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/summer-school/2021/lec2-2-simple-quantum-algorithms-ii'
+      url: 'https://learn.qiskit.org/course/qgss2021/lec2-2'
     },
     {
       image: 'QGSS2021_Lecture3.1_CoverImage.png',
       label: 'Noise in Quantum Computers pt 1',
       segment: { cta: 'lecture-3-1', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/summer-school/2021/lec3-1-noise-quantum-computers-1'
+      url: 'https://learn.qiskit.org/course/qgss2021/lec3-1'
     },
     {
       image: 'QGSS2021_Lecture3.2_CoverImage.png',
       label: 'Noise in Quantum Computers pt. 2',
       segment: { cta: 'lecture-3-2', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/summer-school/2021/lec3-2-noise-quantum-computers-pt-2'
+      url: 'https://learn.qiskit.org/course/qgss2021/lec3-2'
     },
     {
       image: 'QGSS2021_Lab1_CoverImage.png',
       label: 'Lab 1: Quantum Computing Algorithms and Operations',
       segment: { cta: 'lab-1', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/summer-school/2021/lab1-quantum-computing-algorithm-operations'
+      url: 'https://learn.qiskit.org/course/qgss2021/lab1'
     },
     {
       image: 'QGSS2021_Lecture4.1_CoverImage.png',
       label: 'Introduction to Classical Machine Learning',
       segment: { cta: 'lecture-4-1', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/summer-school/2021/lec4-1-introduction-classical-machine-learning'
+      url: 'https://learn.qiskit.org/course/qgss2021/lec4-1'
     },
     {
       image: 'QGSS2021_Lecture4.2_CoverImage.png',
       label: 'Advanced Classical Machine Learning',
       segment: { cta: 'lecture-4-2', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/summer-school/2021/lec4-2-advanced-classical-machine-learning'
+      url: 'https://learn.qiskit.org/course/qgss2021/lec4-2'
     },
     {
       image: 'QGSS2021_Lecture5.1_CoverImage.png',
       label: 'Building a Quantum Classifier',
       segment: { cta: 'lecture-5-1', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/summer-school/2021/lec5-1-building-quantum-classifier'
+      url: 'https://learn.qiskit.org/course/qgss2021/lec5-1'
     },
     {
       image: 'QGSS2021_Lecture5.2_CoverImage.png',
       label: 'Introduction to the Quantum Approximate Optimization Algorithm and Applications',
       segment: { cta: 'lecture-5-2', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/summer-school/2021/lec5-2-introduction-quantum-approximate-optimization-algorithm-applications'
+      url: 'https://learn.qiskit.org/course/qgss2021/lec5-2'
     },
     {
       image: 'QGSS2021_Lab2_CoverImage.png',
       label: 'Lab 2: Variational Algorithms',
       segment: { cta: 'lab2', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/summer-school/2021/lab2-variational-algorithms'
+      url: 'https://learn.qiskit.org/course/qgss2021/lab2'
     },
     {
       image: 'QGSS2021_Lecture6.1_CoverImage.png',
       label: 'From Variational Classifiers to Linear Classifiers',
       segment: { cta: 'lecture-6-1', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/summer-school/2021/lec6-1-from-variational-classifiers-linear-classifiers'
+      url: 'https://learn.qiskit.org/course/qgss2021/lec6-1'
     },
     {
       image: 'QGSS2021_Lecture6.2_CoverImage.png',
       label: 'Quantum Feature Spaces and Kernels',
       segment: { cta: 'lecture-6-2', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/summer-school/2021/lec6-2-quantum-feature-spaces-kernels'
+      url: 'https://learn.qiskit.org/course/qgss2021/lec6-2'
     },
     {
       image: 'QGSS2021_Lecture7.1_CoverImage.png',
       label: 'Quantum Kernels in Practice',
       segment: { cta: 'lecture-7-1', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/summer-school/2021/lec7-1-quantum-kernels-practice'
+      url: 'https://learn.qiskit.org/course/qgss2021/lec7-1'
     },
     {
       image: 'QGSS2021_Lab3_CoverImage.png',
       label: 'Lab 3: Introduction to Quantum Kernels and Support Vector Machines',
       segment: { cta: 'lab3', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/summer-school/2021/lab3-introduction-quantum-kernels-support-vector-machines'
+      url: 'https://learn.qiskit.org/course/qgss2021/lab3'
     },
     {
       image: 'QGSS2021_Lecture8.1_CoverImage.png',
       label: 'Introduction and Applications of Quantum Models',
       segment: { cta: 'lecture-8-1', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/summer-school/2021/lec8-1-introduction-applications-quantum-models'
+      url: 'https://learn.qiskit.org/course/qgss2021/lec8-1'
     },
     {
       image: 'QGSS2021_Lecture8.2_CoverImage.png',
       label: 'Barren Plateaus, Trainability Issues, and How to Avoid Them',
       segment: { cta: 'lecture-8-2', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/summer-school/2021/lec8-2-barren-plateaus-trainability-issues-how-avoid-them'
+      url: 'https://learn.qiskit.org/course/qgss2021/lec8-2'
     },
     {
       image: 'QGSS2021_Lab4_CoverImage.png',
       label: 'Lab 4: Introduction to Training Quantum Circuits',
       segment: { cta: 'lab4', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/summer-school/2021/lab4-introduction-training-quantum-circuits'
+      url: 'https://learn.qiskit.org/course/qgss2021/lab4'
     },
     {
       image: 'QGSS2021_Lecture9.1_CoverImage.png',
       label: 'Introduction to Quantum Hardware',
       segment: { cta: 'lecture-9-1', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/summer-school/2021/lec9-1-introduction-quantum-hardware'
+      url: 'https://learn.qiskit.org/course/qgss2021/lec9-1'
     },
     {
       image: 'QGSS2021_Lecture9.2_CoverImage.png',
       label: 'Hardware Efficient Ansatze for Quantum Machine Learning',
       segment: { cta: 'lecture-9-2', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/summer-school/2021/lec9-2-hardware-efficient-ansatze-quantum-machine-learning'
+      url: 'https://learn.qiskit.org/course/qgss2021/lec9-2'
     },
     {
       image: 'QGSS2021_Lab5_CoverImage.png',
       label: 'Lab 5: Introduction to Hardware Efficient Ansatze for Quantum Machine Learning',
       segment: { cta: 'lab5', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/summer-school/2021/lab5-introduction-hardware-efficient-ansatze-quantum-machine-learning'
+      url: 'https://learn.qiskit.org/course/qgss2021/lab5'
     },
     {
       image: 'QGSS2021_Lecture10.1_CoverImage.png',
       label: 'Advanced QML Algorithms: Quantum Boltzmann Machines and Quantum Generative Adversarial Networks',
       segment: { cta: 'lecture-10-1', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/summer-school/2021/lec10-1-advanced-qml-algorithms'
+      url: 'https://learn.qiskit.org/course/qgss2021/lec10-1'
     },
     {
       image: 'QGSS2021_Lecture10.2_CoverImage.png',
       label: 'The Capacity and Power of Quantum Machine Learning Models & the Future of Quantum Machine Learning',
       segment: { cta: 'lecture-10-2', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/summer-school/2021/lec10-2-the-capacity-power-quantum-machine-learning-models-future-quantum-machine-learning'
+      url: 'https://learn.qiskit.org/course/qgss2021/lec10-2'
     }
   ]
 

--- a/pages/textbook-beta/summer-school/quantum-computing-and-quantum-learning-2021.vue
+++ b/pages/textbook-beta/summer-school/quantum-computing-and-quantum-learning-2021.vue
@@ -86,145 +86,145 @@ export default class SummerSchoolCoursePage extends QiskitPage {
       image: 'QGSS2021_Lecture1.1_CoverImage.png',
       label: 'Vector Spaces, Tensor Products, and Qubits',
       segment: { cta: 'lecture-1-1', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/course/qgss2021/lec1-1'
+      url: 'https://learn.qiskit.org/summer-school/2021/lec1-1-vector-spaces-tensor-products-qubits'
     },
     {
       image: 'QGSS2021_Lecture1.2_CoverImage.png',
       label: 'Introduction to Quantum Circuits',
       segment: { cta: 'lecture-1-2', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/course/qgss2021/lec1-2'
+      url: 'https://learn.qiskit.org/summer-school/2021/lec1-2-introduction-quantum-circuits'
     },
     {
       image: 'QGSS2021_Lecture2.1_CoverImage.png',
       label: 'Simple Quantum Algorithms I',
       segment: { cta: 'lecture-2-1', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/course/qgss2021/lec2-1'
+      url: 'https://learn.qiskit.org/summer-school/2021/lec2-1-simple-quantum-algorithms-i'
     },
     {
       image: 'QGSS2021_Lecture2.2_CoverImage.png',
       label: 'Simple Quantum Algorithms II',
       segment: { cta: 'lecture-2-2', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/course/qgss2021/lec2-2'
+      url: 'https://learn.qiskit.org/summer-school/2021/lec2-2-simple-quantum-algorithms-ii'
     },
     {
       image: 'QGSS2021_Lecture3.1_CoverImage.png',
       label: 'Noise in Quantum Computers pt 1',
       segment: { cta: 'lecture-3-1', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/course/qgss2021/lec3-1'
+      url: 'https://learn.qiskit.org/summer-school/2021/lec3-1-noise-quantum-computers-1'
     },
     {
       image: 'QGSS2021_Lecture3.2_CoverImage.png',
       label: 'Noise in Quantum Computers pt. 2',
       segment: { cta: 'lecture-3-2', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/course/qgss2021/lec3-2'
+      url: 'https://learn.qiskit.org/summer-school/2021/lec3-2-noise-quantum-computers-pt-2'
     },
     {
       image: 'QGSS2021_Lab1_CoverImage.png',
       label: 'Lab 1: Quantum Computing Algorithms and Operations',
       segment: { cta: 'lab-1', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/course/qgss2021/lab1'
+      url: 'https://learn.qiskit.org/summer-school/2021/lab1-quantum-computing-algorithm-operations'
     },
     {
       image: 'QGSS2021_Lecture4.1_CoverImage.png',
       label: 'Introduction to Classical Machine Learning',
       segment: { cta: 'lecture-4-1', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/course/qgss2021/lec4-1'
+      url: 'https://learn.qiskit.org/summer-school/2021/lec4-1-introduction-classical-machine-learning'
     },
     {
       image: 'QGSS2021_Lecture4.2_CoverImage.png',
       label: 'Advanced Classical Machine Learning',
       segment: { cta: 'lecture-4-2', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/course/qgss2021/lec4-2'
+      url: 'https://learn.qiskit.org/summer-school/2021/lec4-2-advanced-classical-machine-learning'
     },
     {
       image: 'QGSS2021_Lecture5.1_CoverImage.png',
       label: 'Building a Quantum Classifier',
       segment: { cta: 'lecture-5-1', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/course/qgss2021/lec5-1'
+      url: 'https://learn.qiskit.org/summer-school/2021/lec5-1-building-quantum-classifier'
     },
     {
       image: 'QGSS2021_Lecture5.2_CoverImage.png',
       label: 'Introduction to the Quantum Approximate Optimization Algorithm and Applications',
       segment: { cta: 'lecture-5-2', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/course/qgss2021/lec5-2'
+      url: 'https://learn.qiskit.org/summer-school/2021/lec5-2-introduction-quantum-approximate-optimization-algorithm-applications'
     },
     {
       image: 'QGSS2021_Lab2_CoverImage.png',
       label: 'Lab 2: Variational Algorithms',
       segment: { cta: 'lab2', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/course/qgss2021/lab2'
+      url: 'https://learn.qiskit.org/summer-school/2021/lab2-variational-algorithms'
     },
     {
       image: 'QGSS2021_Lecture6.1_CoverImage.png',
       label: 'From Variational Classifiers to Linear Classifiers',
       segment: { cta: 'lecture-6-1', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/course/qgss2021/lec6-1'
+      url: 'https://learn.qiskit.org/summer-school/2021/lec6-1-from-variational-classifiers-linear-classifiers'
     },
     {
       image: 'QGSS2021_Lecture6.2_CoverImage.png',
       label: 'Quantum Feature Spaces and Kernels',
       segment: { cta: 'lecture-6-2', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/course/qgss2021/lec6-2'
+      url: 'https://learn.qiskit.org/summer-school/2021/lec6-2-quantum-feature-spaces-kernels'
     },
     {
       image: 'QGSS2021_Lecture7.1_CoverImage.png',
       label: 'Quantum Kernels in Practice',
       segment: { cta: 'lecture-7-1', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/course/qgss2021/lec7-1'
+      url: 'https://learn.qiskit.org/summer-school/2021/lec7-1-quantum-kernels-practice'
     },
     {
       image: 'QGSS2021_Lab3_CoverImage.png',
       label: 'Lab 3: Introduction to Quantum Kernels and Support Vector Machines',
       segment: { cta: 'lab3', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/course/qgss2021/lab3'
+      url: 'https://learn.qiskit.org/summer-school/2021/lab3-introduction-quantum-kernels-support-vector-machines'
     },
     {
       image: 'QGSS2021_Lecture8.1_CoverImage.png',
       label: 'Introduction and Applications of Quantum Models',
       segment: { cta: 'lecture-8-1', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/course/qgss2021/lec8-1'
+      url: 'https://learn.qiskit.org/summer-school/2021/lec8-1-introduction-applications-quantum-models'
     },
     {
       image: 'QGSS2021_Lecture8.2_CoverImage.png',
       label: 'Barren Plateaus, Trainability Issues, and How to Avoid Them',
       segment: { cta: 'lecture-8-2', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/course/qgss2021/lec8-2'
+      url: 'https://learn.qiskit.org/summer-school/2021/lec8-2-barren-plateaus-trainability-issues-how-avoid-them'
     },
     {
       image: 'QGSS2021_Lab4_CoverImage.png',
       label: 'Lab 4: Introduction to Training Quantum Circuits',
       segment: { cta: 'lab4', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/course/qgss2021/lab4'
+      url: 'https://learn.qiskit.org/summer-school/2021/lab4-introduction-training-quantum-circuits'
     },
     {
       image: 'QGSS2021_Lecture9.1_CoverImage.png',
       label: 'Introduction to Quantum Hardware',
       segment: { cta: 'lecture-9-1', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/course/qgss2021/lec9-1'
+      url: 'https://learn.qiskit.org/summer-school/2021/lec9-1-introduction-quantum-hardware'
     },
     {
       image: 'QGSS2021_Lecture9.2_CoverImage.png',
       label: 'Hardware Efficient Ansatze for Quantum Machine Learning',
       segment: { cta: 'lecture-9-2', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/course/qgss2021/lec9-2'
+      url: 'https://learn.qiskit.org/summer-school/2021/lec9-2-hardware-efficient-ansatze-quantum-machine-learning'
     },
     {
       image: 'QGSS2021_Lab5_CoverImage.png',
       label: 'Lab 5: Introduction to Hardware Efficient Ansatze for Quantum Machine Learning',
       segment: { cta: 'lab5', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/course/qgss2021/lab5'
+      url: 'https://learn.qiskit.org/summer-school/2021/lab5-introduction-hardware-efficient-ansatze-quantum-machine-learning'
     },
     {
       image: 'QGSS2021_Lecture10.1_CoverImage.png',
       label: 'Advanced QML Algorithms: Quantum Boltzmann Machines and Quantum Generative Adversarial Networks',
       segment: { cta: 'lecture-10-1', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/course/qgss2021/lec10-1'
+      url: 'https://learn.qiskit.org/summer-school/2021/lec10-1-advanced-qml-algorithms'
     },
     {
       image: 'QGSS2021_Lecture10.2_CoverImage.png',
       label: 'The Capacity and Power of Quantum Machine Learning Models & the Future of Quantum Machine Learning',
       segment: { cta: 'lecture-10-2', location: 'summer-school-2021' },
-      url: 'https://learn.qiskit.org/course/qgss2021/lec10-2'
+      url: 'https://learn.qiskit.org/summer-school/2021/lec10-2-the-capacity-power-quantum-machine-learning-models-future-quantum-machine-learning'
     }
   ]
 
@@ -257,7 +257,7 @@ export default class SummerSchoolCoursePage extends QiskitPage {
         cta: 'linear-algebra', location: 'related-material'
       },
       url:
-        'https://qiskit.org/textbook/ch-appendix/linear_algebra.html'
+        'https://learn.qiskit.org/course/ch-appendix/an-introduction-to-linear-algebra-for-quantum-computing'
     },
     {
       title: 'Probability Theory — Random Variables and Distributions',


### PR DESCRIPTION
Fixes the first and third issues from [this comment](https://github.com/Qiskit/qiskit.org/pull/2190#issuecomment-928981633)

- Link pointing to Linear Algebra 
- Sticky preview frame for the Course pages


