### PR TITLE
Segment Tracking added to event tabs

### DIFF
--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -164,6 +164,7 @@ export default class EventsPage extends QiskitPage {
   ]
 
   tabs = ['upcoming', 'past', 'calendar']
+  firstLoadOfPageDone = false
 
   get noEvents (): boolean {
     return (this as any).filteredEvents.length === 0
@@ -204,7 +205,10 @@ export default class EventsPage extends QiskitPage {
 
   handleTabSelected (tabIndex: number) {
     this.selectTab(tabIndex)
-    this.$trackClickEvent(this.tabs[tabIndex], 'events-list')
+    if (this.firstLoadOfPageDone) {
+      this.$trackClickEvent(this.tabs[tabIndex], 'events-list')
+    }
+    this.firstLoadOfPageDone = true
   }
 
   selectTab (selectedTab: number) {

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -15,7 +15,7 @@
     <div class="bx--grid">
       <div class="event-page__tabs">
         <client-only>
-          <cv-tabs aria-label="Event tabs" @tab-selected="selectTab">
+          <cv-tabs aria-label="Event tabs" @tab-selected="selectTab" @click="[$trackClickEvent]">
             <cv-tab id="tab-1" label="Upcoming events" />
             <cv-tab id="tab-2" label="Past events" />
             <cv-tab id="tab-3" label="Calendar" />
@@ -106,6 +106,7 @@
 </template>
 
 <script lang="ts">
+import { CtaClickedEventProp } from '~/constants/segment'
 import { mapGetters } from 'vuex'
 import { Component } from 'vue-property-decorator'
 import QiskitPage from '~/components/logic/QiskitPage.vue'

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -164,7 +164,7 @@ export default class EventsPage extends QiskitPage {
   ]
 
   tabs = ['upcoming', 'past', 'calendar']
-  firstLoadOfPageDone = false
+  tabsIsDirty = false
 
   get noEvents (): boolean {
     return (this as any).filteredEvents.length === 0
@@ -205,10 +205,10 @@ export default class EventsPage extends QiskitPage {
 
   handleTabSelected (tabIndex: number) {
     this.selectTab(tabIndex)
-    if (this.firstLoadOfPageDone) {
+    if (this.tabsIsDirty) {
       this.$trackClickEvent(this.tabs[tabIndex], 'events-list')
     }
-    this.firstLoadOfPageDone = true
+    this.tabsIsDirty = true
   }
 
   selectTab (selectedTab: number) {

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -15,7 +15,7 @@
     <div class="bx--grid">
       <div class="event-page__tabs">
         <client-only>
-          <cv-tabs aria-label="Event tabs" @tab-selected="selectTab" @click="[$trackClickEvent]">
+          <cv-tabs aria-label="Event tabs" @tab-selected="handleTabSelected($event)">
             <cv-tab id="tab-1" label="Upcoming events" />
             <cv-tab id="tab-2" label="Past events" />
             <cv-tab id="tab-3" label="Calendar" />
@@ -106,7 +106,6 @@
 </template>
 
 <script lang="ts">
-import { CtaClickedEventProp } from '~/constants/segment'
 import { mapGetters } from 'vuex'
 import { Component } from 'vue-property-decorator'
 import QiskitPage from '~/components/logic/QiskitPage.vue'
@@ -164,6 +163,8 @@ export default class EventsPage extends QiskitPage {
     }
   ]
 
+  tabs = ['upcoming', 'past', 'calendar']
+
   get noEvents (): boolean {
     return (this as any).filteredEvents.length === 0
   }
@@ -201,9 +202,13 @@ export default class EventsPage extends QiskitPage {
       : commit('events/removeFilter', payload)
   }
 
+  handleTabSelected (tabIndex: number) {
+    this.selectTab(tabIndex)
+    this.$trackClickEvent(this.tabs[tabIndex], 'events-list')
+  }
+
   selectTab (selectedTab: number) {
-    const tabs = ['upcoming', 'past', 'calendar']
-    this.$store.commit('events/setActiveSet', tabs[selectedTab])
+    this.$store.commit('events/setActiveSet', this.tabs[selectedTab])
   }
 }
 </script>


### PR DESCRIPTION
## Changes

Added segment to the tabs that split the events list in the events page, resolving #3004.

## Implementation details

For some reason, I wasn't able to double check everything because the Segment extension wasn't working for me.

Also, I added some logic to skip first loading of the page so that segment doesn't register the default selected tab as if the user had clicked on that one.
