### PR TITLE
Update `$layout` to `$spacing` in styling

### DIFF
--- a/components/advocates/AdvocateCard.vue
+++ b/components/advocates/AdvocateCard.vue
@@ -45,7 +45,7 @@ export default class AdvocateCard extends Vue {
 
 <style lang="scss" scoped>
 .advocate-card {
-  margin-bottom: $layout-02;
+  margin-bottom: $spacing-06;
 
   @include mq($until: large) {
     margin-bottom: $spacing-05;

--- a/components/advocates/AdvocateCard.vue
+++ b/components/advocates/AdvocateCard.vue
@@ -48,7 +48,7 @@ export default class AdvocateCard extends Vue {
   margin-bottom: $layout-02;
 
   @include mq($until: large) {
-    margin-bottom: $layout-01;
+    margin-bottom: $spacing-05;
   }
 
   &__location, &__contact {

--- a/components/advocates/MeetTheAdvocates.vue
+++ b/components/advocates/MeetTheAdvocates.vue
@@ -110,7 +110,7 @@ export default class MeetTheAdvocates extends Vue {
 
 <style lang="scss" scoped>
 .meet-the-advocates {
-  margin-top: $layout-06;
+  margin-top: $spacing-12;
 
   &__filters-result-section {
     margin-top: $spacing-10;

--- a/components/advocates/MeetTheAdvocates.vue
+++ b/components/advocates/MeetTheAdvocates.vue
@@ -113,7 +113,7 @@ export default class MeetTheAdvocates extends Vue {
   margin-top: $layout-06;
 
   &__filters-result-section {
-    margin-top: $layout-05;
+    margin-top: $spacing-10;
   }
 }
 </style>

--- a/components/learn/TheLearningResourceList.vue
+++ b/components/learn/TheLearningResourceList.vue
@@ -113,7 +113,7 @@ export default class TheLearningResourceList extends Vue {
   background-position: left bottom;
 
   &__filter-level {
-    margin-bottom: $layout-04;
+    margin-bottom: $spacing-09;
 
     @include mq($until: medium) {
       margin-bottom: $spacing-05;

--- a/components/learn/TheLearningResourceList.vue
+++ b/components/learn/TheLearningResourceList.vue
@@ -116,7 +116,7 @@ export default class TheLearningResourceList extends Vue {
     margin-bottom: $layout-04;
 
     @include mq($until: medium) {
-      margin-bottom: $layout-01;
+      margin-bottom: $spacing-05;
     }
   }
 }

--- a/components/metal/BuildingSection.vue
+++ b/components/metal/BuildingSection.vue
@@ -78,7 +78,7 @@ export default class BuildingSection extends Vue {
   }
 
   @include mq($until: medium) {
-    padding-bottom: $layout-03;
+    padding-bottom: $spacing-07;
   }
 
   &__container {

--- a/components/metal/BuildingSection.vue
+++ b/components/metal/BuildingSection.vue
@@ -95,10 +95,10 @@ export default class BuildingSection extends Vue {
 
   &__text {
     max-width: 7.5 * $column-size-large;
-    margin-bottom: $layout-04;
+    margin-bottom: $spacing-09;
 
     @include mq($until: large) {
-      margin-bottom: $layout-04;
+      margin-bottom: $spacing-09;
     }
 
     @include mq($from: medium, $until: large) {

--- a/components/metal/BuildingSection.vue
+++ b/components/metal/BuildingSection.vue
@@ -71,7 +71,7 @@ export default class BuildingSection extends Vue {
 
   background-position: right -1rem bottom -2px;
   background-repeat: no-repeat;
-  padding-bottom: $layout-05;
+  padding-bottom: $spacing-10;
 
   @include mq($until: large) {
     background-position: right -.5rem bottom -2px;
@@ -84,7 +84,7 @@ export default class BuildingSection extends Vue {
   &__container {
     @include contained();
 
-    padding-top: $layout-05;
+    padding-top: $spacing-10;
   }
 
   &__subtitle {

--- a/components/metal/BuildingSection.vue
+++ b/components/metal/BuildingSection.vue
@@ -89,7 +89,7 @@ export default class BuildingSection extends Vue {
 
   &__subtitle {
     @include mq($until: large) {
-      margin-bottom: $layout-02;
+      margin-bottom: $spacing-06;
     }
   }
 
@@ -108,7 +108,7 @@ export default class BuildingSection extends Vue {
     @include mq($until: medium) {
       width: 100%;
       max-width: initial;
-      margin-bottom: $layout-02;
+      margin-bottom: $spacing-06;
     }
   }
 

--- a/components/metal/CapabilitiesSection.vue
+++ b/components/metal/CapabilitiesSection.vue
@@ -94,7 +94,7 @@ export default class CapabilitiesSection extends Mixins(ScrollSectionsMixin) {
     @include contained();
 
     padding-top: $layout-05;
-    padding-bottom: $layout-04;
+    padding-bottom: $spacing-09;
   }
 
   &__capabilities {

--- a/components/metal/CapabilitiesSection.vue
+++ b/components/metal/CapabilitiesSection.vue
@@ -117,7 +117,7 @@ export default class CapabilitiesSection extends Mixins(ScrollSectionsMixin) {
 
   &__scrolling-ui {
     position: sticky;
-    top: $layout-02;
+    top: $spacing-06;
     flex: 0 0 32rem;
     min-height: 20rem;
     margin-bottom: $layout-06;

--- a/components/metal/CapabilitiesSection.vue
+++ b/components/metal/CapabilitiesSection.vue
@@ -93,7 +93,7 @@ export default class CapabilitiesSection extends Mixins(ScrollSectionsMixin) {
   &__container {
     @include contained();
 
-    padding-top: $layout-05;
+    padding-top: $spacing-10;
     padding-bottom: $spacing-09;
   }
 

--- a/components/metal/CapabilitiesSection.vue
+++ b/components/metal/CapabilitiesSection.vue
@@ -108,7 +108,7 @@ export default class CapabilitiesSection extends Mixins(ScrollSectionsMixin) {
   }
 
   &__card {
-    margin-bottom: $layout-06;
+    margin-bottom: $spacing-12;
 
     @include mq($until: medium) {
       margin-bottom: $spacing-07;
@@ -120,7 +120,7 @@ export default class CapabilitiesSection extends Mixins(ScrollSectionsMixin) {
     top: $spacing-06;
     flex: 0 0 32rem;
     min-height: 20rem;
-    margin-bottom: $layout-06;
+    margin-bottom: $spacing-12;
 
     @include mq($from: medium, $until: large) {
       flex: 1.5;

--- a/components/metal/CapabilitiesSection.vue
+++ b/components/metal/CapabilitiesSection.vue
@@ -111,7 +111,7 @@ export default class CapabilitiesSection extends Mixins(ScrollSectionsMixin) {
     margin-bottom: $layout-06;
 
     @include mq($until: medium) {
-      margin-bottom: $layout-03;
+      margin-bottom: $spacing-07;
     }
   }
 

--- a/components/metal/CapabilityCard.vue
+++ b/components/metal/CapabilityCard.vue
@@ -80,7 +80,7 @@ export default class CapabilityCard extends Vue {
 
     @include mq($until: medium) {
       padding-bottom: 0;
-      margin-bottom: $layout-01;
+      margin-bottom: $spacing-05;
     }
   }
 
@@ -93,7 +93,7 @@ export default class CapabilityCard extends Vue {
 
     @include mq($until: medium) {
       padding-bottom: 0;
-      margin-bottom: $layout-01;
+      margin-bottom: $spacing-05;
     }
   }
 

--- a/components/metal/FeaturesSection.vue
+++ b/components/metal/FeaturesSection.vue
@@ -66,7 +66,7 @@ export default class FeaturesSection extends Vue {
   }
 
   &__card {
-    margin-top: $layout-04;
+    margin-top: $spacing-09;
   }
 }
 </style>

--- a/components/metal/FeaturesSection.vue
+++ b/components/metal/FeaturesSection.vue
@@ -53,7 +53,7 @@ export default class FeaturesSection extends Vue {
     margin-bottom: $layout-06;
 
     @include mq($until: large) {
-      margin-bottom: $layout-03;
+      margin-bottom: $spacing-07;
     }
 
     @include mq($from: medium, $until: large) {

--- a/components/metal/FeaturesSection.vue
+++ b/components/metal/FeaturesSection.vue
@@ -40,7 +40,7 @@ export default class FeaturesSection extends Vue {
     @include contained();
 
     padding-top: $spacing-10;
-    padding-bottom: $layout-06;
+    padding-bottom: $spacing-12;
 
     @include mq($until: medium) {
       padding-top: $spacing-06;
@@ -50,7 +50,7 @@ export default class FeaturesSection extends Vue {
 
   &__description {
     max-width: 9 * $column-size-large;
-    margin-bottom: $layout-06;
+    margin-bottom: $spacing-12;
 
     @include mq($until: large) {
       margin-bottom: $spacing-07;

--- a/components/metal/FeaturesSection.vue
+++ b/components/metal/FeaturesSection.vue
@@ -43,8 +43,8 @@ export default class FeaturesSection extends Vue {
     padding-bottom: $layout-06;
 
     @include mq($until: medium) {
-      padding-top: $layout-02;
-      padding-bottom: $layout-02;
+      padding-top: $spacing-06;
+      padding-bottom: $spacing-06;
     }
   }
 

--- a/components/metal/FeaturesSection.vue
+++ b/components/metal/FeaturesSection.vue
@@ -39,7 +39,7 @@ export default class FeaturesSection extends Vue {
   &__container {
     @include contained();
 
-    padding-top: $layout-05;
+    padding-top: $spacing-10;
     padding-bottom: $layout-06;
 
     @include mq($until: medium) {

--- a/components/metal/IntroSection.vue
+++ b/components/metal/IntroSection.vue
@@ -78,7 +78,7 @@ export default class IntroSection extends Vue {
     padding-right: $spacing-07;
 
     @include mq($until: large) {
-      margin-bottom: $layout-03;
+      margin-bottom: $spacing-07;
     }
 
     @include mq($from: medium, $until: large) {
@@ -94,7 +94,7 @@ export default class IntroSection extends Vue {
     width: 100%;
 
     @include mq($until: medium) {
-      margin-bottom: $layout-03;
+      margin-bottom: $spacing-07;
     }
   }
 
@@ -104,7 +104,7 @@ export default class IntroSection extends Vue {
 
     @include mq($until: large) {
       top: 0;
-      margin-top: $layout-03;
+      margin-top: $spacing-07;
     }
   }
 }

--- a/components/metal/IntroSection.vue
+++ b/components/metal/IntroSection.vue
@@ -74,7 +74,7 @@ export default class IntroSection extends Vue {
 
   &__description {
     max-width: 6 * $column-size-large;
-    margin-bottom: $layout-06;
+    margin-bottom: $spacing-12;
     padding-right: $spacing-07;
 
     @include mq($until: large) {

--- a/components/metal/IntroSection.vue
+++ b/components/metal/IntroSection.vue
@@ -59,7 +59,7 @@ export default class IntroSection extends Vue {
   &__container {
     @include contained();
 
-    padding-top: $layout-05;
+    padding-top: $spacing-10;
     padding-bottom: 0;
   }
 

--- a/components/metal/JoinUsSection.vue
+++ b/components/metal/JoinUsSection.vue
@@ -36,7 +36,7 @@ export default class JoinUsSection extends Vue {
     padding-bottom: $layout-06;
 
     @include mq($until: medium) {
-      padding-top: $layout-03;
+      padding-top: $spacing-07;
       padding-bottom: $layout-05;
     }
   }
@@ -46,7 +46,7 @@ export default class JoinUsSection extends Vue {
     margin-bottom: 3.25rem;
 
     @include mq($until: large) {
-      margin-bottom: $layout-03;
+      margin-bottom: $spacing-07;
     }
 
     @include mq($from: medium, $until: large) {

--- a/components/metal/JoinUsSection.vue
+++ b/components/metal/JoinUsSection.vue
@@ -32,12 +32,12 @@ export default class JoinUsSection extends Vue {
   &__container {
     @include contained();
 
-    padding-top: $layout-05;
+    padding-top: $spacing-10;
     padding-bottom: $layout-06;
 
     @include mq($until: medium) {
       padding-top: $spacing-07;
-      padding-bottom: $layout-05;
+      padding-bottom: $spacing-10;
     }
   }
 

--- a/components/metal/JoinUsSection.vue
+++ b/components/metal/JoinUsSection.vue
@@ -33,7 +33,7 @@ export default class JoinUsSection extends Vue {
     @include contained();
 
     padding-top: $spacing-10;
-    padding-bottom: $layout-06;
+    padding-bottom: $spacing-12;
 
     @include mq($until: medium) {
       padding-top: $spacing-07;

--- a/components/metal/MetalGrid.vue
+++ b/components/metal/MetalGrid.vue
@@ -406,7 +406,7 @@ export default class MetalGrid extends Vue {
   &__slot-container {
     pointer-events: none;
     position: absolute;
-    padding-top: $layout-05;
+    padding-top: $spacing-10;
     top: 0;
     left: 0;
     right: 0;

--- a/components/overview/TheTableOfContents.vue
+++ b/components/overview/TheTableOfContents.vue
@@ -40,7 +40,7 @@ export default class TheTableOfContents extends Vue {
   &__entry {
     color: $text-color-light;
     text-decoration: none;
-    margin-bottom: $layout-02;
+    margin-bottom: $spacing-06;
 
     &_second-level {
       &:hover {
@@ -52,7 +52,7 @@ export default class TheTableOfContents extends Vue {
         color: $text-active-color;
         font-weight: bold;
         display: inline-block;
-        padding-right: $layout-02;
+        padding-right: $spacing-06;
       }
     }
 

--- a/components/textbook-beta/StartLearningSection.vue
+++ b/components/textbook-beta/StartLearningSection.vue
@@ -148,7 +148,7 @@ export default class StartLearningSection extends Vue {
 <style lang="scss" scoped>
 .start-learning-section {
   &__subtitle {
-    margin-bottom: $layout-01;
+    margin-bottom: $spacing-05;
   }
 
   &__section {
@@ -159,7 +159,7 @@ export default class StartLearningSection extends Vue {
     margin-bottom: $layout-02;
 
     @include mq($until: large) {
-      margin-bottom: $layout-01;
+      margin-bottom: $spacing-05;
     }
 
     @include mq($from: x-large) {

--- a/components/textbook-beta/StartLearningSection.vue
+++ b/components/textbook-beta/StartLearningSection.vue
@@ -152,7 +152,7 @@ export default class StartLearningSection extends Vue {
   }
 
   &__section {
-    margin-bottom: $layout-03;
+    margin-bottom: $spacing-07;
   }
 
   &__card {

--- a/components/textbook-beta/StartLearningSection.vue
+++ b/components/textbook-beta/StartLearningSection.vue
@@ -156,14 +156,14 @@ export default class StartLearningSection extends Vue {
   }
 
   &__card {
-    margin-bottom: $layout-02;
+    margin-bottom: $spacing-06;
 
     @include mq($until: large) {
       margin-bottom: $spacing-05;
     }
 
     @include mq($from: x-large) {
-      height: calc(100% - #{$layout-02});
+      height: calc(100% - #{$spacing-06});
     }
   }
 }

--- a/components/textbook-beta/TextbookBetaHeader.vue
+++ b/components/textbook-beta/TextbookBetaHeader.vue
@@ -155,7 +155,7 @@ export default class TextbookBetaHeader extends (Vue as VueConstructor<VueCompon
   }
 
   &__dropdown {
-    margin-top: $layout-03;
+    margin-top: $spacing-07;
   }
 
   &__dropdown-fixed {

--- a/components/textbook-beta/TextbookBetaHeader.vue
+++ b/components/textbook-beta/TextbookBetaHeader.vue
@@ -114,7 +114,7 @@ export default class TextbookBetaHeader extends (Vue as VueConstructor<VueCompon
     padding-top: $spacing-09;
 
     @include mq($from:medium, $until: large) {
-      padding-top: $layout-06;
+      padding-top: $spacing-12;
     }
 
     &-wrapper {

--- a/components/ui/AppFieldset.vue
+++ b/components/ui/AppFieldset.vue
@@ -19,7 +19,7 @@ export default class AppFieldset extends Vue {
 
 <style lang="scss">
 .app-fieldset {
-  margin-bottom: $layout-03;
+  margin-bottom: $spacing-07;
 
   &__label {
     margin-bottom: $spacing-05;

--- a/components/ui/AppFieldset.vue
+++ b/components/ui/AppFieldset.vue
@@ -22,7 +22,7 @@ export default class AppFieldset extends Vue {
   margin-bottom: $layout-03;
 
   &__label {
-    margin-bottom: $layout-01;
+    margin-bottom: $spacing-05;
   }
 }
 </style>

--- a/components/ui/AppFiltersResultsLayout.vue
+++ b/components/ui/AppFiltersResultsLayout.vue
@@ -27,7 +27,7 @@ export default class AppFiltersResultsLayout extends Vue {}
 .app-filters-results-layout {
   ::v-deep &__main-section {
     @include mq($until: medium) {
-      margin-top: $layout-04;
+      margin-top: $spacing-09;
     }
   }
 

--- a/components/ui/AppFiltersResultsLayout.vue
+++ b/components/ui/AppFiltersResultsLayout.vue
@@ -35,7 +35,7 @@ export default class AppFiltersResultsLayout extends Vue {}
     margin-bottom: $layout-02;
 
     @include mq($until: large) {
-      margin-bottom: $layout-01;
+      margin-bottom: $spacing-05;
     }
 
     @include mq($from: x-large) {

--- a/components/ui/AppFiltersResultsLayout.vue
+++ b/components/ui/AppFiltersResultsLayout.vue
@@ -32,14 +32,14 @@ export default class AppFiltersResultsLayout extends Vue {}
   }
 
   ::v-deep &__results-item {
-    margin-bottom: $layout-02;
+    margin-bottom: $spacing-06;
 
     @include mq($until: large) {
       margin-bottom: $spacing-05;
     }
 
     @include mq($from: x-large) {
-      height: calc(100% - #{$layout-02});
+      height: calc(100% - #{$spacing-06});
     }
   }
 }

--- a/components/ui/AppIntroductoryContent.vue
+++ b/components/ui/AppIntroductoryContent.vue
@@ -56,7 +56,7 @@ export default class AppIntroductoryContent extends Vue {
   }
 
   &__description {
-    margin-bottom: $layout-05;
+    margin-bottom: $spacing-10;
 
     @include mq($until: large) {
       margin-bottom: $spacing-07;

--- a/components/ui/AppIntroductoryContent.vue
+++ b/components/ui/AppIntroductoryContent.vue
@@ -39,7 +39,7 @@ export default class AppIntroductoryContent extends Vue {
   }
 
   &__overview {
-    margin-bottom: $layout-03;
+    margin-bottom: $spacing-07;
 
     @include mq($from: large) {
       $grid-columns: 5/13; // Number of columns that the element will use at this breakpoint.
@@ -59,7 +59,7 @@ export default class AppIntroductoryContent extends Vue {
     margin-bottom: $layout-05;
 
     @include mq($until: large) {
-      margin-bottom: $layout-03;
+      margin-bottom: $spacing-07;
     }
   }
 

--- a/components/ui/AppMosaicSection.vue
+++ b/components/ui/AppMosaicSection.vue
@@ -33,7 +33,7 @@ export default class AppMosaicSection extends Vue {
   }
 
   &__mosaic {
-    margin-bottom: $layout-03;
+    margin-bottom: $spacing-07;
 
     @include mq($from: medium, $until: large) {
       margin-bottom: $spacing-05;

--- a/components/ui/AppMosaicSection.vue
+++ b/components/ui/AppMosaicSection.vue
@@ -36,11 +36,11 @@ export default class AppMosaicSection extends Vue {
     margin-bottom: $layout-03;
 
     @include mq($from: medium, $until: large) {
-      margin-bottom: $layout-01;
+      margin-bottom: $spacing-05;
     }
 
     @include mq($until: medium) {
-      margin-bottom: $layout-01;
+      margin-bottom: $spacing-05;
     }
   }
 

--- a/components/ui/AppPageHeaderWithCard.vue
+++ b/components/ui/AppPageHeaderWithCard.vue
@@ -45,7 +45,7 @@ export default class AppPageHeaderWithCard extends Vue {
 .app-page-header {
   @include responsive-grid-bg-strip("/images/grid/grid-hero-learn.svg", auto, 28rem);
 
-  padding-top: $layout-06;
+  padding-top: $spacing-12;
 
   @include mq($until: medium) {
     padding-top: $spacing-09;

--- a/components/ui/AppPageHeaderWithCard.vue
+++ b/components/ui/AppPageHeaderWithCard.vue
@@ -48,7 +48,7 @@ export default class AppPageHeaderWithCard extends Vue {
   padding-top: $layout-06;
 
   @include mq($until: medium) {
-    padding-top: $layout-04;
+    padding-top: $spacing-09;
   }
 
   &__main {

--- a/components/ui/AppPageHeaderWithImage.vue
+++ b/components/ui/AppPageHeaderWithImage.vue
@@ -60,7 +60,7 @@ export default class AppPageHeaderWithImage extends Vue {
     ;
 
     @include mq($until: medium) {
-      padding-top: $layout-04;
+      padding-top: $spacing-09;
       grid-template-columns: 1fr;
       grid-template-areas:
         "headline"

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -203,7 +203,7 @@ export default class EventsPage extends QiskitPage {
 .event-page {
   &__time-filters {
     margin-top: $spacing-07;
-    margin-bottom: $layout-04;
+    margin-bottom: $spacing-09;
     .bx--tabs__nav-link {
       color: black;
       border-bottom-color: $border-color;
@@ -258,7 +258,7 @@ export default class EventsPage extends QiskitPage {
 
   &__main-content {
     @include mq($until: medium) {
-      margin-top: $layout-04;
+      margin-top: $spacing-09;
     }
   }
 

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -275,7 +275,7 @@ export default class EventsPage extends QiskitPage {
     margin-bottom: $layout-05;
 
     &__description {
-      margin-top: $layout-02;
+      margin-top: $spacing-06;
       margin-bottom: $layout-03;
       max-width: 20rem;
 

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -271,8 +271,8 @@ export default class EventsPage extends QiskitPage {
   }
 
   &__start-an-event {
-    margin-top: $layout-05;
-    margin-bottom: $layout-05;
+    margin-top: $spacing-10;
+    margin-bottom: $spacing-10;
 
     &__description {
       margin-top: $spacing-06;

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -202,7 +202,7 @@ export default class EventsPage extends QiskitPage {
 
 .event-page {
   &__time-filters {
-    margin-top: $layout-03;
+    margin-top: $spacing-07;
     margin-bottom: $layout-04;
     .bx--tabs__nav-link {
       color: black;
@@ -276,7 +276,7 @@ export default class EventsPage extends QiskitPage {
 
     &__description {
       margin-top: $spacing-06;
-      margin-bottom: $layout-03;
+      margin-bottom: $spacing-07;
       max-width: 20rem;
 
       @include mq($from: large) {

--- a/pages/events/india-week-of-women-in-quantum.vue
+++ b/pages/events/india-week-of-women-in-quantum.vue
@@ -369,7 +369,7 @@ export default class IndiaWeekOfWomenInQuantumPage extends QiskitPage {
 .india-week-of-women-in-quantum-page {
   &__section {
     margin-top: $layout-05;
-    margin-bottom: $layout-03;
+    margin-bottom: $spacing-07;
 
     @include mq($until: large) {
       margin-bottom: $spacing-05;

--- a/pages/events/india-week-of-women-in-quantum.vue
+++ b/pages/events/india-week-of-women-in-quantum.vue
@@ -368,7 +368,7 @@ export default class IndiaWeekOfWomenInQuantumPage extends QiskitPage {
 <style lang="scss" scoped>
 .india-week-of-women-in-quantum-page {
   &__section {
-    margin-top: $layout-05;
+    margin-top: $spacing-10;
     margin-bottom: $spacing-07;
 
     @include mq($until: large) {

--- a/pages/events/india-week-of-women-in-quantum.vue
+++ b/pages/events/india-week-of-women-in-quantum.vue
@@ -372,7 +372,7 @@ export default class IndiaWeekOfWomenInQuantumPage extends QiskitPage {
     margin-bottom: $layout-03;
 
     @include mq($until: large) {
-      margin-bottom: $layout-01;
+      margin-bottom: $spacing-05;
     }
   }
 }

--- a/pages/events/physics-of-computation.vue
+++ b/pages/events/physics-of-computation.vue
@@ -481,7 +481,7 @@ export default class PhysicsOfComputationPage extends QiskitPage {
     margin-bottom: $layout-03;
 
     @include mq($until: large) {
-      margin-bottom: $layout-01;
+      margin-bottom: $spacing-05;
     }
   }
 }

--- a/pages/events/physics-of-computation.vue
+++ b/pages/events/physics-of-computation.vue
@@ -478,7 +478,7 @@ export default class PhysicsOfComputationPage extends QiskitPage {
 .physics-of-computation-page {
   &__section {
     margin-top: $layout-05;
-    margin-bottom: $layout-03;
+    margin-bottom: $spacing-07;
 
     @include mq($until: large) {
       margin-bottom: $spacing-05;

--- a/pages/events/physics-of-computation.vue
+++ b/pages/events/physics-of-computation.vue
@@ -477,7 +477,7 @@ export default class PhysicsOfComputationPage extends QiskitPage {
 <style lang="scss" scoped>
 .physics-of-computation-page {
   &__section {
-    margin-top: $layout-05;
+    margin-top: $spacing-10;
     margin-bottom: $spacing-07;
 
     @include mq($until: large) {

--- a/pages/events/seminar-series.vue
+++ b/pages/events/seminar-series.vue
@@ -246,7 +246,7 @@ export default class SeminarSeriesPage extends QiskitPage {
 .seminar-series-page {
   &__section {
     margin-top: $layout-05;
-    margin-bottom: $layout-03;
+    margin-bottom: $spacing-07;
 
     @include mq($until: large) {
       margin-bottom: $spacing-05;

--- a/pages/events/seminar-series.vue
+++ b/pages/events/seminar-series.vue
@@ -249,7 +249,7 @@ export default class SeminarSeriesPage extends QiskitPage {
     margin-bottom: $layout-03;
 
     @include mq($until: large) {
-      margin-bottom: $layout-01;
+      margin-bottom: $spacing-05;
     }
   }
 

--- a/pages/events/seminar-series.vue
+++ b/pages/events/seminar-series.vue
@@ -245,7 +245,7 @@ export default class SeminarSeriesPage extends QiskitPage {
 <style lang="scss" scoped>
 .seminar-series-page {
   &__section {
-    margin-top: $layout-05;
+    margin-top: $spacing-10;
     margin-bottom: $spacing-07;
 
     @include mq($until: large) {

--- a/pages/events/summer-school.vue
+++ b/pages/events/summer-school.vue
@@ -154,7 +154,7 @@ export default class SummerSchoolPage extends QiskitPage {
 
   &__section {
     margin-top: $layout-05;
-    margin-bottom: $layout-03;
+    margin-bottom: $spacing-07;
 
     @include mq($until: large) {
       margin-bottom: $spacing-05;

--- a/pages/events/summer-school.vue
+++ b/pages/events/summer-school.vue
@@ -153,7 +153,7 @@ export default class SummerSchoolPage extends QiskitPage {
   flex-direction: column;
 
   &__section {
-    margin-top: $layout-05;
+    margin-top: $spacing-10;
     margin-bottom: $spacing-07;
 
     @include mq($until: large) {

--- a/pages/events/summer-school.vue
+++ b/pages/events/summer-school.vue
@@ -157,7 +157,7 @@ export default class SummerSchoolPage extends QiskitPage {
     margin-bottom: $layout-03;
 
     @include mq($until: large) {
-      margin-bottom: $layout-01;
+      margin-bottom: $spacing-05;
     }
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -86,7 +86,7 @@ export default class LandingPage extends QiskitPage {
   }
 
   &__section {
-    margin-top: $layout-05;
+    margin-top: $spacing-10;
     margin-bottom: $spacing-07;
     padding-bottom: $layout-07;
 
@@ -95,7 +95,7 @@ export default class LandingPage extends QiskitPage {
     }
 
     @include mq($until: medium) {
-      padding-bottom: $layout-05;
+      padding-bottom: $spacing-10;
     }
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -91,7 +91,7 @@ export default class LandingPage extends QiskitPage {
     padding-bottom: $layout-07;
 
     @include mq($until: large) {
-      margin-bottom: $layout-01;
+      margin-bottom: $spacing-05;
     }
 
     @include mq($until: medium) {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -88,7 +88,7 @@ export default class LandingPage extends QiskitPage {
   &__section {
     margin-top: $spacing-10;
     margin-bottom: $spacing-07;
-    padding-bottom: $layout-07;
+    padding-bottom: $spacing-13;
 
     @include mq($until: large) {
       margin-bottom: $spacing-05;

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -87,7 +87,7 @@ export default class LandingPage extends QiskitPage {
 
   &__section {
     margin-top: $layout-05;
-    margin-bottom: $layout-03;
+    margin-bottom: $spacing-07;
     padding-bottom: $layout-07;
 
     @include mq($until: large) {

--- a/pages/learn/_slug.vue
+++ b/pages/learn/_slug.vue
@@ -93,7 +93,7 @@ export default class LearnEntry extends QiskitPage {
       position: relative;
       background-color: $background-color-highlight;
       padding: $spacing-07;
-      margin-bottom: $layout-03;
+      margin-bottom: $spacing-07;
 
       &::before {
         @include type-style('display-02');
@@ -121,7 +121,7 @@ export default class LearnEntry extends QiskitPage {
 
     ul {
       list-style-type: '-';
-      margin-bottom: $layout-03;
+      margin-bottom: $spacing-07;
       max-width: 9 * $column-size-large;
 
       li {
@@ -136,7 +136,7 @@ export default class LearnEntry extends QiskitPage {
     }
 
     table {
-      margin-bottom: $layout-03;
+      margin-bottom: $spacing-07;
 
       td, th {
         border: 1px solid $cool-gray-20;

--- a/pages/learn/_slug.vue
+++ b/pages/learn/_slug.vue
@@ -111,11 +111,11 @@ export default class LearnEntry extends QiskitPage {
       }
 
       @include mq($from: medium, $until: large) {
-        margin-bottom: $layout-01;
+        margin-bottom: $spacing-05;
       }
 
       @include mq($until: medium) {
-        margin-bottom: $layout-01;
+        margin-bottom: $spacing-05;
       }
     }
 
@@ -127,7 +127,7 @@ export default class LearnEntry extends QiskitPage {
       li {
         padding-left: $spacing-03;
         margin-left: $spacing-03;
-        margin-top: $layout-01;
+        margin-top: $spacing-05;
 
         li {
           margin-left: $spacing-03;
@@ -145,12 +145,12 @@ export default class LearnEntry extends QiskitPage {
         max-width: 9 * $column-size-large;
 
         @include mq($from: medium, $until: large) {
-          margin-bottom: $layout-01;
+          margin-bottom: $spacing-05;
         }
 
         @include mq($until: medium) {
           padding: $spacing-03;
-          margin-bottom: $layout-01;
+          margin-bottom: $spacing-05;
         }
       }
 

--- a/pages/overview.vue
+++ b/pages/overview.vue
@@ -101,7 +101,7 @@ export default class OverviewPage extends QiskitPage {
 .overview-page {
   &__table-of-contents {
     position: sticky;
-    top: $layout-02;
+    top: $spacing-06;
   }
 
   &__content-section {

--- a/pages/overview.vue
+++ b/pages/overview.vue
@@ -105,7 +105,7 @@ export default class OverviewPage extends QiskitPage {
   }
 
   &__content-section {
-    margin-bottom: $layout-05;
+    margin-bottom: $spacing-10;
     overflow: hidden;
   }
 

--- a/pages/textbook-beta/course/introduction-course.vue
+++ b/pages/textbook-beta/course/introduction-course.vue
@@ -98,7 +98,7 @@ export default class IntroductionCoursePage extends QiskitPage {
     @include contained();
 
     max-width: $max-size;
-    margin-bottom: $layout-03;
+    margin-bottom: $spacing-07;
     margin-top: $layout-05;
   }
 

--- a/pages/textbook-beta/course/introduction-course.vue
+++ b/pages/textbook-beta/course/introduction-course.vue
@@ -99,7 +99,7 @@ export default class IntroductionCoursePage extends QiskitPage {
 
     max-width: $max-size;
     margin-bottom: $spacing-07;
-    margin-top: $layout-05;
+    margin-top: $spacing-10;
   }
 
   &__content-menu {

--- a/pages/textbook-beta/index.vue
+++ b/pages/textbook-beta/index.vue
@@ -93,7 +93,7 @@ export default class TextbookBetaPage extends QiskitPage {
     @include contained();
 
     max-width: $max-size;
-    margin-bottom: $layout-03;
+    margin-bottom: $spacing-07;
     margin-top: $layout-05;
   }
 }

--- a/pages/textbook-beta/index.vue
+++ b/pages/textbook-beta/index.vue
@@ -94,7 +94,7 @@ export default class TextbookBetaPage extends QiskitPage {
 
     max-width: $max-size;
     margin-bottom: $spacing-07;
-    margin-top: $layout-05;
+    margin-top: $spacing-10;
   }
 }
 </style>


### PR DESCRIPTION
https://github.com/Qiskit/qiskit.org/issues/1789

This seeks to update references to `$layout-0x` to the newer references, `$spacing-0y`.

Please refer to [this table](https://github.com/carbon-design-system/carbon/blob/48deedf2fb7a343594ed844d6c852c9108a3eb53/docs/migration/11.x-layout.md) or [this table](https://github.com/carbon-design-system/carbon/blob/1ea5be5e5e477d9fda65cd8f3b9a53267df56d52/docs/migration/11.x-carbon-components.md#scssglobalsscss_spacingscss) for confirming the new reference replacements.

