### PR TITLE
Add Chapters section to learn page

### DIFF
--- a/components/textbook-beta/StartLearningSection.vue
+++ b/components/textbook-beta/StartLearningSection.vue
@@ -96,7 +96,13 @@ export default class StartLearningSection extends Vue {
             url: '/textbook-beta/course/machine-learning-course',
             segment: { cta: 'machine-learning', location: 'course' }
           }
-        },
+        }
+      ]
+    },
+    {
+      title: 'Chapters',
+      description: 'These pages are not part of a course, but contain useful reference material.',
+      courses: [
         {
           image: '/images/textbook-beta/course/prerequisites/prerequisites.png',
           title: 'Prerequisites',


### PR DESCRIPTION
## Changes

Fixes #2598 

## Implementation details

- add new "Chapters" section to the `StartLearningSection` 
- organize chapters into the appropriate Chapters section

## Branch preview
https://qiskit-org-pr-2601.dcq4xc5i083.us-south.codeengine.appdomain.cloud/textbook-beta
