### PR TITLE
remove registration

### DIFF
--- a/constants/summerSchool2022Content.ts
+++ b/constants/summerSchool2022Content.ts
@@ -13,7 +13,7 @@ const header = {
   },
   cta: {
     label: 'Register now!',
-    url: 'https://www.eventbrite.com/e/2022-qiskit-global-summer-school-quantum-simulations-tickets-348866728777',
+    url: '',
     segment: {
       cta: 'register',
       location: 'header'
@@ -27,7 +27,7 @@ const header = {
     location: 'Online',
     date: 'July 18 - 29, 2022',
     time: '',
-    to: 'https://www.eventbrite.com/e/2022-qiskit-global-summer-school-quantum-simulations-tickets-348866728777',
+    to: '',
     ctaLabel: 'Learn more',
     segment: {
       cta: 'ibm-research-blog',

--- a/pages/events/summer-school.vue
+++ b/pages/events/summer-school.vue
@@ -1,7 +1,7 @@
 <template>
   <main class="summer-school-page">
     <AppPageHeaderWithCard
-      :cta="headerData.cta"
+      :cta="null"
       :card-title="headerData.cardSectionHeading"
     >
       <template slot="title">
@@ -21,7 +21,7 @@
           for more details and updates. For any questions, please check out our FAQ below!
         </p>
         <p>
-          Early Bird Registration will open at 12:00 PM EST on May 26, 2022.
+          See you next year!
         </p>
       </template>
       <template slot="card">


### PR DESCRIPTION
## Changes

this PR removes the registration for summer school 2022 from it's event page

[preview link](https://qiskit-org-pr-2849.dcq4xc5i083.us-south.codeengine.appdomain.cloud/events/summer-school/)

Closes https://github.com/Qiskit/qiskit.org/issues/2848

## Implementation details

- removed the eventbrite registration links
- removed the registration CTA
- replaced early registration text with `See you next year!`

## How to read this PR

1. review updates made to the summer school page
2. go to the [summer school event page](https://qiskit-org-pr-2849.dcq4xc5i083.us-south.codeengine.appdomain.cloud/events/summer-school/)
3. review the event page shows the updates (i.e., doesn't show registration)

## Screenshots

**before**

![image](https://user-images.githubusercontent.com/13156555/196497746-5cdaa26f-536a-4ad0-ae6e-83f11c057d4f.png)

**after**

![image](https://user-images.githubusercontent.com/13156555/196497813-7d4ff20d-1b17-4cd2-a12c-3f526ba5564e.png)

