### PR TITLE
Remove (beta) and banner from textbook-beta page

### DIFF
--- a/components/Learn/LearnPageHeader.vue
+++ b/components/Learn/LearnPageHeader.vue
@@ -6,7 +6,7 @@
           <LearnDynamicBackgroundLogo class="learn-header__logo" />
         </div>
         <div>
-          <h1 class="learn-header__headline">Qiskit Textbook (beta)</h1>
+          <h1 class="learn-header__headline">Qiskit Textbook</h1>
           <qiskit-mega-menu-dropdown
             :id="appMegaDropdownMenuId"
             class="learn-header__dropdown cds--col-md-4 cds--col-lg-4 cds--no-gutter"

--- a/pages/learn/index.vue
+++ b/pages/learn/index.vue
@@ -1,17 +1,5 @@
 <template>
   <main class="learn-page">
-    <qiskit-banner>
-      <div class="content">
-        Miss the old version of the textbook? Access it
-        <UiLink
-          class="link"
-          :segment="{ action: `${routeName} > banner > old-textbook-version` }"
-          url="https://qiskit.org/textbook"
-        >
-          here
-        </UiLink>
-      </div>
-    </qiskit-banner>
     <LearnPageHeader />
     <LearnStartLearningSection class="learn-page__section" />
     <UiHelpfulResourcesSection

--- a/pages/learn/index.vue
+++ b/pages/learn/index.vue
@@ -24,8 +24,6 @@ useHead({
   title: "Qiskit Textbook",
 });
 
-const routeName = "learn";
-
 const helpfulResources: DescriptionCard[] = [
   {
     title: "Documentation",


### PR DESCRIPTION
As the textbook is graduating out of beta, probably the title and banner needs to be updated. 

before
![Screenshot 2023-04-12 at 18 11 38](https://user-images.githubusercontent.com/766693/231518190-746824f1-b049-49d4-82ae-36b146d4ae8e.png)

after
![Screenshot 2023-04-12 at 18 14 03](https://user-images.githubusercontent.com/766693/231518706-94ab950f-48ed-4fed-94ba-e6631731c9b5.png)
