### PR TITLE
Run `generate` instead of `build`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:14-alpine
 WORKDIR /qiskit.org
 
-COPY package.json .
-RUN npm install
+COPY package*.json .
+RUN npm ci
 
 COPY app app/
 COPY assets assets/
@@ -23,9 +23,11 @@ COPY .eslintrc.js jest.config.js jest.setup.js \
      ./
 COPY tests tests/
 COPY components components/
-RUN npm run build
+RUN npm run generate
 
 EXPOSE 3000
-ENV HOST=0.0.0.0
-ENV NODE_ENV=development
-CMD [ "npx", "nuxt", "start" ]
+
+ENV NUXT_HOST=0.0.0.0
+ENV NUXT_PORT=3000
+
+CMD [ "npm", "start" ]


### PR DESCRIPTION
Fix https://github.com/Qiskit/qiskit.org/issues/2395

this PR updates the build script in the Dockerfile to use Nuxt generate (`npm run generate`) instead of just Nuxt build (`npm run build`)

Nuxt build does not create the `/dist` directory needed for deploying of static target
