### PR TITLE
Updates tutorials link on the footer

### DIFF
--- a/constants/menuLinks.ts
+++ b/constants/menuLinks.ts
@@ -146,7 +146,7 @@ const QISKIT_VIDEOS: NavLink = {
 
 const TUTORIALS_LINK: NavLink = {
   label: 'Tutorials',
-  url: 'https://github.com/Qiskit/qiskit-tutorials',
+  url: 'https://qiskit.org/documentation/tutorials.html',
   segment: {
     cta: 'tutorials',
     location: 'menu'


### PR DESCRIPTION
## Changes

Fix #2779 

## How to read this PR

On the footer, `tutorials` link now points to the tutorials on the documentation page, not on github
