### PR TITLE
categories.json for /providers

### DIFF
--- a/content/providers/categories.json
+++ b/content/providers/categories.json
@@ -1,30 +1,35 @@
 [
   {
     "id": "hardwareId",
+    "label": "qpus",
     "title": "Quantum Systems",
     "file": "~/content/providers/hardware.json",
     "description":"Quantum systems (aka quantum processors, QPUs, quantum hardware, quantum chips) are services that allow users to execute quantum programs in specialized hardware that leverages quantum mechanical phenomena for quantum computation. These services usually require user registration and have different pricing plans."
   },
   {
     "id": "simulatorsId",
+    "label": "simulators",
     "title": "Local Simulators",
     "file": "~/content/providers/simulators.json",
     "description":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis posuere eros sed tortor facilisis efficitur. Vestibulum finibus, libero vitae aliquam finibus."
   },
   {
     "id": "cloud_simulatorsId",
+    "label": "cloud_simulators",
     "title": "Local Simulators",
     "file": "~/content/providers/cloud_simulators.json",
     "description":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis posuere eros sed tortor facilisis efficitur. Vestibulum finibus, libero vitae aliquam finibus."
   },
   {
     "id": "runtimes",
+    "label": "runtimes",
     "title": "Quantum Runtimes",
     "file": "~/content/providers/runtime.json",
     "description":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis posuere eros sed tortor facilisis efficitur. Vestibulum finibus, libero vitae aliquam finibus."
   },
   {
     "id": "multiplatformsId",
+    "label": "multiplatforms",
     "title": "Multiplatforms",
     "file": "~/content/providers/multiplatforms.json",
     "description":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis posuere eros sed tortor facilisis efficitur. Vestibulum finibus, libero vitae aliquam finibus."

--- a/content/providers/categories.json
+++ b/content/providers/categories.json
@@ -4,34 +4,34 @@
     "label": "qpus",
     "title": "Quantum Systems",
     "file": "~/content/providers/hardware.json",
-    "description":"Quantum systems (aka quantum processors, QPUs, quantum hardware, quantum chips) are services that allow users to execute quantum programs in specialized hardware that leverages quantum mechanical phenomena for quantum computation. These services usually require user registration and have different pricing plans."
+    "description": "Quantum systems (aka quantum processors, QPUs, quantum hardware, quantum chips) are services that allow users to execute quantum programs in specialized hardware that leverages quantum mechanical phenomena for quantum computation. These services usually require user registration and have different pricing plans."
   },
   {
     "id": "simulatorsId",
     "label": "simulators",
     "title": "Local Simulators",
     "file": "~/content/providers/simulators.json",
-    "description":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis posuere eros sed tortor facilisis efficitur. Vestibulum finibus, libero vitae aliquam finibus."
+    "description": "It is possible to simulate in quantum processor in your own computer. There are several projects that allow you to do that locally after installing some extra software. This is probably the best way to start with quantum computing."
   },
   {
     "id": "cloud_simulatorsId",
     "label": "cloud_simulators",
-    "title": "Local Simulators",
+    "title": "High Performance Simulation Service",
     "file": "~/content/providers/cloud_simulators.json",
-    "description":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis posuere eros sed tortor facilisis efficitur. Vestibulum finibus, libero vitae aliquam finibus."
+    "description": "There are services that allow you to simulate quantum processors in high performance computers. These services usually require user registration and many are not free."
   },
   {
     "id": "runtimes",
     "label": "runtimes",
     "title": "Quantum Runtimes",
     "file": "~/content/providers/runtime.json",
-    "description":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis posuere eros sed tortor facilisis efficitur. Vestibulum finibus, libero vitae aliquam finibus."
+    "description": "Quantum runtimes are services that allow quantum-classical hybrid computations. Sometimes called near-team computing, this computation model allows relative quick iteration between classical and quantum processors, which is useful for variational algorithms. "
   },
   {
     "id": "multiplatformsId",
     "label": "multiplatforms",
     "title": "Multiplatforms",
     "file": "~/content/providers/multiplatforms.json",
-    "description":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis posuere eros sed tortor facilisis efficitur. Vestibulum finibus, libero vitae aliquam finibus."
+    "description": "Cloud services that allow you to connect with several quantum services. "
   }
 ]

--- a/content/providers/categories.json
+++ b/content/providers/categories.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "hardwareId",
+    "title": "Quantum Systems",
+    "file": "~/content/providers/hardware.json",
+    "description":"Quantum systems (aka quantum processors, QPUs, quantum hardware, quantum chips) are services that allow users to execute quantum programs in specialized hardware that leverages quantum mechanical phenomena for quantum computation. These services usually require user registration and have different pricing plans."
+  },
+  {
+    "id": "simulatorsId",
+    "title": "Local Simulators",
+    "file": "~/content/providers/simulators.json",
+    "description":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis posuere eros sed tortor facilisis efficitur. Vestibulum finibus, libero vitae aliquam finibus."
+  },
+  {
+    "id": "cloud_simulatorsId",
+    "title": "Local Simulators",
+    "file": "~/content/providers/cloud_simulators.json",
+    "description":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis posuere eros sed tortor facilisis efficitur. Vestibulum finibus, libero vitae aliquam finibus."
+  },
+  {
+    "id": "runtimes",
+    "title": "Quantum Runtimes",
+    "file": "~/content/providers/runtime.json",
+    "description":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis posuere eros sed tortor facilisis efficitur. Vestibulum finibus, libero vitae aliquam finibus."
+  },
+  {
+    "id": "multiplatformsId",
+    "title": "Multiplatforms",
+    "file": "~/content/providers/multiplatforms.json",
+    "description":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis posuere eros sed tortor facilisis efficitur. Vestibulum finibus, libero vitae aliquam finibus."
+  }
+]


### PR DESCRIPTION
## Changes

The `/providers` page organize providers in different categories. Each category has a small description. This `categories.json` file describes the data related to said categories.

Here some sort of schema (written by hand, do not take it very strictly)

```
{
  "$schema": "http://json-schema.org/draft-04/schema#",
  "type": "array",
  "items": [
    {
      "type": "object",
      "properties": {
        "id": {
          "type": "string",
          "description": "I took this one from TableOfContentEntry[sectionId]",
        },
        "label": {
          "type": "string",
          "description": "I took this one from TableOfContentEntry[label]",
        },
        "title": {
          "type": "string",
          "description": "I took this one from ProvidersSection[title]",
        },
        "file": {
          "type": "string",
          "description": "File from where raw data  is",
        },
        "description": {
          "type": "string",
          "description": "I took this one from ProvidersSection[description]",
        }
      },
      "required": [
        "id",
        "title",
        "file"
      ]
    },
  ]
}
```