### PR TITLE
Bug: Fixed filters bug and put "Main" at top of filters list

### DIFF
--- a/store/ecosystem.ts
+++ b/store/ecosystem.ts
@@ -11,7 +11,6 @@ const getters = <GetterTree<State, any>> {
    * List of members filtered by selected tiers.
    */
   filteredMembers ({ members, tierFilters }): any[] {
-    tierFilters = tierFilters.map((t) => { return t.toUpperCase() })
     const noTierFilters = tierFilters.length === 0
 
     if (noTierFilters) {
@@ -46,8 +45,10 @@ const actions = <ActionTree<State, any>> {
     commit('setMembers', members)
 
     const tiers = [...new Set(members.map(item => item.tier))]
-    const formattedTiers = tiers.map((t) => { return t.toLowerCase() })
-    commit('setTiers', formattedTiers)
+    const idx = tiers.findIndex(i => i == 'Main')
+    tiers.splice(idx, 1)
+    tiers.unshift('Main')
+    commit('setTiers', tiers)
   }
 }
 

--- a/store/ecosystem.ts
+++ b/store/ecosystem.ts
@@ -45,7 +45,7 @@ const actions = <ActionTree<State, any>> {
     commit('setMembers', members)
 
     const tiers = [...new Set(members.map(item => item.tier))]
-    const idx = tiers.findIndex(i => i == 'Main')
+    const idx = tiers.findIndex(i => i === 'Main')
     tiers.splice(idx, 1)
     tiers.unshift('Main')
     commit('setTiers', tiers)

--- a/tests/store/ecosystem.spec.ts
+++ b/tests/store/ecosystem.spec.ts
@@ -13,7 +13,7 @@ const mockMember1 = () => ({
   url: 'https://github.com/member1',
   description: 'This is member1',
   licence: 'Apache-2.0 License',
-  tier: 'MAIN'
+  tier: 'Main'
 })
 
 const mockMember2 = () => ({
@@ -21,7 +21,7 @@ const mockMember2 = () => ({
   url: 'https://github.com/member2',
   description: 'This is member2',
   licence: 'Apache-2.0 License',
-  tier: 'COMMUNITY'
+  tier: 'Community'
 })
 
 const mockMember3 = () => ({
@@ -29,12 +29,12 @@ const mockMember3 = () => ({
   url: 'https://github.com/member3',
   description: 'This is member3',
   licence: 'Apache-2.0 License',
-  tier: 'PROTOTYPES'
+  tier: 'Prototypes'
 })
 
-const mockTier1 = () => 'main'
-const mockTier2 = () => 'community'
-const mockTier3 = () => 'prototypes'
+const mockTier1 = () => 'Main'
+const mockTier2 = () => 'Community'
+const mockTier3 = () => 'Prototypes'
 
 /**
  * GETTERS


### PR DESCRIPTION
## Changes

Due to an update to the ecosystem repo yesterday the filters functionality on the qiskit.org page broke. This PR fixes the issue (caused by changing between upper and lowercase).

This PR also arranges the order of the tier filters so that "Main" is always at the top of the list (and the rest is in the order they appear in `members.json`

@1ucian0 @IceKhan13

## Screenshots
<img width="1563" alt="Screenshot 2022-06-16 at 11 52 50 AM" src="https://user-images.githubusercontent.com/23662430/174113418-93ab4b09-1ca9-4ebd-be72-af4e8e32300a.png">

