### PR TITLE
Adjust front page to show Python 3.7+ is required

### DIFF
--- a/components/landing/TheQuickStart/StartLocally.vue
+++ b/components/landing/TheQuickStart/StartLocally.vue
@@ -6,7 +6,7 @@
       <AppLink
         url="https://www.python.org/downloads/"
       >
-        Python 3.6+.
+        Python 3.7+.
       </AppLink>
       Although it is not required, we recommend using a
       <AppLink


### PR DESCRIPTION
## Changes components/landing/TheQuickStart/StartLocally.vue

<!--
  Required.

  Briefly describe the changes introduced by this pull request.
  Also link relevant issues with the "closes", "fixes" or "resolves" keywords,
  and add co-authors where appropriate with the "co-authored-by" keyword.

  Example:
  Implemented the functionality to update the user's name.
  Closes #42
  Co-authored-by: @octocat
-->

Qiskit versions starting with 0.35 require Python 3.7 or higher.

The front page of qiskit.org should be updated, as Qiskit 0.35 was released on March 31.

