### PR TITLE
feat(advocates): order and rename locations

### DIFF
--- a/store/advocates.ts
+++ b/store/advocates.ts
@@ -1,8 +1,8 @@
 import type { ActionTree, GetterTree, MutationTree } from 'vuex'
 
 const ADVOCATES_WORLD_REGIONS = Object.freeze({
-  northAmerica: 'North America',
-  southAmerica: 'South America',
+  northAmerica: 'America (North)',
+  southAmerica: 'America (South)',
   oceania: 'Oceania',
   africa: 'Africa',
   europe: 'Europe',
@@ -25,14 +25,7 @@ interface Advocate {
   slackUsername?: string
 }
 
-const ADVOCATES_WORLD_REGION_OPTIONS = Object.freeze([
-  ADVOCATES_WORLD_REGIONS.northAmerica,
-  ADVOCATES_WORLD_REGIONS.southAmerica,
-  ADVOCATES_WORLD_REGIONS.oceania,
-  ADVOCATES_WORLD_REGIONS.africa,
-  ADVOCATES_WORLD_REGIONS.europe,
-  ADVOCATES_WORLD_REGIONS.asia
-])
+const ADVOCATES_WORLD_REGION_OPTIONS = Object.values(ADVOCATES_WORLD_REGIONS).sort()
 
 export {
   AdvocatesWorldRegion,

--- a/tests/hooks/advocate-conversion-utils.spec.ts
+++ b/tests/hooks/advocate-conversion-utils.spec.ts
@@ -52,7 +52,7 @@ describe('convertToAdvocate', () => {
       }
     ],
     city: 'Someplace',
-    region: 'North America',
+    region: 'America (North)',
     slackId: 'FAKEID123',
     slackUsername: 'fakename'
   })
@@ -63,7 +63,7 @@ describe('convertToAdvocate', () => {
       name: 'Fake advocate',
       image: '/image.jpeg',
       city: 'Someplace',
-      region: 'North America'
+      region: 'America (North)'
     })
   })
 })
@@ -183,7 +183,7 @@ describe('getSlackId', () => {
     const fakeSlackId = 'FAKEID123'
     const fakeAdvocate = new FakeRecord({
       name: 'Fake Advocate',
-      region: 'North America',
+      region: 'America (North)',
       slackId: 'FAKEID123',
       slackUsername: 'fakename'
     })
@@ -196,7 +196,7 @@ describe('getSlackUsername', () => {
     const fakeSlackUsername = 'fakename'
     const fakeAdvocate = new FakeRecord({
       name: 'Fake Advocate',
-      region: 'North America',
+      region: 'America (North)',
       slackId: 'FAKEID123',
       slackUsername: 'fakename'
     })

--- a/tests/store/advocates.spec.ts
+++ b/tests/store/advocates.spec.ts
@@ -12,7 +12,7 @@ const mockAdvocate1 = () => ({
   country: 'Peru',
   image: 'https://example.com/img/1.jpg',
   name: 'John Doe',
-  region: 'South America'
+  region: 'America (South)'
 })
 const mockAdvocate2 = () => ({
   city: 'Munich',
@@ -29,7 +29,7 @@ const mockAdvocate2 = () => ({
 
 describe('filteredAdvocates', () => {
   const getter = 'advocates/filteredAdvocates'
-  const mockMatchingRegionFilter1 = () => 'South America'
+  const mockMatchingRegionFilter1 = () => 'America (South)'
   const mockMatchingRegionFilter2 = () => 'Europe'
   const mockNonMatchingRegionFilter = () => 'Moon'
 
@@ -97,7 +97,7 @@ describe('setAdvocates', () => {
 
 describe('setRegionFilters', () => {
   const mutationType = 'advocates/setRegionFilters'
-  const mockRegionFilter1 = 'South America'
+  const mockRegionFilter1 = 'America (South)'
   const mockRegionFilter2 = 'Europe'
 
   beforeEach(() => {


### PR DESCRIPTION
## Changes

Fix https://github.com/Qiskit/qiskit.org/issues/2736

## Implementation details

On the advocates page:

- `North America` is now `America (North)
- `South America` is now `America (South)
- Locations now are on alphabetical order

## How to read this PR

- Go to the [advocates page](https://qiskit.org/advocates/) 
- Check that the locations are in alphabetical order
- Check that the label on the advocate card also replace North/South America with America (North/South)
- Check that everything still works as expected

## Screenshots

![Captura de pantalla 2023-01-16 a las 16 27 42](https://user-images.githubusercontent.com/17231966/212713942-0019e51f-3b45-4fd7-a58c-6416a2a4bae4.png)

