### PR TITLE
Calendar added via Iframe (airtable)

### DIFF
--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -18,10 +18,23 @@
           <cv-tabs aria-label="Event tabs" @tab-selected="selectTab">
             <cv-tab id="tab-1" label="Upcoming events" />
             <cv-tab id="tab-2" label="Past events" />
+            <cv-tab id="tab-3" label="Calendar" />
           </cv-tabs>
         </client-only>
       </div>
-      <AppFiltersResultsLayout>
+      {{ isCalendar }}
+      <div v-if="isCalendar">
+        <iframe
+          class="airtable-embed"
+          src="https://airtable.com/embed/shrzmTpiOo1Ye8Nrs?backgroundColor=purple&viewControls=on"
+          frameborder="0"
+          onmousewheel=""
+          width="100%"
+          height="533"
+          style="background: transparent; border: 1px solid #ccc;"
+        />
+      </div>
+      <AppFiltersResultsLayout v-else>
         <template slot="filters-on-m-l-screen">
           <AppFieldset
             v-for="filter in extraFilters"
@@ -155,7 +168,8 @@ import { EVENT_REQUEST_LINK, GeneralLink } from '~/constants/appLinks'
     ...mapGetters('events', [
       'filteredEvents',
       'typeFilters',
-      'regionFilters'
+      'regionFilters',
+      'activeSet'
     ])
   },
   components: {
@@ -224,6 +238,10 @@ export default class EventsPage extends QiskitPage {
       return (this as any).filteredEvents.length === 0
     }
 
+    get isCalendar (): boolean {
+      return (this as any).activeSet === 'calendar'
+    }
+
     getCheckedFilters (filter: string) {
       return (this as any)[filter]
     }
@@ -254,9 +272,18 @@ export default class EventsPage extends QiskitPage {
     }
 
     selectTab (selectedTab: number) {
-      const activeSet = selectedTab === 0 ? 'upcoming' : 'past'
-
-      this.$store.commit('events/setActiveSet', activeSet)
+      console.log(selectedTab)
+      switch (selectedTab) {
+        case 0:
+          this.$store.commit('events/setActiveSet', 'upcoming')
+          break
+        case 1:
+          this.$store.commit('events/setActiveSet', 'past')
+          break
+        case 2:
+          this.$store.commit('events/setActiveSet', 'calendar')
+          break
+      }
     }
 }
 </script>
@@ -360,3 +387,4 @@ export default class EventsPage extends QiskitPage {
   }
 }
 </style>
+</iframe>

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -22,7 +22,6 @@
           </cv-tabs>
         </client-only>
       </div>
-      {{ isCalendar }}
       <div v-if="isCalendar">
         <iframe
           class="airtable-embed"
@@ -272,7 +271,6 @@ export default class EventsPage extends QiskitPage {
     }
 
     selectTab (selectedTab: number) {
-      console.log(selectedTab)
       switch (selectedTab) {
         case 0:
           this.$store.commit('events/setActiveSet', 'upcoming')

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -22,15 +22,13 @@
           </cv-tabs>
         </client-only>
       </div>
-      <div v-if="isCalendar">
+      <div v-if="isCalendar" class="event-page__calendar">
         <iframe
           class="airtable-embed"
           src="https://airtable.com/embed/shrzmTpiOo1Ye8Nrs?backgroundColor=purple&viewControls=on"
-          frameborder="0"
-          onmousewheel=""
           width="100%"
-          height="533"
-          style="background: transparent; border: 1px solid #ccc;"
+          height="560"
+          allowtransparency="true"
         />
       </div>
       <AppFiltersResultsLayout v-else>
@@ -359,6 +357,12 @@ export default class EventsPage extends QiskitPage {
     @include mq($until: medium) {
       height: auto;
     }
+  }
+
+  &__calendar{
+    margin-bottom: $spacing-06;
+    border: 1px solid #8d8d8d;
+    margin-top: $spacing-06;
   }
 
   &__section {

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -360,7 +360,7 @@ export default class EventsPage extends QiskitPage {
   }
 
   &__calendar{
-    margin-bottom: $spacing-06;
+    margin-bottom: $spacing-10;
     border: 1px solid #8d8d8d;
     margin-top: $spacing-06;
   }

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -389,4 +389,3 @@ export default class EventsPage extends QiskitPage {
   }
 }
 </style>
-</iframe>

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -362,7 +362,10 @@ export default class EventsPage extends QiskitPage {
   &__calendar{
     margin-bottom: $spacing-10;
     border: 1px solid $border-color ;
-    margin-top: $spacing-06;
+
+    @include mq($until: medium) {
+      margin-top: $spacing-06;
+    }
   }
 
   &__section {

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -361,7 +361,7 @@ export default class EventsPage extends QiskitPage {
 
   &__calendar{
     margin-bottom: $spacing-10;
-    border: 1px solid #8d8d8d;
+    border: 1px solid $border-color ;
     margin-top: $spacing-06;
   }
 

--- a/store/events.ts
+++ b/store/events.ts
@@ -102,6 +102,9 @@ export default {
     regionFilters (state: State) {
       return state.regionFilters
     },
+    activeSet (state: State) {
+      return state.activeSet
+    },
     filteredEvents (state: State) {
       const {
         activeSet,


### PR DESCRIPTION
## Changes
Closes #2924 
This PR adds a new tab to the [qiskit.org/events](https://qiskit.org/events/) page, where users can view the Airtable calendar, and get advantage of the integrated features.

Styling as much as I'd have liked to has not been possible because the iframe that's been added it's just a view of the original calendar. Either way, an outline was added as well as some margins.

## Screenshots
Here's how it looks both on big size screens and smaller ones.

<img width="1641" alt="Screenshot 2023-02-23 at 15 42 37" src="https://user-images.githubusercontent.com/108661074/220940461-b1485bda-a21b-4501-b778-7ba11a67c881.png">
<img width="362" alt="Screenshot 2023-02-23 at 15 41 55" src="https://user-images.githubusercontent.com/108661074/220941342-d819f07c-c17c-4571-88d8-1c963d35e7b6.png">



