### PR TITLE
Remove abdonrd as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-* @delapuente @y4izus @techtolentino @korgan00 @eddybrando @abdonrd
+* @delapuente @y4izus @techtolentino @korgan00 @eddybrando
 content/advocates/*   @lerongil
 content/events/*      @justjosie @KallieFerguson @lerongil


### PR DESCRIPTION
I don't need to be strictly a reviewer for all PRs.
There are many PRs that I have no knowledge or context of.
And so I reduce the level of email notifications.
I still watching the repo, so I see the activity in the [GitHub notifications](https://github.com/notifications).