### PR TITLE
add runtime banner

### DIFF
--- a/layouts/default-max.vue
+++ b/layouts/default-max.vue
@@ -38,7 +38,7 @@ export default class MaxLayout extends Vue {
 @import "@carbon/colors/scss/colors";
 
 .qiskit-banner.qiskit-runtime {
-  background: $background-color-lighter !important;
+  background-color: $background-color-lighter !important;
 
   .banner-title {
     color: $cool-gray-100;

--- a/layouts/default-max.vue
+++ b/layouts/default-max.vue
@@ -3,18 +3,6 @@
   <div tabindex="-1">
     <header id="navigation">
       <TheMenu @change-visibility="isMenuShown = $event === 'shown'" />
-      <QiskitBanner padding-x-none class="qiskit-runtime">
-        <div class="bx--grid">
-          <span class="banner-title">Start building with Qiskit runtime.</span>
-          <span class="banner-message">Leverage the new programming model and execution framework to efficiently execute circuits.</span>
-          <AppLink
-            :segment="{ action: `banner > qiskit-runtime` }"
-            url="https://qiskit.org/documentation/partners/qiskit_ibm_runtime/"
-          >
-            Learn more
-          </AppLink>
-        </div>
-      </QiskitBanner>
     </header>
     <nuxt />
     <PageFooter theme="light" />
@@ -24,36 +12,9 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
-import QiskitBanner from '@qiskit-community/qiskit-vue/src/components/banner/Banner.vue'
 
-@Component({
-  components: { QiskitBanner }
-})
+@Component
 export default class MaxLayout extends Vue {
   isMenuShown: boolean = false
 }
 </script>
-
-<style lang="scss">
-@import "@carbon/colors/scss/colors";
-
-.qiskit-banner.qiskit-runtime {
-  background-color: $background-color-lighter !important;
-
-  .banner-title {
-    color: $cool-gray-100;
-    font-weight: 600;
-  }
-
-  .banner-message {
-    color: $cool-gray-100;
-  }
-
-  .app-link,
-  .app-link:visited {
-    color: $active-color !important;
-    text-decoration: none;
-    float: right;
-  }
-}
-</style>

--- a/layouts/default-max.vue
+++ b/layouts/default-max.vue
@@ -3,6 +3,18 @@
   <div tabindex="-1">
     <header id="navigation">
       <TheMenu @change-visibility="isMenuShown = $event === 'shown'" />
+      <QiskitBanner padding-x-none class="qiskit-runtime">
+        <div class="bx--grid">
+          <span class="banner-title">Start building with Qiskit runtime.</span>
+          <span class="banner-message">Leverage the new programming model and execution framework to efficiently execute circuits.</span>
+          <AppLink
+            :segment="{ action: `banner > qiskit-runtime` }"
+            url="https://qiskit.org/documentation/partners/qiskit_ibm_runtime/"
+          >
+            Learn more
+          </AppLink>
+        </div>
+      </QiskitBanner>
     </header>
     <nuxt />
     <PageFooter theme="light" />
@@ -12,9 +24,36 @@
 <script lang="ts">
 import Vue from 'vue'
 import { Component } from 'vue-property-decorator'
+import QiskitBanner from '@qiskit-community/qiskit-vue/src/components/banner/Banner.vue'
 
-@Component
+@Component({
+  components: { QiskitBanner }
+})
 export default class MaxLayout extends Vue {
   isMenuShown: boolean = false
 }
 </script>
+
+<style lang="scss">
+@import "@carbon/colors/scss/colors";
+
+.qiskit-banner.qiskit-runtime {
+  background: $background-color-lighter !important;
+
+  .banner-title {
+    color: $cool-gray-100;
+    font-weight: 600;
+  }
+
+  .banner-message {
+    color: $cool-gray-100;
+  }
+
+  .app-link,
+  .app-link:visited {
+    color: $active-color !important;
+    text-decoration: none;
+    float: right;
+  }
+}
+</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,17 @@
 <template>
   <main class="landing-page">
+    <QiskitBanner padding-x-none class="qiskit-runtime">
+      <div class="bx--grid">
+        <span class="banner-title">Start building with Qiskit runtime.</span>
+        <span class="banner-message">Leverage the new programming model and execution framework to efficiently execute circuits.</span>
+        <AppLink
+          :segment="{ action: `banner > qiskit-runtime` }"
+          url="https://qiskit.org/documentation/partners/qiskit_ibm_runtime/"
+        >
+          Learn more
+        </AppLink>
+      </div>
+    </QiskitBanner>
     <TheHeroMoment :version="qiskitVersion" />
     <TheQuickStart />
     <TheQiskitCapabilitiesSection />
@@ -11,6 +23,7 @@
 import axios from 'axios'
 import { Component } from 'vue-property-decorator'
 import QiskitPage from '~/components/logic/QiskitPage.vue'
+import QiskitBanner from '@qiskit-community/qiskit-vue/src/components/banner/Banner.vue'
 
 @Component({
   head () {
@@ -23,9 +36,34 @@ import QiskitPage from '~/components/logic/QiskitPage.vue'
     return {
       qiskitVersion: packageInfo.info.version
     }
-  }
+  },
+  components: { QiskitBanner }
 })
 export default class LandingPage extends QiskitPage {
   routeName = 'qiskit-landing-page'
 }
 </script>
+
+<style lang="scss">
+@import "@carbon/colors/scss/colors";
+
+.qiskit-banner.qiskit-runtime {
+  background-color: $background-color-lighter !important;
+
+  .banner-title {
+    color: $cool-gray-100;
+    font-weight: 600;
+  }
+
+  .banner-message {
+    color: $cool-gray-100;
+  }
+
+  .app-link,
+  .app-link:visited {
+    color: $active-color !important;
+    text-decoration: none;
+    float: right;
+  }
+}
+</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -22,8 +22,8 @@
 <script lang="ts">
 import axios from 'axios'
 import { Component } from 'vue-property-decorator'
-import QiskitPage from '~/components/logic/QiskitPage.vue'
 import QiskitBanner from '@qiskit-community/qiskit-vue/src/components/banner/Banner.vue'
+import QiskitPage from '~/components/logic/QiskitPage.vue'
 
 @Component({
   head () {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -2,8 +2,8 @@
   <main class="landing-page">
     <QiskitBanner padding-x-none class="qiskit-runtime">
       <div class="bx--grid">
-        <span class="banner-title">Start building with Qiskit runtime.</span>
-        <span class="banner-message">Leverage the new programming model and execution framework to efficiently execute circuits.</span>
+        <span class="banner__title">Start building with Qiskit runtime.</span>
+        <span class="banner__message">Leverage the new programming model and execution framework to efficiently execute circuits.</span>
         <AppLink
           :segment="{ action: `banner > qiskit-runtime` }"
           url="https://qiskit.org/documentation/partners/qiskit_ibm_runtime/"
@@ -50,12 +50,12 @@ export default class LandingPage extends QiskitPage {
 .qiskit-banner.qiskit-runtime {
   background-color: $background-color-lighter !important;
 
-  .banner-title {
+  .banner__title {
     color: $cool-gray-100;
     font-weight: 600;
   }
 
-  .banner-message {
+  .banner__message {
     color: $cool-gray-100;
   }
 


### PR DESCRIPTION
## Changes

Fixes https://github.com/Qiskit/qiskit.org/issues/2592

add a banner announcing qiskit runtime to the home page

preview: https://qiskit-org-pr-2594.dcq4xc5i083.us-south.codeengine.appdomain.cloud/

## Implementation details

add QiskitBanner to `index.vue` page with runtime announcement message.
banner style is updated to match design https://www.figma.com/file/hvicTzjohhLyBRbUzmCsfV/2592-home-page-banner

## How to read this PR

- review design and compare to banner in [preview build](https://qiskit-org-pr-2594.dcq4xc5i083.us-south.codeengine.appdomain.cloud/)
- review updates to `pages/index.vue`

## Screenshots

<img width="1246" alt="image" src="https://user-images.githubusercontent.com/13156555/168422121-65b995f9-b548-4fa6-8c61-7f27de15611c.png">


---

CC @JRussellHuffman @lerongil 
