### PR TITLE
Updates @qiskit/web-components to the last version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@nuxtjs/axios": "^5.13.6",
         "@open-wc/webpack-import-meta-loader": "^0.4.7",
         "@qiskit-community/qiskit-vue": "^3.4.0",
-        "@qiskit/web-components": "^0.11.0",
+        "@qiskit/web-components": "^0.11.1",
         "@vue/composition-api": "^1.4.9",
         "airtable": "~0.11.4",
         "cross-env": "^7.0.3",
@@ -4383,9 +4383,9 @@
       "integrity": "sha512-iX8rWc2CkFB7W7wi5NLa3pVRVb/jRI2KrVDna3FO3X3DgNz3zoRCgN+r2c+8FEhpJWeUwds5aDzTWUuTtlOT3w=="
     },
     "node_modules/@qiskit/web-components": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@qiskit/web-components/-/web-components-0.11.0.tgz",
-      "integrity": "sha512-UwUeNnh2KTAyLHXcFgq6+KRqF2MvM7z/oQbwpPg+uJi982zxQMSQM8g3mOoHQPoyJ3wY2KghrdpWl3pdGcMBbA==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@qiskit/web-components/-/web-components-0.11.1.tgz",
+      "integrity": "sha512-K7Jnyetgq4DxSrg0Ul6Jwv18ad+lO9ilzskMwoyFCxwjYB81r6b7bjq95sz9UclSFqLBjmKIYxSJIg96KSRvIw==",
       "dependencies": {
         "@carbon/colors": "^10.37.1",
         "@carbon/icon-helpers": "^10.30.0",
@@ -29297,9 +29297,9 @@
       }
     },
     "@qiskit/web-components": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@qiskit/web-components/-/web-components-0.11.0.tgz",
-      "integrity": "sha512-UwUeNnh2KTAyLHXcFgq6+KRqF2MvM7z/oQbwpPg+uJi982zxQMSQM8g3mOoHQPoyJ3wY2KghrdpWl3pdGcMBbA==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@qiskit/web-components/-/web-components-0.11.1.tgz",
+      "integrity": "sha512-K7Jnyetgq4DxSrg0Ul6Jwv18ad+lO9ilzskMwoyFCxwjYB81r6b7bjq95sz9UclSFqLBjmKIYxSJIg96KSRvIw==",
       "requires": {
         "@carbon/colors": "^10.37.1",
         "@carbon/icon-helpers": "^10.30.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@nuxtjs/axios": "^5.13.6",
     "@open-wc/webpack-import-meta-loader": "^0.4.7",
     "@qiskit-community/qiskit-vue": "^3.4.0",
-    "@qiskit/web-components": "^0.11.0",
+    "@qiskit/web-components": "^0.11.1",
     "@vue/composition-api": "^1.4.9",
     "airtable": "~0.11.4",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
## Changes

The [`ui-shell` component has changed](https://github.com/Qiskit/web-components/issues/193), so we need to update the `@qiskit/web-components` package to the last version (`0.11.1`)

## How to read this PR

Check the top menu > Documentation
Instead of having: **_Getting started > Overview_**, we should have:
- **_Start Here > Documentation Home_**
- **_Start Here > Getting Started_**


## Screenshots

![Captura de pantalla 2023-02-01 a las 13 20 31](https://user-images.githubusercontent.com/17231966/216041680-170fa79c-19d4-48e6-8bcb-83d739e02f98.png)


