### PR TITLE
Add Summer School registration link

### DIFF
--- a/constants/summerSchool2022Content.ts
+++ b/constants/summerSchool2022Content.ts
@@ -12,8 +12,8 @@ const header = {
     }
   },
   cta: {
-    label: 'Register (Coming Soon!)',
-    url: 'https://qiskit.org/events/summer-school/',
+    label: 'Register now!',
+    url: 'https://www.eventbrite.com/e/2022-qiskit-global-summer-school-quantum-simulations-tickets-348866728777',
     segment: {
       cta: 'register',
       location: 'header'
@@ -27,7 +27,7 @@ const header = {
     location: 'Online',
     date: 'July 18 - 29, 2022',
     time: '',
-    to: '',
+    to: 'https://www.eventbrite.com/e/2022-qiskit-global-summer-school-quantum-simulations-tickets-348866728777',
     ctaLabel: 'Learn more',
     segment: {
       cta: 'ibm-research-blog',


### PR DESCRIPTION
## Changes

Fixes https://github.com/Qiskit/qiskit.org/issues/2628
Adds Summer School 2022 registration link

## Implementation details

Following the [conversation happening in our internal Community Slack channel](https://ibm-quantumcomputing.slack.com/archives/GMU4N7RM0/p1653580820269489), and after syncing with @justjosie, it was decided that our Summer School page needed to be updated.

## How to read this PR

- visit `/events/summer-school`
- review UI and test link

## Screenshots

https://user-images.githubusercontent.com/6276074/170530232-e83099b3-a8cd-488c-985b-47397448c060.mov


