### PR TITLE
Added new conditions so that events happening today will appear on th…

### DIFF
--- a/hooks/event-conversion-utils.ts
+++ b/hooks/event-conversion-utils.ts
@@ -73,14 +73,19 @@ function isEventInDateRange (
   const today: Date = new Date()
   const eventStartDate: Date = new Date(startDate)
   const eventEndDate: Date = new Date(endDate)
-  const isFutureRange: boolean = days > 0
+  const isFutureRange: boolean = days >= 0
   const isOngoingEvent: boolean = eventStartDate <= today && today <= eventEndDate
+  const isToday: boolean = eventStartDate.getDate() === today.getDate() && eventStartDate.getMonth() === today.getMonth() && eventStartDate.getFullYear() === today.getFullYear()
   let eventDateToCheck: Date
 
   // Determine which date to check based on the days parameter and checking if
   // the event's dates are valid.
   if (isFutureRange && isOngoingEvent) {
     return true
+  } else if (isFutureRange && isToday) {
+    return true
+  } else if (!isFutureRange && isToday) {
+    return false
   } else if (!isFutureRange && !isNaN(eventEndDate.getTime())) {
     eventDateToCheck = eventEndDate
   } else if (!isNaN(eventStartDate.getTime())) {

--- a/tests/hooks/event-conversion-utils.spec.ts
+++ b/tests/hooks/event-conversion-utils.spec.ts
@@ -91,6 +91,14 @@ describe('isEventInDateRange', () => {
     }
     expect(isEventInDateRange(mockEvent, days)).toBe(true)
 
+    // Event starts today
+    mockEvent = {
+      ...mockEventBase,
+      startDate: getFormattedDate(0),
+      endDate: ''
+    }
+    expect(isEventInDateRange(mockEvent, days)).toBe(true)
+
     // Event starts within the next 15 days and ends after 15 days
     mockEvent = {
       ...mockEventBase,
@@ -139,6 +147,14 @@ describe('isEventInDateRange', () => {
     mockEvent = {
       ...mockEventBase,
       startDate: getFormattedDate(7),
+      endDate: ''
+    }
+    expect(isEventInDateRange(mockEvent, days)).toBe(false)
+
+    // Event starts today
+    mockEvent = {
+      ...mockEventBase,
+      startDate: getFormattedDate(0),
       endDate: ''
     }
     expect(isEventInDateRange(mockEvent, days)).toBe(false)


### PR DESCRIPTION
### Problem: A single-day event card moves to "past events" the day it is happening
To solve issue [#2675 ](https://github.com/Qiskit/qiskit.org/issues/2675) I added some more conditions in file hooks/event-conversion-utils.ts that work similar to the ones we added in [#2746](https://github.com/Qiskit/qiskit.org/issues/2746) .
Also included the case of events happening "today" in the tests, by adding this special cases to the test in the file tests/hooks/event-conversion-utils.spec.ts.
