### PR TITLE
Course Overview pages — preview image overlapping footer

### DIFF
--- a/components/logic/CourseOverviewPage.vue
+++ b/components/logic/CourseOverviewPage.vue
@@ -78,7 +78,8 @@ export default abstract class CourseOverviewPage extends QiskitPage {
     margin-top: $spacing-10;
 
     ::v-deep .course-pages-section__main {
-      max-height: 32.5rem;
+      min-height: 20rem;
+      height: max-content;
     }
   }
 


### PR DESCRIPTION
## Changes

Fix https://github.com/Qiskit/qiskit.org/issues/2567

## How to read this PR

`/textbook-beta/course/machine-learning-course`
`/textbook-beta/summer-school/quantum-computing-and-quantum-learning-2021`

