### PR TITLE
remove beta from label

### DIFF
--- a/components/learn/LearnHeader.vue
+++ b/components/learn/LearnHeader.vue
@@ -7,7 +7,7 @@
         </div>
         <div>
           <h1 class="learn-header__headline">
-            Qiskit Textbook (beta)
+            Qiskit Textbook
           </h1>
           <qiskit-mega-menu-dropdown
             :id="appMegaDropdownMenuId"


### PR DESCRIPTION
this PR is part of a bigger set of changes required as the Qiskit textbook get re-organized/versioned: https://github.com/Qiskit/platypus/issues/2046


## Changes

Remove `(beta)` from heading

## Implementation details

the header text is updates and the beta label was removed

## How to read this PR

- review updated file
- review page in preview link

## Screenshots

**before**

<img width="800" alt="image" src="https://user-images.githubusercontent.com/13156555/229873532-5593c1db-e516-447f-8d66-0fdd4dd41bd3.png">

**after**

<img width="800" alt="image" src="https://user-images.githubusercontent.com/13156555/229873707-4250a364-b717-43d8-8423-945570881559.png">




