### PR TITLE
docs: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/user_research.yml
+++ b/.github/ISSUE_TEMPLATE/user_research.yml
@@ -1,0 +1,29 @@
+name: User Research
+description: Define new user research
+title: User Research for ...
+labels: ["user testing"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to create this research story!
+
+        In most cases, the Qiskit Textbook maintainers are the only ones creating and performing user research to test new ideas. If you believe you need to create a research task, please continue and provide as much information as you can.
+  - type: textarea
+    id: background
+    attributes:
+      label: Background
+      description: Set the scene and describe the motivation to conduct this user research
+  - type: textarea
+    id: audience
+    attributes:
+      label: Audience
+      description: High-level description of the intended audience
+    validations:
+      required: true
+  - type: textarea
+    id: relevant
+    attributes:
+      label: Relevant existing research and issues
+      placeholder: |
+        e.g. Relevant issues, user stories, existing research, etc.

--- a/.github/ISSUE_TEMPLATE/user_story.yml
+++ b/.github/ISSUE_TEMPLATE/user_story.yml
@@ -39,6 +39,16 @@ body:
         - Clicking twice fast reproduces sound only once
         - Feature is accessible via voice commands
   - type: textarea
+    id: future-of-feature
+    attributes:
+      label: Future of feature
+      description: After this iteration, how do you see this feature being developed further / integrated across the platform?
+      placeholder: |
+        e.g.
+        - One-off task
+        - Future development ideas (to be validated)
+        - Integrated with X feature
+  - type: textarea
     id: resources
     attributes:
       label: Resources


### PR DESCRIPTION
## Changes

<!--
  Required.

  Briefly describe the changes introduced by this pull request.
  Also link relevant issues with the "closes", "fixes" or "resolves" keywords,
  and add co-authors where appropriate with the "co-authored-by" keyword.

  Example:
  Implemented the functionality to update the user's name.
  Closes #42
  Co-authored-by: @octocat
-->

This is a follow-up of https://github.com/Qiskit/platypus/pull/1353.

> Extended our issue templates to include items from the Sprint Retro:
> 
> - Future of Feature (to `user_story.yml`)
> - User Research Template (`user_research.yml`)
