### PR TITLE
Fix accessibility for internal links

### DIFF
--- a/components/landing/TheLearnSection/LearnCard.vue
+++ b/components/landing/TheLearnSection/LearnCard.vue
@@ -30,7 +30,7 @@ import { GeneralLink } from '~/constants/appLinks'
 @Component
 export default class LearnCard extends Vue {
   learnLink: GeneralLink = {
-    url: 'learn',
+    url: '/learn',
     label: 'Get learning',
     segment: { cta: 'get-learning', location: 'learn-card' }
   }

--- a/components/ui/BasicLink.vue
+++ b/components/ui/BasicLink.vue
@@ -33,6 +33,10 @@ export default class BasicLink extends Vue {
     return !!url && url.startsWith('http')
   }
 
+  static isInternal (url: string): boolean {
+    return !!url && url.startsWith('/')
+  }
+
   static isMail (url: string): boolean {
     return !!url && url.startsWith('mailto')
   }
@@ -50,6 +54,7 @@ export default class BasicLink extends Vue {
     return BasicLink.isExternal(url) ||
       BasicLink.isMail(url) ||
       BasicLink.isIdAnchor(url) ||
+      BasicLink.isInternal(url) ||
       this.isStatic
   }
 


### PR DESCRIPTION
## Changes

Fixes #2847 

## Implementation details

- updated "Get learning" link to use relative path
- added check for `isInternal` links, which are `url`'s that begin with a `/`
- added `isInternal` links to the `isAnchor` check which will render a valid `href` 
- also fixes the "Go to this course" links for the `AppCard`s on the `/learn` page

## Branch preview
https://qiskit-org-pr-2911.dcq4xc5i083.us-south.codeengine.appdomain.cloud/

## Screenshots
- user can now tab to the "Get learning" link
- user can `cmd + click` to open link in a new tab



https://user-images.githubusercontent.com/6276074/211906227-3cc75713-c2ab-4837-87d3-29c0468c479a.mov


![Screenshot 2023-01-11 at 11 59 13 AM (2)](https://user-images.githubusercontent.com/6276074/211906631-a75de578-bd5c-4f8d-8635-1abe44b7c5c8.png)

