### PR TITLE
feat: adds photos downloaded from airtable to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,7 @@ dist
 
 # Service worker
 sw.*
+
+# Pictures downloaded from airtable
+static/images/advocates/downloaded/*
+static/images/events/downloaded/*


### PR DESCRIPTION
## Changes

This PR adds the pictures downloaded from airtable with `npm run generate` to .gitignore

