### PR TITLE
Fix description content on cards

### DIFF
--- a/components/textbook-beta/StartLearningSection.vue
+++ b/components/textbook-beta/StartLearningSection.vue
@@ -29,6 +29,7 @@
               image-contain
               :title="courseTitle"
               class="start-learning-section__card"
+              :description-whole-size="true"
             >
               {{ courseDescription }}
             </AppCard>

--- a/components/ui/AppCard.vue
+++ b/components/ui/AppCard.vue
@@ -187,8 +187,8 @@ export default class AppCard extends Vue {
 
 .app-card_description-whole-size {
   .app-card {
-    &__content {
-      gap: $spacing-03;
+    &__header {
+      min-height: $spacing-09;
     }
     &__body {
       display: flex;

--- a/components/ui/AppCard.vue
+++ b/components/ui/AppCard.vue
@@ -1,7 +1,10 @@
 <template>
   <article
     class="app-card"
-    :class="{'app-card_vertical': verticalLayout}"
+    :class="{
+      'app-card_vertical': verticalLayout,
+      'app-card_description-whole-size': descriptionWholeSize
+    }"
   >
     <div
       class="app-card__image"
@@ -22,7 +25,7 @@
           />
         </div>
       </header>
-      <div>
+      <div class="app-card__body">
         <div class="app-card__description">
           <slot />
         </div>
@@ -53,6 +56,7 @@ export default class AppCard extends Vue {
   @Prop({ type: String, default: '' }) ctaLabel!: string
   @Prop({ type: Object, required: false }) segment: CtaClickedEventProp | undefined
   @Prop({ type: Boolean, default: false }) verticalLayout!: Boolean
+  @Prop({ type: Boolean, default: false }) descriptionWholeSize!: Boolean
 
   get ctaLink () {
     return {
@@ -177,6 +181,20 @@ export default class AppCard extends Vue {
       @include mq($from: small, $until: medium) {
         min-height: 6 * $column-size-large;
       }
+    }
+  }
+}
+
+.app-card_description-whole-size {
+  .app-card {
+    &__content {
+      gap: $spacing-03;
+    }
+    &__body {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      flex: 1;
     }
   }
 }


### PR DESCRIPTION
## Changes

Per offline conversations with @techtolentino, this description doesn't look so good.

![Screen Shot 2022-05-12 at 8 40 59 AM](https://user-images.githubusercontent.com/4138279/168119639-90995bed-f41d-44d3-9b96-74f5d2df7fc6.png)

This PR adds an additional configuration for the `AppCard`.

## How to read this PR

`/textbook-beta/`