### PR TITLE
Fix deploy.yml quotes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
   build-and-deploy:
     # Run only from the original repository
     # Because this job requires secrets, which cannot be shared with forks
-    if: github.repository == "Qiskit/qiskit.org"
+    if: github.repository == 'Qiskit/qiskit.org'
 
     name: Build and Deploy
 


### PR DESCRIPTION
Seems like double quotes doesn't work on the `if` condition:

https://github.com/Qiskit/qiskit.org/actions/runs/1708639108