### PR TITLE
[Providers] update providers layout

### DIFF
--- a/components/landing/TheQuickStart/Algorithms.vue
+++ b/components/landing/TheQuickStart/Algorithms.vue
@@ -9,7 +9,6 @@
           :code-snippet-location="'quick-start-algorithms'"
         />
       </div>
-      <h3>Test some algorithms</h3>
       <bx-tabs container :value="activeTabLabel" @bx-tabs-selected="updateSelectedTab($event)">
         <bx-tab
           v-for="algorithm in codeExamples"
@@ -75,7 +74,7 @@ export default class Algorithms extends Vue {
 $cta-max-width: 4rem;
 
 .algorithms {
-  padding: $spacing-05;
+  padding: $spacing-09 $spacing-05 $spacing-05 $spacing-05;
 
   &__container {
     background-color: $background-color-lighter;
@@ -84,7 +83,6 @@ $cta-max-width: 4rem;
 
   &__section {
     position: relative;
-    margin-bottom: $spacing-07;
   }
 }
 </style>

--- a/components/landing/TheQuickStart/ProvidersList.vue
+++ b/components/landing/TheQuickStart/ProvidersList.vue
@@ -64,10 +64,14 @@ export default class StartLocally extends Vue {
   padding-top: $spacing-05;
 
   &__list {
-    max-height: 29rem;
+    max-height: 31.25rem;
     overflow-y: scroll;
     margin-bottom: $spacing-07;
     border-bottom: 1px solid $background-color-light;
+
+    @include mq($until: large) {
+      max-height: initial;
+    }
 
     &__cta {
       opacity: 0;

--- a/components/landing/TheQuickStart/index.vue
+++ b/components/landing/TheQuickStart/index.vue
@@ -1,16 +1,22 @@
 <template>
   <article class="bx--grid page-section quick-start">
-    <h2>Quick Start</h2>
-    <div class="bx--row quick-start__introduction">
+    <div class="bx--row">
       <div class="bx--col-md-8 bx--col-lg-8">
-        <p class="quick-start__introduction__copy">
-          When you are looking to start Qiskit, you have two options. You can
-          start Qiskit locally, which is much more secure and private, or you
-          get started with Jupyter Notebooks hosted in IBM Quantum Lab.
-        </p>
-        <p class="quick-start__introduction__copy">
-          Test some of the available providers and algorithms.
-        </p>
+        <div class="quick-start__introduction">
+          <h2>Quick Start</h2>
+          <p class="quick-start__introduction__copy">
+            When you are looking to start Qiskit, you have two options. You can
+            start Qiskit locally, which is much more secure and private, or you
+            get started with Jupyter Notebooks hosted in IBM Quantum Lab.
+          </p>
+          <p class="quick-start__introduction__copy">
+            Test some of the available providers and algorithms.
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="bx--row">
+      <div class="bx--col-md-8 bx--col-lg-8">
         <ProvidersList :providers-list="providersData" @select-provider="updateSelectedProvider($event)" />
       </div>
       <Algorithms


### PR DESCRIPTION
## Changes

Closes https://github.com/Qiskit/qiskit.org/issues/3052



## Implementation details
- restructured the Quick Start widget's use of the Carbon grid
- updated styles
- removed "Test some algorithms" label
- now, the widget components (ProvidersList + Algorithms) are visually aligned at the top

## Screenshots

https://user-images.githubusercontent.com/6276074/227566741-f9bb719d-7ab0-4baa-9ef5-28a17b634f9e.mov


