### PR TITLE
Add a link to installation doc from the front page

### DIFF
--- a/components/landing/TheQuickStart/StartLocally.vue
+++ b/components/landing/TheQuickStart/StartLocally.vue
@@ -2,7 +2,13 @@
   <section class="start-locally">
     <h3>Start locally</h3>
     <p class="start-locally__introduction">
-      To install Qiskit locally, you will need
+      To
+      <AppLink
+        url="https://qiskit.org/documentation/getting_started.html#installation"
+      >
+        install Qiskit locally,
+      </AppLink>
+      you will need
       <AppLink
         url="https://www.python.org/downloads/"
       >


### PR DESCRIPTION
This adds a link to the full [local installation guide](https://qiskit.org/documentation/getting_started.html#installation) from the qiskit.org front page.  Prior to this change, if one wants to find the full installation guide, one must scroll back to the top (or bottom), click "Documentation", and then either click "Getting started" (or, if one doesn't recognize that as the appropriate link, search for "installation" in the side panel search bar).  I believe there is value in directly linking to it from the front page.