### PR TITLE
Ecosystem: Fix tooltip bug

### DIFF
--- a/components/ui/AppCard.vue
+++ b/components/ui/AppCard.vue
@@ -160,11 +160,6 @@ export default class AppCard extends Vue {
   }
 }
 
-.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--align-center
-.bx--assistive-text {
-  width: 10rem;
-}
-
 .app-card_vertical {
   flex-direction: column;
 
@@ -214,6 +209,11 @@ export default class AppCard extends Vue {
 
 <style lang="scss">
 @import '~carbon-components/scss/globals/scss/typography';
+
+.bx--tooltip__trigger.bx--tooltip--bottom.bx--tooltip--align-center
+.bx--assistive-text {
+  width: 10rem;
+}
 
 .app-card {
   .bx--tag--purple {


### PR DESCRIPTION
## Changes
fixes #2759 

## Implementation details
This bug is caused by a css item that was previously moved into the scoped section but actually should have stayed in the global section. This caused that css to be ignored for some reason so this PR just moves it to the correct place so it is actually implemented.

## Screenshots
now the text is not cut off by the side of the screen anymore:
<img width="284" alt="Screenshot 2022-08-23 at 11 17 08 AM" src="https://user-images.githubusercontent.com/23662430/186197761-21b41bc6-b0ea-4e97-87a1-0aa1774f4025.png">
<img width="362" alt="Screenshot 2022-08-23 at 11 17 35 AM" src="https://user-images.githubusercontent.com/23662430/186197763-c3a90343-e96f-4b0d-9f04-5898a7d0018f.png">

cc: @1ucian0 