### PR TITLE
extend external recommended readings component

### DIFF
--- a/components/logic/CourseOverviewPage.vue
+++ b/components/logic/CourseOverviewPage.vue
@@ -24,9 +24,10 @@
       :data="prerequisites"
     />
     <ExternalRecommendedReadings
-      v-if="links.length > 0"
+      v-if="links.length > 0 || references.length > 0"
       class="course-overview-page__section"
       :links="links"
+      :references="references"
     />
     <CoursePagesSection class="course-overview-page__section" :courses="courses" :img-base="imageUrlBase" />
   </main>
@@ -51,6 +52,8 @@ export default abstract class CourseOverviewPage extends QiskitPage {
   abstract startLearningCTA: GeneralLink
 
   abstract links: GeneralLink[]
+
+  abstract references: string[]
 
   abstract courses: Course[]
 

--- a/components/textbook-beta/ExternalRecommendedReadings.vue
+++ b/components/textbook-beta/ExternalRecommendedReadings.vue
@@ -3,6 +3,13 @@
     <h2>
       External recommended readings
     </h2>
+    <p
+      v-for="reference in references"
+      :key="reference.label"
+      class="external-recommended-readings__reference"
+    >
+      {{ reference }}
+    </p>
     <AppLink
       v-for="link in links"
       :key="link.label"
@@ -23,15 +30,22 @@ import { GeneralLink } from '~/constants/appLinks'
 @Component
 export default class ExternalRecommendedReadings extends Vue {
   @Prop({ type: Array, required: true }) links!: GeneralLink[]
+  @Prop({ type: Array, required: false }) references!: GeneralLink[]
 }
 </script>
 
 <style lang="scss" scoped>
+@import '~carbon-components/scss/globals/scss/typography';
+
 .external-recommended-readings {
   &__link {
     display: block;
     margin-bottom: $spacing-01;
     width: fit-content;
+  }
+
+  &__reference {
+    margin-bottom: $spacing-01;
   }
 }
 </style>

--- a/pages/textbook-beta/course/introduction-course.vue
+++ b/pages/textbook-beta/course/introduction-course.vue
@@ -43,6 +43,7 @@ export default class IntroductionCoursePage extends CourseOverviewPage {
     }
   }
 
+  references: string[] = []
   links: GeneralLink[] = [
     {
       url: 'https://math.mit.edu/~gs/linearalgebra/',

--- a/pages/textbook-beta/course/machine-learning-course.vue
+++ b/pages/textbook-beta/course/machine-learning-course.vue
@@ -23,7 +23,7 @@ export default class QuantumMachineLearningCoursePage extends CourseOverviewPage
   unsupervised learning such as quantum kernels and general adversarial networks.
   This course finishes with a project that you can use to showcase what you've
   learnt.`,
-  `This course was created by IBM Quantum with the help of Qiskit Advocates 
+  `This course was created by IBM Quantum with the help of Qiskit Advocates
   through the Qiskit Advocate Mentoring Program.`]
 
   headerImg = '/images/textbook-beta/course/machine-learning-course/header.png'
@@ -36,6 +36,7 @@ export default class QuantumMachineLearningCoursePage extends CourseOverviewPage
     }
   }
 
+  references: string[] = []
   links: GeneralLink[] = []
 
   prerequisites: Prerequisite[] = []

--- a/pages/textbook-beta/summer-school/introduction-to-quantum-computing-and-quantum-hardware-2020.vue
+++ b/pages/textbook-beta/summer-school/introduction-to-quantum-computing-and-quantum-hardware-2020.vue
@@ -14,12 +14,12 @@ export default class SummerSchoolCoursePage extends CourseOverviewPage {
 
   headerTitle = '2020 Qiskit Global Summer School on Quantum Computing and Quantum Hardware'
   headerDescription = [
-    `This course is an introduction to the world of quantum computing, with 
-    an exploration of some of the key quantum algorithms and their 
-    implementations using quantum circuits, as well as the quantum hardware 
-    that is designed to run these algorithms. The course was first offered 
-    during the Qiskit Global Summer School in July 2020 as a two-week intensive 
-    summer school. There are 27 lectures in this course, which cover the 
+    `This course is an introduction to the world of quantum computing, with
+    an exploration of some of the key quantum algorithms and their
+    implementations using quantum circuits, as well as the quantum hardware
+    that is designed to run these algorithms. The course was first offered
+    during the Qiskit Global Summer School in July 2020 as a two-week intensive
+    summer school. There are 27 lectures in this course, which cover the
     material in 9 lecture notes and 9 associated labs.`
   ]
 
@@ -104,6 +104,7 @@ export default class SummerSchoolCoursePage extends CourseOverviewPage {
     }
   ]
 
+  references: string[] = []
   links: GeneralLink[] = []
 
   prerequisites: Prerequisite[] = [

--- a/pages/textbook-beta/summer-school/quantum-computing-and-quantum-learning-2021.vue
+++ b/pages/textbook-beta/summer-school/quantum-computing-and-quantum-learning-2021.vue
@@ -14,9 +14,9 @@ export default class SummerSchoolCoursePage extends CourseOverviewPage {
 
   headerTitle = '2021 Qiskit Global Summer School on Quantum Machine Learning'
   headerDescription = [
-    `Quantum computing experts and mentors share valuable insights through 
-    twenty lectures and five applied lab exercises that provide deep-dives 
-    exploring concepts in quantum computing, focused on the implementations 
+    `Quantum computing experts and mentors share valuable insights through
+    twenty lectures and five applied lab exercises that provide deep-dives
+    exploring concepts in quantum computing, focused on the implementations
     of quantum machine learning algorithms in Qiskit.`
   ]
 
@@ -38,6 +38,7 @@ export default class SummerSchoolCoursePage extends CourseOverviewPage {
     }
   }
 
+  references: string[] = []
   links: GeneralLink[] = [
     {
       url: 'http://mmrc.amss.cas.cn/tlb/201702/W020170224608149940643.pdf',


### PR DESCRIPTION
## Changes

Fixes #2571 


## Implementation details

- added new `references` prop to component for plain text recommendations that are not links
- added references arrays to each of the learning pages (even if empty for now)
- following the designs, text-only recommendations will always be above links

## How to add references
```
references: string[] = [
    'Michael Nielsen and Isaac Chuang. Quantum Computation and Quantum Information (Chapter 1). Cambridge University Press, 2000.',
    'Phillip Kaye, Raymond Laflamme, and Michele Mosca. An Introduction to Quantum Computing (Chapters 1-3). Oxford University Press, 2007.'
  ]
```

## Screenshots 
(example only, based on snippet above)
<br>
![Screen Shot 2022-05-06 at 6 18 25 AM](https://user-images.githubusercontent.com/6276074/167148035-e23bf2be-8a37-4359-a08c-aaccc01c405d.png)



