### PR TITLE
update event links and content

### DIFF
--- a/components/events/fall-fest/UniversityDirectorySection.vue
+++ b/components/events/fall-fest/UniversityDirectorySection.vue
@@ -201,7 +201,7 @@ export default class UniversityDirectorySection extends Vue {
       detail: 'Online',
       cta: {
         label: 'Learn more here',
-        url: 'https://qisk.it/fallfest',
+        url: 'https://qisk.it/fallfesthype',
         segment: { cta: 'qiskit-fall-fest-mexico-ipn', location: 'fall-fest-page' }
       }
     },
@@ -234,7 +234,7 @@ export default class UniversityDirectorySection extends Vue {
       detail: 'In Person',
       cta: {
         label: 'Learn more here',
-        url: '',
+        url: 'https://www.facebook.com/groups/ucquantum',
         segment: { cta: 'university-of-chicago', location: 'fall-fest-page' }
       }
     },
@@ -267,7 +267,7 @@ export default class UniversityDirectorySection extends Vue {
       detail: 'In Person',
       cta: {
         label: 'Learn more here',
-        url: '',
+        url: 'https://github.com/qBITS-github/Quest-Qiskit-Fall-Fest',
         segment: { cta: 'quest-qiskit-fall-fest-bits-goa-chapter', location: 'fall-fest-page' }
       }
     },
@@ -333,7 +333,7 @@ export default class UniversityDirectorySection extends Vue {
       detail: 'In Person',
       cta: {
         label: 'Learn more here',
-        url: 'https://github.com/UT-Austin-Quantum-Collective',
+        url: 'https://github.com/UT-Austin-Quantum-Collective/Qiskit-Fall-Fest-2022/blob/main/README.md',
         segment: { cta: 'university-of-texas-at-austin', location: 'fall-fest-page' }
       }
     },
@@ -344,7 +344,7 @@ export default class UniversityDirectorySection extends Vue {
       detail: 'In Person',
       cta: {
         label: 'Learn more here',
-        url: 'https://qisk.it/fallfest',
+        url: 'https://qisk.it/fallfesthype',
         segment: { cta: 'izmir-institute-of-technology', location: 'fall-fest-page' }
       }
     },

--- a/constants/fallFest2022Content.ts
+++ b/constants/fallFest2022Content.ts
@@ -83,7 +83,7 @@ const wave1Schedule: eventSchedule[] = [
     endDate: 'October 17, 2022',
     detail: 'In Person',
     type: 'Hackathon, Workshop Series',
-    url: 'https://github.com/UT-Austin-Quantum-Collective'
+    url: 'https://github.com/UT-Austin-Quantum-Collective/Qiskit-Fall-Fest-2022/blob/main/README.md'
   },
   {
     university: 'Quantum Fall Fest QColombia',
@@ -92,14 +92,6 @@ const wave1Schedule: eventSchedule[] = [
     detail: 'Online',
     type: 'Hackathon, Workshop Series',
     url: 'https://github.com/QColombia/Quantum-Fall-Fest-2022'
-  },
-  {
-    university: 'University of Chicago',
-    startDate: 'October 10, 2022',
-    endDate: 'October 12, 2022',
-    detail: 'In Person',
-    type: 'Workshop Series',
-    url: ''
   },
   {
     university: 'Start Innovation hub',
@@ -126,7 +118,7 @@ const wave2Schedule: eventSchedule[] = [
     endDate: 'October 27, 2022',
     detail: 'Online',
     type: 'Challenge, Hackathon, Workshop Series',
-    url: 'https://qisk.it/fallfest'
+    url: 'https://qisk.it/fallfesthype'
   },
   {
     university: 'Qiskit Fall Fest Kolkata Chapter',
@@ -180,6 +172,14 @@ const wave3Schedule: eventSchedule[] = [
     url: ''
   },
   {
+    university: 'University of Chicago',
+    startDate: 'October 22, 2022',
+    endDate: 'October 24, 2022',
+    detail: 'In Person',
+    type: 'Workshop Series',
+    url: 'https://www.facebook.com/groups/ucquantum'
+  },
+  {
     university: 'The University of Hong Kong',
     startDate: 'October 25, 2022',
     endDate: 'October 26, 2022',
@@ -201,7 +201,7 @@ const wave3Schedule: eventSchedule[] = [
     endDate: 'October 31, 2022',
     detail: 'In Person',
     type: 'Hackathon',
-    url: 'https://qisk.it/fallfest'
+    url: 'https://qisk.it/fallfesthype'
   },
   {
     university: 'AUC (American University in Cairo)',
@@ -276,7 +276,7 @@ const wave4Schedule: eventSchedule[] = [
     endDate: 'November 28, 2022',
     detail: 'In Person',
     type: 'Challenge, Hackathon, Workshop Series',
-    url: ''
+    url: 'https://github.com/qBITS-github/Quest-Qiskit-Fall-Fest'
   }
 ]
 


### PR DESCRIPTION
## Changes

Closes #2822 

## Implementation details

- [x] The major update is to change the short link from [qisk.it/fallfest](http://qisk.it/fallfest) to [qisk.it/fallfesthype](http://qisk.it/fallfesthype) 
- [x] Quest event | new link
- [x] UT Austin | new link
- [x] University of Chicago | new wave, date, and link

## Preview link
[View branch updates here](https://qiskit-org-pr-2823.dcq4xc5i083.us-south.codeengine.appdomain.cloud/events/fall-fest)

## Screenshots
https://user-images.githubusercontent.com/6276074/193866472-653c0491-3019-4714-99c6-6d8d69b897d2.mov

