### PR TITLE
Remove Qiskit Runtime banner

### DIFF
--- a/layouts/default-max.vue
+++ b/layouts/default-max.vue
@@ -23,7 +23,7 @@ export default class MaxLayout extends Vue {
 
 <style lang="scss" scoped>
 .main-container {
-  margin-top: 3.5rem;
+  margin-top: 3.25rem;
 }
 
 qiskit-ui-shell {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -23,7 +23,7 @@ export default class DefaultLayout extends Vue {
 
 <style lang="scss" scoped>
 .main-container {
-  margin-top: 3.5rem;
+  margin-top: 3.25rem;
 }
 
 qiskit-ui-shell {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,17 +1,5 @@
 <template>
   <main class="landing-page">
-    <QiskitBanner padding-x-none class="qiskit-runtime">
-      <div class="bx--grid">
-        <span class="banner__title">Start building with Qiskit Runtime.</span>
-        <span class="banner__message">Leverage the new programming model and execution framework to efficiently execute circuits.</span>
-        <AppLink
-          :segment="{ action: `banner > qiskit-runtime` }"
-          url="https://qiskit.org/documentation/partners/qiskit_ibm_runtime/"
-        >
-          Learn more
-        </AppLink>
-      </div>
-    </QiskitBanner>
     <TheHeroMoment :version="qiskitVersion" />
     <TheQuickStart />
     <TheQiskitCapabilitiesSection />
@@ -22,7 +10,6 @@
 <script lang="ts">
 import axios from 'axios'
 import { Component } from 'vue-property-decorator'
-import QiskitBanner from '@qiskit-community/qiskit-vue/src/components/banner/Banner.vue'
 import QiskitPage from '~/components/logic/QiskitPage.vue'
 
 @Component({
@@ -36,34 +23,9 @@ import QiskitPage from '~/components/logic/QiskitPage.vue'
     return {
       qiskitVersion: packageInfo.info.version
     }
-  },
-  components: { QiskitBanner }
+  }
 })
 export default class LandingPage extends QiskitPage {
   routeName = 'qiskit-landing-page'
 }
 </script>
-
-<style lang="scss">
-@import "@carbon/colors/scss/colors";
-
-.qiskit-banner.qiskit-runtime {
-  background-color: $background-color-lighter !important;
-
-  .banner__title {
-    color: $cool-gray-100;
-    font-weight: 600;
-  }
-
-  .banner__message {
-    color: $cool-gray-100;
-  }
-
-  .app-link,
-  .app-link:visited {
-    color: $active-color !important;
-    text-decoration: none;
-    float: right;
-  }
-}
-</style>


### PR DESCRIPTION
## Changes

Fixes https://github.com/Qiskit/qiskit.org/issues/2898

## Implementation details

- Removed `QiskitBanner` import, component, and styles
- Updated `default` and `default-max` layouts w/ a small CSS fix because the `qiskit-ui-shell` component + the hero background grid, was causing a _double line_ effect

**BEFORE CSS update**
![before_css_update](https://user-images.githubusercontent.com/6276074/211091177-b487e076-705d-4999-beea-7829918cd1d7.png)


**AFTER CSS update**
![after_css_update](https://user-images.githubusercontent.com/6276074/211091041-86d01817-1b5d-4b12-84dc-532be97d714b.png)

