### PR TITLE
feat(providers): add deprecated overview page redirect

### DIFF
--- a/pages/overview.vue
+++ b/pages/overview.vue
@@ -1,0 +1,6 @@
+<!-- eslint-disable vue/multi-word-component-names -->
+<template>
+  <head>
+    <meta http-equiv="refresh" content="0; URL=/">
+  </head>
+</template>


### PR DESCRIPTION
## Changes

Fixes #3090 

## Implementation details
- handled redirection based on our previous approach with the [qiskit/textbook-beta file](https://github.com/Qiskit/qiskit.org/blob/main/pages/textbook-beta/index.vue)
- please let me know if the approach is okay to use here, or if we need a different approach

## Test for yourself
In the preview branch, try navigating to the `/overview page` and you'll find that you're redirected to the homepage.

https://qiskit-org-pr-3091.dcq4xc5i083.us-south.codeengine.appdomain.cloud/overview