### PR TITLE
Fix docker installation dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:14-alpine
 WORKDIR /qiskit.org
 
-COPY package.json .
-RUN npm install
+COPY package*.json ./
+RUN npm ci
 
 COPY app app/
 COPY assets assets/


### PR DESCRIPTION
In this PR we are adding the `package-lock` and the `npm ci` to the Dockerfile to avoid versions problems between libraries updates.

Fix #2399 