### PR TITLE
Ecosystem: Add github star data to project cards

### DIFF
--- a/pages/ecosystem/index.vue
+++ b/pages/ecosystem/index.vue
@@ -67,9 +67,17 @@
                 }"
                 :to="member.url"
               >
-                <p class="project-card__license">
-                  {{ member.licence }}
-                </p>
+                <div class="bx--row">
+                  <p class="project-card__license">
+                    {{ member.licence }}
+                  </p>
+                  <div class="bx--row">
+                    <StarFilled16 />
+                    <p class="project-card__star-val">
+                      {{ member.stars }}
+                    </p>
+                  </div>
+                </div>
                 <p>
                   {{ member.description }}
                 </p>
@@ -197,8 +205,16 @@ export default class EcosystemPage extends QiskitPage {
   padding-bottom: $spacing-08;
 }
 
-.app-card__tags {
-  flex-direction: row;
+.app-card {
+  &__description {
+    .bx--row {
+      margin-left: 0;
+    }
+  }
+
+  &__tags {
+    flex-direction: row;
+  }
 }
 
 .bx--accordion__title {
@@ -231,6 +247,14 @@ export default class EcosystemPage extends QiskitPage {
 .project-card {
   &__license {
     font-size: 12px;
+    margin-right: $spacing-05;
+    margin-top: $spacing-01 / 2;
+  }
+
+  svg {
+    margin-top: $spacing-01 / 2;
+    margin-right: $spacing-01;
+    fill: $cool-gray-60;
   }
 
   .app-card__title {

--- a/plugins/carbon.ts
+++ b/plugins/carbon.ts
@@ -22,6 +22,7 @@ import LogoGitHub32 from '@carbon/icons-vue/lib/logo--github/32'
 import Launch16 from '@carbon/icons-vue/lib/launch/16'
 import ErrorOutline16 from '@carbon/icons-vue/lib/error--outline/16'
 import Copy16 from '@carbon/icons-vue/lib/copy/16'
+import StarFilled16 from '@carbon/icons-vue/lib/star--filled/16'
 
 Vue.use(CarbonComponentsVue)
 Vue.use(CarbonIconsVue, {
@@ -46,6 +47,7 @@ Vue.use(CarbonIconsVue, {
     ErrorOutline16,
     CheckmarkFilled16,
     ErrorFilled16,
-    PendingFilled16
+    PendingFilled16,
+    StarFilled16
   }
 })


### PR DESCRIPTION
## Changes

This PR adds github star data for each project to the cards. We didn't discuss a specific design for the star info so I just went with this simple version. Not sure if just the star icon is clear enough or if there should be some extra text as well? I've seen similar ecosystem pages use the github logo but I personally don't think that is any clearer. Would appreciate any thoughts, particularly from @JRussellHuffman 😄 

## Screenshots
<img width="1342" alt="Screenshot 2022-07-08 at 5 54 38 PM" src="https://user-images.githubusercontent.com/23662430/178075500-f17d0ec3-433d-4ba9-af85-6308413de972.png">
