### PR TITLE
Add accessible labels to test icons on ecosystem page

### DIFF
--- a/components/ecosystem/TestTable.vue
+++ b/components/ecosystem/TestTable.vue
@@ -1,16 +1,30 @@
 <template>
   <AppDataTable :columns="['Status', 'Test Type', 'Terra Version']">
-    <cv-data-table-row v-for="(row, rowIndex) in tableData" :key="`${rowIndex}`">
-      <cv-data-table-cell v-for="({component, styles, data}, elementIndex) in row" :key="`${elementIndex}`">
+    <cv-data-table-row
+      v-for="(row, rowIndex) in tableData"
+      :key="`${rowIndex}`"
+    >
+      <cv-data-table-cell
+        v-for="({ component, styles, data }, elementIndex) in row"
+        :key="`${elementIndex}`"
+      >
         <!-- eslint-disable vue/no-v-html -->
-        <span
-          v-if="component == 'span'"
-          :style="styles"
-          v-html="data"
+        <span v-if="component == 'span'" :style="styles" v-html="data" />
+        <CheckmarkFilled16
+          v-else-if="component === true"
+          :fill="styles"
+          aria-label="Passing tests"
         />
-        <CheckmarkFilled16 v-else-if="component === true" :fill="styles" />
-        <ErrorFilled16 v-else-if="component === false" :fill="styles" />
-        <PendingFilled16 v-else fill="#c6c6c6" />
+        <ErrorFilled16
+          v-else-if="component === false"
+          :fill="styles"
+          aria-label="Failing tests"
+        />
+        <PendingFilled16
+          v-else
+          fill="#c6c6c6"
+          aria-label="No test information"
+        />
         <!-- eslint-enable -->
       </cv-data-table-cell>
     </cv-data-table-row>
@@ -24,12 +38,12 @@ import { TableRowElement } from '~/components/ui/AppDataTable.vue'
 
 @Component
 export default class TestTable extends Vue {
-  @Prop({ type: Array, default: () => [['', '', '']] }) filteredData!: Object[]
+  @Prop({ type: Array, default: () => [['', '', '']] }) filteredData!: Object[];
 
-  tableData = this.dataPerRow(this.filteredData)
+  tableData = this.dataPerRow(this.filteredData);
 
-  dataPerRow (filteredData: Object[]) : TableRowElement[][] {
-    return filteredData.map(({ passed, testType, terraVersion }: any) => ([
+  dataPerRow (filteredData: Object[]): TableRowElement[][] {
+    return filteredData.map(({ passed, testType, terraVersion }: any) => [
       {
         component: passed,
         styles: passed ? '#42be65' : '#da1e28',
@@ -43,16 +57,15 @@ export default class TestTable extends Vue {
         component: 'span',
         data: terraVersion
       }
-    ]))
+    ])
   }
 }
-
 </script>
 
 <style lang="scss">
 .test-table {
   padding: 0;
-  background-color: $cool-gray-10
+  background-color: $cool-gray-10;
 }
 
 .bx--data-table th[aria-sort] {
@@ -60,7 +73,8 @@ export default class TestTable extends Vue {
   border-bottom: 1px solid $cool-gray-30;
 }
 
-.bx--data-table tbody tr td, .bx--data-table tbody tr:hover td {
+.bx--data-table tbody tr td,
+.bx--data-table tbody tr:hover td {
   background-color: $cool-gray-10 !important;
   border-bottom: 1px solid $cool-gray-30 !important;
   color: $black-100;


### PR DESCRIPTION
## Changes

Added accessible labels to test status icons on ecosystem page.

Closes  #2653

<!--
  Required.

  Briefly describe the changes introduced by this pull request.
  Also link relevant issues with the "closes", "fixes" or "resolves" keywords,
  and add co-authors where appropriate with the "co-authored-by" keyword.

  Example:
  Implemented the functionality to update the user's name.
  Closes #42
  Co-authored-by: @octocat
-->

## Implementation details

Since the icons are inline `<svg>` elements, they do not support adding an `alt` property. So, since there is no visible text to describe the icons, I opted to implement the accessible labels with `aria-label` as [recommended by MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/img_role#associated_wai-aria_roles_states_and_properties).

<!--
  Optional.

  If useful for the code review, describe implementation details and, if
  necessary, why a certain approach was chosen.

  Example:
  Changes are introduced to the controller and the database model. UI changes
  are not in the scope of this PR.
-->
