### PR TITLE
Add redirects for broken pages

### DIFF
--- a/pages/learn/intro-qc-qh.vue
+++ b/pages/learn/intro-qc-qh.vue
@@ -1,0 +1,5 @@
+<template>
+  <head>
+    <meta http-equiv="refresh" content="0; URL=/learn/summer-school/introduction-to-quantum-computing-and-quantum-hardware-2020">
+  </head>
+</template>

--- a/pages/textbook-beta/index.vue
+++ b/pages/textbook-beta/index.vue
@@ -1,3 +1,4 @@
+<!-- eslint-disable vue/multi-word-component-names -->
 <template>
   <head>
     <meta http-equiv="refresh" content="0; URL=/learn">

--- a/pages/textbook-beta/summer-school/quantum-computing-and-quantum-learning-2021.vue
+++ b/pages/textbook-beta/summer-school/quantum-computing-and-quantum-learning-2021.vue
@@ -1,0 +1,5 @@
+<template>
+  <head>
+    <meta http-equiv="refresh" content="0; URL=/learn/summer-school/quantum-computing-and-quantum-learning-2021">
+  </head>
+</template>


### PR DESCRIPTION
## Changes

Fixes #2717 

## Implementation details

- using same redirect strategy that we've used for previous, deprecated pages

## How to review
- visit localhost:3000/learn/intro-qc-qh
- visit localhost:3000/textbook-beta/summer-school/quantum-computing-and-quantum-learning-2021


