### PR TITLE
[Providers] add CTAs linking to provider documentation

### DIFF
--- a/components/providers/AccordionLayout.vue
+++ b/components/providers/AccordionLayout.vue
@@ -3,7 +3,6 @@
     <p class="accordion-layout__description">
       {{ description }}
     </p>
-    <img v-if="image" :src="image" class="accordion-layout__image">
     <CodeSnippet
       :code-lines="installation"
       :code-snippet-title="title"
@@ -36,7 +35,6 @@ import { ProviderCodeExample } from '~/constants/providersContent'
 
 interface AccordionLayoutProps {
   title: string
-  image: string | null
   description: string
   installation: string[]
   websiteCta: {
@@ -62,7 +60,6 @@ export { AccordionLayoutProps }
 export default class AccordionLayout extends Vue implements AccordionLayoutProps {
   @Prop(String) title!: string
   @Prop(String) description!: string
-  @Prop(String) image!: string
   @Prop(Array) installation!: string[]
   @Prop(Object) websiteCta!: GeneralLink
   @Prop(Object) docsCta!: GeneralLink
@@ -81,13 +78,6 @@ $cta-max-width: 4rem;
 .accordion-layout {
   display: flex;
   flex-direction: column;
-
-  &__image {
-    align-self: center;
-    height: auto;
-    width: 100%;
-    margin-bottom: $spacing-05;
-  }
 
   &__description {
     margin-bottom: $spacing-06;

--- a/components/providers/ContentAccordion.vue
+++ b/components/providers/ContentAccordion.vue
@@ -12,7 +12,6 @@
           :title="tab.title"
           :description="tab.description"
           :installation="tab.installation"
-          :image="tab.image"
           :website-cta="tab.websiteCta"
           :docs-cta="tab.docsCta"
           :source-cta="tab.sourceCta"

--- a/constants/providersContent.ts
+++ b/constants/providersContent.ts
@@ -20,7 +20,6 @@ type ProviderCodeExample = {
 
 type ProviderObject = {
   title: string
-  image: string | null
   description: string
   installation: string[]
   websiteCta?: {

--- a/pages/providers.vue
+++ b/pages/providers.vue
@@ -20,6 +20,10 @@
               :entries="tocEntries"
               :active-section="activeSection"
             />
+            <AppCta
+              v-bind="howToGuideLink"
+              kind="ghost"
+            />
           </div>
         </div>
         <div class="bx--col-md-5 bx--col-lg-13">
@@ -38,6 +42,13 @@
             />
           </AppIntroductoryContent>
         </div>
+      </div>
+      <div class="bx--row providers-page__join-section">
+        <div class="bx--col-md-5 bx--offset-lg-3 bx--col-lg-5">
+          <h2>Become a provider</h2>
+          <p>Are you looking to integrate with Qiskit? Become a provider and enable your quantum device or simulator to be used with our SDK. Check out our guides on how to write a new provider, and join our community of providers today to help accelerate the development of quantum computing.</p>
+          <AppCta class="providers-page__join-section__cta" v-bind="howToGuideLink" />
+        </div>        
       </div>
     </section>
   </div>
@@ -68,6 +79,11 @@ export default class ProvidersPage extends QiskitPage {
   tocEntries = TABLE_OF_CONTENTS
   contentSections = CONTENT_SECTIONS
 
+  howToGuideLink = {
+    url: 'https://qiskit.org/documentation/apidoc/providers.html#writing-a-new-provider',
+    label: 'Become a provider'
+  }
+
   asTabs (providers: Array<ProviderObject>): Array<ProviderObject> {
     return providers.map(provider => provider as ProviderObject)
   }
@@ -88,6 +104,18 @@ export default class ProvidersPage extends QiskitPage {
   &__content-section-details {
     background-color: $background-color-lighter;
     height: 100%;
+  }
+
+  &__join-section {
+    padding-top: $spacing-09;
+
+    @include mq($until: medium) {
+      padding-top: initial;
+    }
+
+    &__cta {
+      margin-top: $spacing-07;
+    }
   }
 }
 </style>

--- a/pages/providers.vue
+++ b/pages/providers.vue
@@ -48,7 +48,7 @@
           <h2>Become a provider</h2>
           <p>Are you looking to integrate with Qiskit? Become a provider and enable your quantum device or simulator to be used with our SDK. Check out our guides on how to write a new provider, and join our community of providers today to help accelerate the development of quantum computing.</p>
           <AppCta class="providers-page__join-section__cta" v-bind="howToGuideLink" />
-        </div>        
+        </div>
       </div>
     </section>
   </div>


### PR DESCRIPTION
## Changes

Closes #2991 

## Branch preview
https://qiskit-org-pr-3041.dcq4xc5i083.us-south.codeengine.appdomain.cloud/

## Implementation details

- Adds AppCta to the Provider page sidebar (same approach as the Overview page)
- Adds a bottom section on the Provider page (like Ecosystem hero, but at the bottom)
- Removes images from Accordion layout (request from @JRussellHuffman)

## How to read this PR
- please review CTA implementation
- please also review the CTA labels, the bottom section title, and the copy since I made this up as a first attempt

## Screenshots

https://user-images.githubusercontent.com/6276074/226672391-12a53516-d773-4d3e-b479-552177d6ae84.mov


