### PR TITLE
Wrap division in 'calc' to suppress warnings

### DIFF
--- a/pages/ecosystem/index.vue
+++ b/pages/ecosystem/index.vue
@@ -278,7 +278,7 @@ export default class EcosystemPage extends QiskitPage {
   &__license {
     font-size: 12px;
     margin-right: $spacing-05;
-    margin-top: $spacing-01 / 2;
+    margin-top: calc($spacing-01 / 2);
   }
 
   &__star {
@@ -286,7 +286,7 @@ export default class EcosystemPage extends QiskitPage {
     flex-direction: row;
 
     svg {
-      margin-top: $spacing-01 / 2;
+      margin-top: calc($spacing-01 / 2);
       margin-right: $spacing-01;
       fill: $cool-gray-60;
     }


### PR DESCRIPTION
Noticed this warning while building:
```
: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($spacing-01, 2) or calc($spacing-01 / 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

    ╷
287 │     margin-top: $spacing-01 / 2;
    │                 ^^^^^^^^^^^^^^^
    ╵
    pages/ecosystem/index.vue 287:17  root stylesheet

: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($spacing-01, 2) or calc($spacing-01 / 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

    ╷
295 │       margin-top: $spacing-01 / 2;
    │                   ^^^^^^^^^^^^^^^
    ╵
    pages/ecosystem/index.vue 295:19  root stylesheet
```

## Changes

This PR wraps divisions in `calc` to suppress warnings when building. The rest of the division warnings seem to be in other modules outside our control.
