### PR TITLE
fix(events): add ongoing events in "future events"

### DIFF
--- a/hooks/event-conversion-utils.ts
+++ b/hooks/event-conversion-utils.ts
@@ -74,11 +74,14 @@ function isEventInDateRange (
   const eventStartDate: Date = new Date(startDate)
   const eventEndDate: Date = new Date(endDate)
   const isFutureRange: boolean = days > 0
+  const isOngoingEvent: boolean = eventStartDate <= today && today <= eventEndDate
   let eventDateToCheck: Date
 
   // Determine which date to check based on the days parameter and checking if
   // the event's dates are valid.
-  if (!isFutureRange && !isNaN(eventEndDate.getTime())) {
+  if (isFutureRange && isOngoingEvent) {
+    return true
+  } else if (!isFutureRange && !isNaN(eventEndDate.getTime())) {
     eventDateToCheck = eventEndDate
   } else if (!isNaN(eventStartDate.getTime())) {
     eventDateToCheck = eventStartDate

--- a/tests/hooks/event-conversion-utils.spec.ts
+++ b/tests/hooks/event-conversion-utils.spec.ts
@@ -106,12 +106,11 @@ describe('isEventInDateRange', () => {
       endDate: ''
     }
     expect(isEventInDateRange(mockEvent, days)).toBe(true)
-    
     // Event started 100 days ago and end in 100 days (ongoing event)
     mockEvent = {
       ...mockEventBase,
       startDate: getFormattedDate(-100),
-      endDate: getFormattedDate(100),
+      endDate: getFormattedDate(100)
     }
     expect(isEventInDateRange(mockEvent, days)).toBe(true)
   })
@@ -147,7 +146,7 @@ describe('isEventInDateRange', () => {
     mockEvent = {
       ...mockEventBase,
       startDate: getFormattedDate(-100),
-      endDate: getFormattedDate(100),
+      endDate: getFormattedDate(100)
     }
     expect(isEventInDateRange(mockEvent, days)).toBe(false)
   })

--- a/tests/hooks/event-conversion-utils.spec.ts
+++ b/tests/hooks/event-conversion-utils.spec.ts
@@ -106,6 +106,14 @@ describe('isEventInDateRange', () => {
       endDate: ''
     }
     expect(isEventInDateRange(mockEvent, days)).toBe(true)
+    
+    // Event started 100 days ago and end in 100 days (ongoing event)
+    mockEvent = {
+      ...mockEventBase,
+      startDate: getFormattedDate(-100),
+      endDate: getFormattedDate(100),
+    }
+    expect(isEventInDateRange(mockEvent, days)).toBe(true)
   })
 
   it('returns true if the event happened within the last 15 days', () => {
@@ -132,6 +140,14 @@ describe('isEventInDateRange', () => {
       ...mockEventBase,
       startDate: getFormattedDate(7),
       endDate: ''
+    }
+    expect(isEventInDateRange(mockEvent, days)).toBe(false)
+
+    // Event started 100 days ago and end in 100 days (ongoing event)
+    mockEvent = {
+      ...mockEventBase,
+      startDate: getFormattedDate(-100),
+      endDate: getFormattedDate(100),
     }
     expect(isEventInDateRange(mockEvent, days)).toBe(false)
   })


### PR DESCRIPTION
Closes #2746

Quantum explorers event not showing on events page.

Ongoing events weren't showing on events page, because the code didn't contemplate its case.
A boolean constant was created to identify this events, under the condition of having started but not yet finished, which suffice the characteristics of ongoing events. 
This events will be included in the future events tab from now on. 