### PR TITLE
Update copy code formatting

### DIFF
--- a/components/landing/TheQiskitCapabilitiesSection/index.vue
+++ b/components/landing/TheQiskitCapabilitiesSection/index.vue
@@ -114,7 +114,7 @@ export default class TheQiskitCapabilitiesSection extends Mixins(ScrollSectionsM
   copyToClipboard (): void {
     const codeSnippet = document.querySelector('.code-cell') as HTMLElement | null
 
-    if (codeSnippet != null) {
+    if (codeSnippet !== null) {
       navigator.clipboard.writeText(codeSnippet.innerText)
     }
   }

--- a/components/landing/TheQiskitCapabilitiesSection/index.vue
+++ b/components/landing/TheQiskitCapabilitiesSection/index.vue
@@ -112,8 +112,11 @@ export default class TheQiskitCapabilitiesSection extends Mixins(ScrollSectionsM
   }
 
   copyToClipboard (): void {
-    const codeSnippet = document.querySelector('.code-cell')?.textContent!
-    navigator.clipboard.writeText(codeSnippet)
+    const codeSnippet = document.querySelector('.code-cell') as HTMLElement | null
+
+    if (codeSnippet != null) {
+      navigator.clipboard.writeText(codeSnippet.innerText)
+    }
   }
 }
 </script>


### PR DESCRIPTION
## Changes

Fixes #2846 

## Implementation details

- updated the `copyToClipboard` function to use `innerText` instead of `textContent`
- handled TS error using conditional (borrowed approach from [this source](https://bobbyhadz.com/blog/typescript-property-innertext-not-exist-type-element#:~:text=The%20reason%20we%20got%20the%20error%20is%20that%20the%20return%20type%20of%20the%20document.querySelector%20method%20is%20Element%20%7C%20null%20and%20the%20innerText%20property%20doesn%27t%20exist%20in%20the%20Element%20type.))


## Branch preview
https://qiskit-org-pr-2910.dcq4xc5i083.us-south.codeengine.appdomain.cloud/

## Screenshots

https://user-images.githubusercontent.com/6276074/211881711-efa41204-13d8-4548-b43f-1a5907fff545.mov


