### PR TITLE
Restructure homepage code cell comments

### DIFF
--- a/components/landing/TheQiskitCapabilitiesSection/CodeCell.vue
+++ b/components/landing/TheQiskitCapabilitiesSection/CodeCell.vue
@@ -11,7 +11,10 @@
     <div class="code-cell__block" :class="{'code-cell__block_active' : activeBlocks[1]}">
       <pre><span class="code-cell__comment"># prepare your circuit to run</span></pre>
       <pre>from qiskit import IBMQ <span class="code-cell__comment">#2</span></pre>
-      <pre>IBMQ.save_account("YOUR TOKEN")<span class="code-cell__comment">#Get the API token in https://quantum-computing.ibm.com/</span></pre>
+      <pre>&nbsp;</pre>
+      <pre><span class="code-cell__comment"># Get the API token in</span></pre>
+      <pre><span class="code-cell__comment"># https://quantum-computing.ibm.com/</span></pre>
+      <pre>IBMQ.save_account("YOUR TOKEN")</pre>
       <pre>&nbsp;</pre>
       <pre class="code-cell__line">provider = IBMQ.load_account() <span class="code-cell__comment">#3</span></pre>
       <pre class="code-cell__line">backend = provider.get_backend(<span class="code-cell__string">'ibmq_quito'</span>) <span class="code-cell__comment">#4</span></pre>

--- a/components/landing/TheQiskitCapabilitiesSection/CodeCell.vue
+++ b/components/landing/TheQiskitCapabilitiesSection/CodeCell.vue
@@ -4,30 +4,30 @@
       <pre>import qiskit</pre>
       <pre>&nbsp;</pre>
       <pre><span class="code-cell__comment"># Qiskit quantum circuits libraries</span></pre>
-      <pre class="code-cell__line">quantum_circuit = qiskit.circuit.library.QuantumVolume(5) <span class="code-cell__comment">#1</span> <span class="code-cell__comment">#3</span></pre>
+      <pre class="code-cell__line">quantum_circuit = qiskit.circuit.library.QuantumVolume(5)</pre>
       <pre class="code-cell__line">quantum_circuit.measure_all()</pre>
       <pre class="code-cell__line">quantum_circuit.draw()</pre>
     </div>
     <div class="code-cell__block" :class="{'code-cell__block_active' : activeBlocks[1]}">
       <pre><span class="code-cell__comment"># prepare your circuit to run</span></pre>
-      <pre>from qiskit import IBMQ <span class="code-cell__comment">#2</span></pre>
+      <pre>from qiskit import IBMQ</pre>
       <pre>&nbsp;</pre>
       <pre><span class="code-cell__comment"># Get the API token in</span></pre>
       <pre><span class="code-cell__comment"># https://quantum-computing.ibm.com/</span></pre>
       <pre>IBMQ.save_account("YOUR TOKEN")</pre>
       <pre>&nbsp;</pre>
-      <pre class="code-cell__line">provider = IBMQ.load_account() <span class="code-cell__comment">#3</span></pre>
-      <pre class="code-cell__line">backend = provider.get_backend(<span class="code-cell__string">'ibmq_quito'</span>) <span class="code-cell__comment">#4</span></pre>
+      <pre class="code-cell__line">provider = IBMQ.load_account()</pre>
+      <pre class="code-cell__line">backend = provider.get_backend(<span class="code-cell__string">'ibmq_quito'</span>)</pre>
       <pre>&nbsp;</pre>
-      <pre class="code-cell__line">optimized_circuit = qiskit.transpile(quantum_circuit, backend) <span class="code-cell__comment">#5</span></pre>
+      <pre class="code-cell__line">optimized_circuit = qiskit.transpile(quantum_circuit, backend)</pre>
       <pre class="code-cell__line">optimized_circuit.draw()</pre>
     </div>
     <div class="code-cell__block" :class="{'code-cell__block_active' : activeBlocks[2]}">
       <pre><span class="code-cell__comment"># run in real hardware</span></pre>
       <pre class="code-cell__line">job = backend.run(optimized_circuit)</pre>
       <pre class="code-cell__line">retrieved_job = backend.retrieve_job(job.job_id())</pre>
-      <pre class="code-cell__line">result = retrieved_job.result() <span class="code-cell__comment">#6</span></pre>
-      <pre class="code-cell__line">print(result.get_counts()) <span class="code-cell__comment">#7</span></pre>
+      <pre class="code-cell__line">result = retrieved_job.result()</pre>
+      <pre class="code-cell__line">print(result.get_counts())</pre>
     </div>
   </code>
 </template>


### PR DESCRIPTION
## Changes

Fixes #2617 

## Implementation details

- made updates to the homepage "What Can Qiskit Do" section
- removed the _numbered_ comments that seemed to be out of order, and not have meaning
- split long comment into multiline

## How to read this PR

- review the updated comments
- review UI at different breakpoints

**Note:** the first obvious solution was to use some sort of overflow + scrolling solution, however, I opted for this pattern so that the code is _always_ within view, and the user wouldn't have to scroll to see the rest of _any_ code. (In addition, going the overflow + scroll route required more code changes that needed)

## Branch preview
https://qiskit-org-pr-2626.dcq4xc5i083.us-south.codeengine.appdomain.cloud/

## Screenshots

https://user-images.githubusercontent.com/6276074/170507108-825af9af-c495-4a17-b731-6896c246f546.mov


