### PR TITLE
Reuse github action preview

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -9,9 +9,10 @@ jobs:
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     env:
-      PR_TAG: pr-${{ github.event.pull_request.number }}
+      CONTAINER_REGISTRY_NAMESPACE: community-digital
       DOCKER_IMAGE_NAME: qiskit-org
       DOCKER_IMAGE_PORT: "3000"
+      PR_TAG: pr-${{ github.event.pull_request.number }}
 
       IBMCLOUD_ACCOUNT: ${{ secrets.IBMCLOUD_ACCOUNT }}
       IBMCLOUD_API_KEY: ${{ secrets.IBMCLOUD_API_KEY }}
@@ -36,22 +37,17 @@ jobs:
           auto_inactive: true
           ref: ${{ github.event.pull_request.head.ref }}
 
-      - name: Log-in into IBM Container Registry
-        uses: docker/login-action@v1
+      - name: Build and push Docker image to IBM container registry
+        uses: Qiskit/gh-actions/.github/workflows/build-publish-docker-image.yml@main
         with:
-          registry: icr.io
-          username: iamapikey
-          password: ${{ env.IBMCLOUD_API_KEY }}
-
-      - name: Build and push to IBM registry
-        uses: docker/build-push-action@v2.6.1
-        with:
-          push: true
-          tags: ${{ env.DOCKER_IMAGE_TAG }}
-          cache-from: type=registry,ref=${{ env.DOCKER_IMAGE_TAG }}
-          cache-to: type=inline
-        env:
-          DOCKER_IMAGE_TAG: icr.io/community-digital/${{ env.DOCKER_IMAGE_NAME }}:${{ env.PR_TAG }}
+          CONTAINER_REGISTRY_NAMESPACE: ${{ env.CONTAINER_REGISTRY_NAMESPACE }}
+          DOCKER_IMAGE_NAME: ${{ env.DOCKER_IMAGE_NAME }}
+          IBMCLOUD_REGION: ${{ env.IBMCLOUD_REGION }}
+          IBMCLOUD_RESOURCE_GROUP: ${{ env.IBMCLOUD_RESOURCE_GROUP }}
+          PR_TAG: ${{ env.PR_TAG }}
+        secrets:
+          IBMCLOUD_ACCOUNT: ${{ env.IBMCLOUD_ACCOUNT }}
+          IBMCLOUD_API_KEY: ${{ env.IBMCLOUD_API_KEY }}
 
       - name: Setup IBM Cloud CLI
         run: |

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,41 +1,21 @@
-name: Preview
+name: PR Preview
 
 # run when a pull request is made
 on: [pull_request]
 
 jobs:
-  setup:
-    # Prevents action to be executed by forks and draft
-    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
-    uses: Qiskit/gh-actions/.github/workflows/preview-setup.yml@split-workflow
-    with:
-      container_registry_namespace: community-digital
-      docker_image_name: qiskit-org
-      ibmcloud_region: us-south
-      ibmcloud_resource_group: Quantum Community
-    secrets:
-      ibmcloud_account: ${{ secrets.IBMCLOUD_ACCOUNT }}
-      ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}  
-  build-push:
+  preview:
     # Prevents action to be executed by forks and drafts
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
-    uses: Qiskit/gh-actions/.github/workflows/qiskit-org-build-push.yml@split-workflow
-    with:
-      container_registry_namespace: community-digital
-      docker_image_name: qiskit-org
-    secrets:
-      ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}
-  deploy:
-    # Prevents action to be executed by forks and drafts
-    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
-    uses: Qiskit/gh-actions/.github/workflows/preview-deploy.yml@split-workflow
+    uses: Qiskit/gh-actions/.github/workflows/code-engine-preview.yml@main
     with:
       container_registry_namespace: community-digital
       code_engine_project: qiskit.org-preview
       code_engine_registry_secret: ibm-container-registry
-      deployment_id: ${{ needs.setup.outputs.deployment_id }}
       docker_image_name: qiskit-org
       docker_image_port: "3000"
+      ibmcloud_region: us-south
+      ibmcloud_resource_group: Quantum Community
     secrets:
       ibmcloud_account: ${{ secrets.IBMCLOUD_ACCOUNT }}
-      ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}
+      ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}    

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -32,7 +32,7 @@ jobs:
       container_registry_namespace: community-digital
       code_engine_project: qiskit.org-preview
       code_engine_registry_secret: ibm-container-registry
-      depoyment_id: ${{ needs.setup.outputs.depoyment_id }}
+      depoyment_id: ${{ needs.setup.outputs.deployment_id }}
       docker_image_name: qiskit-org
       docker_image_port: "3000"
     secrets:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -4,18 +4,37 @@ name: PR Preview
 on: [pull_request]
 
 jobs:
-  preview:
+  setup:
     # Prevents action to be executed by forks and drafts
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
-    uses: Qiskit/gh-actions/.github/workflows/code-engine-preview.yml@main
+    uses: Qiskit/gh-actions/.github/workflows/preview-setup.yml@split-workflow
     with:
-      container_registry_namespace: community-digital
-      code_engine_project: qiskit.org-preview
-      code_engine_registry_secret: ibm-container-registry
       docker_image_name: qiskit-org
-      docker_image_port: "3000"
       ibmcloud_region: us-south
       ibmcloud_resource_group: Quantum Community
     secrets:
       ibmcloud_account: ${{ secrets.IBMCLOUD_ACCOUNT }}
-      ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}    
+      ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}  
+  build-push:
+    # Prevents action to be executed by forks and drafts
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
+    uses: Qiskit/gh-actions/.github/workflows/qiskit-org-build-push.yml@split-workflow
+    with:
+      container_registry_namespace: community-digital
+      docker_image_name: qiskit-org
+    secrets:
+      ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}
+  deploy:
+    # Prevents action to be executed by forks and drafts
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
+    uses: Qiskit/gh-actions/.github/workflows/preview-deploy.yml@split-workflow
+    with:
+      container_registry_namespace: community-digital
+      code_engine_project: qiskit.org-preview
+      code_engine_registry_secret: ibm-container-registry
+      depoyment_id: ${{ needs.setup.outputs.depoyment_id }}
+      docker_image_name: qiskit-org
+      docker_image_port: "3000"
+    secrets:
+      ibmcloud_account: ${{ secrets.IBMCLOUD_ACCOUNT }}
+      ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,4 +1,4 @@
-name: PR Preview
+name: Preview
 
 # run when a pull request is made
 on: [pull_request]

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -32,7 +32,7 @@ jobs:
       container_registry_namespace: community-digital
       code_engine_project: qiskit.org-preview
       code_engine_registry_secret: ibm-container-registry
-      depoyment_id: ${{ needs.setup.outputs.deployment_id }}
+      deployment_id: ${{ needs.setup.outputs.deployment_id }}
       docker_image_name: qiskit-org
       docker_image_port: "3000"
     secrets:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -7,15 +7,11 @@ jobs:
   code-engine:
     # Prevents action to be executed by forks and drafts
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
-    uses: Qiskit/gh-actions/.github/workflows/code-engine-preview.yml@last-configuration
+    uses: Qiskit/gh-actions/.github/workflows/code-engine-preview.yml@main
     with:
-      container_registry_namespace: community-digital
       code_engine_project: qiskit.org-preview
-      code_engine_registry_secret: ibm-container-registry
       docker_image_name: qiskit-org
       docker_image_port: "3000"
-      ibmcloud_region: us-south
-      ibmcloud_resource_group: Quantum Community
     secrets:
       ibmcloud_account: ${{ secrets.IBMCLOUD_ACCOUNT }}
       ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 
 jobs:
   setup:
-    # Prevents action to be executed by forks and drafts
+    # Prevents action to be executed by forks and draft
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     uses: Qiskit/gh-actions/.github/workflows/preview-setup.yml@split-workflow
     with:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,95 +8,17 @@ jobs:
     # Prevents action to be executed by forks and drafts
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    env:
-      CONTAINER_REGISTRY_NAMESPACE: community-digital
-      DOCKER_IMAGE_NAME: qiskit-org
-      DOCKER_IMAGE_PORT: "3000"
-      PR_TAG: pr-${{ github.event.pull_request.number }}
-
-      IBMCLOUD_ACCOUNT: ${{ secrets.IBMCLOUD_ACCOUNT }}
-      IBMCLOUD_API_KEY: ${{ secrets.IBMCLOUD_API_KEY }}
-      IBMCLOUD_REGION: us-south
-      IBMCLOUD_RESOURCE_GROUP: Quantum Community
-      CODE_ENGINE_PROJECT: qiskit.org-preview
-      CODE_ENGINE_REGISTRY_SECRET: ibm-container-registry
-
-    steps:
-      - name: Fetch content of the PR
-        uses: actions/checkout@v2
-
-      - name: GH deployment status (start)
-        uses: bobheadxi/deployments@v0.4.3
-        id: gh_deployment
-        env:
-          APP_NAME: ${{ env.DOCKER_IMAGE_NAME }}-${{ env.PR_TAG }}
-        with:
-          step: start
-          token: ${{ github.token }}
-          env: ${{ env.APP_NAME }}
-          auto_inactive: true
-          ref: ${{ github.event.pull_request.head.ref }}
-
-      - name: Build and push Docker image to IBM container registry
-        uses: Qiskit/gh-actions/.github/workflows/build-publish-docker-image.yml@main
-        with:
-          CONTAINER_REGISTRY_NAMESPACE: ${{ env.CONTAINER_REGISTRY_NAMESPACE }}
-          DOCKER_IMAGE_NAME: ${{ env.DOCKER_IMAGE_NAME }}
-          IBMCLOUD_REGION: ${{ env.IBMCLOUD_REGION }}
-          IBMCLOUD_RESOURCE_GROUP: ${{ env.IBMCLOUD_RESOURCE_GROUP }}
-          PR_TAG: ${{ env.PR_TAG }}
-        secrets:
-          IBMCLOUD_ACCOUNT: ${{ env.IBMCLOUD_ACCOUNT }}
-          IBMCLOUD_API_KEY: ${{ env.IBMCLOUD_API_KEY }}
-
-      - name: Setup IBM Cloud CLI
-        run: |
-          curl -fsSL https://clis.cloud.ibm.com/install/linux | sh
-          ibmcloud --version
-          ibmcloud config --check-version=false
-          ibmcloud plugin install -f code-engine
-          ibmcloud plugin install -f container-registry
-
-      - name: Authenticate with IBM Cloud CLI
-        run: |
-          ibmcloud login -g "$IBMCLOUD_RESOURCE_GROUP" -r "$IBMCLOUD_REGION" -c "$IBMCLOUD_ACCOUNT" --apikey $IBMCLOUD_API_KEY
-
-      - name: Determine Code Engine project and app status
-        id: ce_command_choice
-        env:
-          APP_NAME: ${{ env.DOCKER_IMAGE_NAME }}-${{ env.PR_TAG }}
-        run: |
-          ibmcloud ce project select -n "$CODE_ENGINE_PROJECT"
-          if ibmcloud ce app list -q | grep "$APP_NAME" ; then
-            echo "::set-output name=command::update"
-          else
-            echo "::set-output name=command::create"
-          fi
-
-      - name: Create a new preview application in Code Engine
-        id: ce_app_creation
-        env:
-          APP_NAME: ${{ env.DOCKER_IMAGE_NAME }}-${{ env.PR_TAG }}
-          DOCKER_IMAGE_TAG: icr.io/community-digital/${{ env.DOCKER_IMAGE_NAME }}:${{ env.PR_TAG }}
-        run: |
-          ibmcloud ce app ${{ steps.ce_command_choice.outputs.command }} \
-            --name "$APP_NAME" \
-            --image "$DOCKER_IMAGE_TAG" \
-            --registry-secret "$CODE_ENGINE_REGISTRY_SECRET" \
-            --port $DOCKER_IMAGE_PORT \
-            --cpu 0.25 \
-            --memory 0.5G \
-            --min 1
-          echo "::set-output name=preview_url::$(\
-            ibmcloud ce app get --name "$APP_NAME" --output url
-          )"
-
-      - name: GH deployment status (finish)
-        uses: bobheadxi/deployments@v0.4.3
-        if: always()
-        with:
-          step: finish
-          token: ${{ github.token }}
-          status: ${{ job.status }}
-          deployment_id: ${{ steps.gh_deployment.outputs.deployment_id }}
-          env_url: "${{ steps.ce_app_creation.outputs.preview_url }}"
+    docker-image-preview:
+      uses: Qiskit/gh-actions/.github/workflows/code-engine-preview.yml@main
+      with:
+        container_registry_namespace: community-digital
+        code_engine_project: qiskit.org-preview
+        code_engine_registry_secret: ibm-container-registry
+        docker_image_name: qiskit-org
+        docker_image_port: "3000"
+        ibmcloud_region: us-south
+        ibmcloud_resource_group: Quantum Community
+        pr_tag: pr-${{ github.event.pull_request.number }}
+      secrets:
+        ibmcloud_account: ${{ secrets.IBMCLOUD_ACCOUNT }}
+        ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -4,21 +4,19 @@ name: PR Preview
 on: [pull_request]
 
 jobs:
-  preview:
+  docker-image-preview:
     # Prevents action to be executed by forks and drafts
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    docker-image-preview:
-      uses: Qiskit/gh-actions/.github/workflows/code-engine-preview.yml@main
-      with:
-        container_registry_namespace: community-digital
-        code_engine_project: qiskit.org-preview
-        code_engine_registry_secret: ibm-container-registry
-        docker_image_name: qiskit-org
-        docker_image_port: "3000"
-        ibmcloud_region: us-south
-        ibmcloud_resource_group: Quantum Community
-        pr_tag: pr-${{ github.event.pull_request.number }}
-      secrets:
-        ibmcloud_account: ${{ secrets.IBMCLOUD_ACCOUNT }}
-        ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}
+    uses: Qiskit/gh-actions/.github/workflows/code-engine-preview.yml@main
+    with:
+      container_registry_namespace: community-digital
+      code_engine_project: qiskit.org-preview
+      code_engine_registry_secret: ibm-container-registry
+      docker_image_name: qiskit-org
+      docker_image_port: "3000"
+      ibmcloud_region: us-south
+      ibmcloud_resource_group: Quantum Community
+      pr_tag: pr-${{ github.event.pull_request.number }}
+    secrets:
+      ibmcloud_account: ${{ secrets.IBMCLOUD_ACCOUNT }}
+      ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}    

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -16,7 +16,6 @@ jobs:
       docker_image_port: "3000"
       ibmcloud_region: us-south
       ibmcloud_resource_group: Quantum Community
-      pr_tag: pr-${{ github.event.pull_request.number }}
     secrets:
       ibmcloud_account: ${{ secrets.IBMCLOUD_ACCOUNT }}
       ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}    

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -4,7 +4,7 @@ name: PR Preview
 on: [pull_request]
 
 jobs:
-  docker-image-preview:
+  preview:
     # Prevents action to be executed by forks and drafts
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     uses: Qiskit/gh-actions/.github/workflows/code-engine-preview.yml@main

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -7,7 +7,7 @@ jobs:
   code-engine:
     # Prevents action to be executed by forks and drafts
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
-    uses: Qiskit/gh-actions/.github/workflows/code-engine-preview.yml@main
+    uses: Qiskit/gh-actions/.github/workflows/code-engine-preview.yml@last-configuration
     with:
       container_registry_namespace: community-digital
       code_engine_project: qiskit.org-preview
@@ -18,4 +18,4 @@ jobs:
       ibmcloud_resource_group: Quantum Community
     secrets:
       ibmcloud_account: ${{ secrets.IBMCLOUD_ACCOUNT }}
-      ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}    
+      ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -9,6 +9,7 @@ jobs:
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     uses: Qiskit/gh-actions/.github/workflows/preview-setup.yml@split-workflow
     with:
+      container_registry_namespace: community-digital
       docker_image_name: qiskit-org
       ibmcloud_region: us-south
       ibmcloud_resource_group: Quantum Community

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,10 +1,10 @@
-name: PR Preview
+name: Preview
 
 # run when a pull request is made
 on: [pull_request]
 
 jobs:
-  preview:
+  code-engine:
     # Prevents action to be executed by forks and drafts
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     uses: Qiskit/gh-actions/.github/workflows/code-engine-preview.yml@main


### PR DESCRIPTION
This PR tries to reuse the new github action that builds and push a docker image to IBM container registry. We are externalising it to improve the reusable logic between projects and interoperability.

Fix #2398 
Related with #2395 