### PR TITLE
Disable preview for forks and drafts

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -5,6 +5,8 @@ on: [pull_request]
 
 jobs:
   preview:
+    # Prevents action to be executed by forks and drafts
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     env:
       PR_TAG: pr-${{ github.event.pull_request.number }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,9 +88,8 @@ need to know that qiskit.org follows the
 [Forking Workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/forking-workflow)
 with [Feature Branches](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow).
 
-Regardless if you are a core contributor or not, the above means we expect you to fork
-the project on your own GitHub account and make your `main` branch to track this
-repository. A typical Git setup after
+The above means we expect you to fork the project on your own GitHub account and make your `main` branch to 
+track this repository. A typical Git setup after
 [forking the project](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo) is:
 
 ```sh
@@ -104,6 +103,9 @@ git branch -u upstream/main
 git pull
 ```
 
+As a core contributor due to some access limitations between forks and the head branch we encourage you to 
+[clone](https://support.atlassian.com/bitbucket-cloud/docs/clone-a-repository/) the repository 
+instead of forking it.
 
 ### Assigning yourself
 
@@ -174,12 +176,14 @@ branch. In these occassions, remember to manually close the related pull request
 
 ### Live previews
 
-As part of our continuous integration infrastructure, every pull request that passes 
-the build process, receives a dedicated deployment running on [IBM Code Engine](https://cloud.ibm.com/codeengine/overview). 
+As part of our continuous integration infrastructure, every pull request opened from the head repository that passes 
+the build process, receives a dedicated deployment running on [IBM Code Engine](https://cloud.ibm.com/codeengine/overview).
 
 This allows the team to have live branch previews, making it easier to share
 links and review changes as necessary. You can preview your working branch at 
 `https://qiskit-org-pr-<pull-request-number>.<unique_id>.us-south.codeengine.appdomain.cloud/`.
+
+This means that for forked repositories the pull request will not generate a live preview and that step will be skipped.
 
 ### Code review
 


### PR DESCRIPTION
Related with #2276 and https://github.com/qiskit-community/platypus/pull/199

The idea with this PR is to disable the preview-ga for forks and drafts to prevent false errors in the PR.