### PR TITLE
Add card subtitle feature

### DIFF
--- a/components/learn/StartLearningSection.vue
+++ b/components/learn/StartLearningSection.vue
@@ -49,6 +49,7 @@ import { GeneralLink } from '~/constants/appLinks'
 type Course = {
   image: string,
   title: string,
+  subtitle?: string,
   description: string,
   cta: GeneralLink
 }

--- a/components/learn/StartLearningSection.vue
+++ b/components/learn/StartLearningSection.vue
@@ -17,7 +17,7 @@
       <div class="bx--col-xlg-12 bx--col-lg-12">
         <div class="bx--row">
           <div
-            v-for="{ description: courseDescription, image, title: courseTitle, cta } in courses"
+            v-for="{ description: courseDescription, image, title: courseTitle, subtitle: courseSubTitle, cta } in courses"
             :key="courseTitle"
             class="bx--col-xlg-8"
           >
@@ -28,6 +28,7 @@
               :image="image"
               image-contain
               :title="courseTitle"
+              :subtitle="courseSubTitle"
               class="start-learning-section__card"
               :description-whole-size="true"
             >

--- a/components/ui/AppCard.vue
+++ b/components/ui/AppCard.vue
@@ -18,9 +18,9 @@
           <h4 class="app-card__title">
             {{ title }}
           </h4>
-          <h4 v-if="subtitle" class="app-card__subtitle">
+          <h5 v-if="subtitle" class="app-card__subtitle">
             {{ subtitle }}
-          </h4>
+          </h5>
         </div>
         <div class="bx--row">
           <div v-if="hasTags(tags)" class="app-card__tags">
@@ -168,6 +168,7 @@ export default class AppCard extends Vue {
   }
 
   &__subtitle {
+    font-size: 0.875rem;
     font-style: italic;
     font-weight: normal;
   }

--- a/components/ui/AppCard.vue
+++ b/components/ui/AppCard.vue
@@ -14,9 +14,14 @@
     />
     <div class="app-card__content">
       <header class="app-card__header">
-        <h4 class="app-card__title">
-          {{ title }}
-        </h4>
+        <div>
+          <h4 class="app-card__title">
+            {{ title }}
+          </h4>
+          <h4 v-if="subtitle" class="app-card__subtitle">
+            {{ subtitle }}
+          </h4>
+        </div>
         <div class="bx--row">
           <div v-if="hasTags(tags)" class="app-card__tags">
             <cv-tag v-for="tag in tags" :key="tag" :label="tag" kind="purple" />
@@ -71,6 +76,7 @@ export default class AppCard extends Vue {
   imageContain!: boolean
 
   @Prop({ type: String, default: '' }) title!: string
+  @Prop({ type: String, default: '' }) subtitle!: string
   @Prop({ type: Array, default: () => [] }) tags!: string[]
   @Prop({ type: Array, default: () => [] }) tooltipTags!: TagTooltip[]
   @Prop({ type: String, default: '' }) to!: string
@@ -143,6 +149,7 @@ export default class AppCard extends Vue {
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
+    margin-bottom: $spacing-03;
 
     @include mq($until: large) {
       flex-direction: column;
@@ -157,6 +164,12 @@ export default class AppCard extends Vue {
 
   &__title {
     flex: 1;
+    margin-bottom: $spacing-02;
+  }
+
+  &__subtitle {
+    font-style: italic;
+    font-weight: normal;
   }
 }
 


### PR DESCRIPTION
## Changes

For the new 'basics of quantum information' course, we need a way to separate the title of the specific course from it's wider series. This PR adds the ability to add a subtitle to a card for this specific purpose.

## Implementation details

I've added an extra HTML tag & some css to `AppCard.vue`, and you can now send an optional `subtitle` value to the card. From my tests, these changes don't seem to affect the appearance of the other cards. Hope I've done this right!

No cards currently use this except the new basics of quantum information course which isn't merged yet, so you'll need to add a `subtitle` field to an existing card to try this out (see [3f5efc0](https://github.com/Qiskit/qiskit.org/pull/2831/commits/3f5efc04b2339a315410e45a0401c18a985239c0) for an example).

## Screenshots

![Screenshot 2022-10-14 at 09 52 38](https://user-images.githubusercontent.com/36071638/195808418-64ded299-c649-4835-a65a-a76f1dafa870.png)
