### PR TITLE
Enables SSR and fix web components import

### DIFF
--- a/components/Advocates/AdvocatesMeetTheAdvocates.vue
+++ b/components/Advocates/AdvocatesMeetTheAdvocates.vue
@@ -66,7 +66,7 @@
 </template>
 
 <script setup lang="ts">
-//import "@carbon/web-components/es/components/checkbox/index.js";
+// import "@carbon/web-components/es/components/checkbox/index.js";
 import { ADVOCATES_WORLD_REGION_OPTIONS, Advocate } from "~/types/advocates";
 import rawAdvocates from "~/content/advocates/advocates.json";
 

--- a/components/Advocates/AdvocatesMeetTheAdvocates.vue
+++ b/components/Advocates/AdvocatesMeetTheAdvocates.vue
@@ -66,7 +66,7 @@
 </template>
 
 <script setup lang="ts">
-import "@carbon/web-components/es/components/checkbox/index.js";
+//import "@carbon/web-components/es/components/checkbox/index.js";
 import { ADVOCATES_WORLD_REGION_OPTIONS, Advocate } from "~/types/advocates";
 import rawAdvocates from "~/content/advocates/advocates.json";
 

--- a/components/Ecosystem/EcosystemTestTable.vue
+++ b/components/Ecosystem/EcosystemTestTable.vue
@@ -52,7 +52,7 @@
 </template>
 
 <script setup lang="ts">
-import "@carbon/web-components/es/components/tooltip/tooltip-icon.js";
+//import "@carbon/web-components/es/components/tooltip/tooltip-icon.js";
 import Information16 from "@carbon/icons-vue/lib/information/16";
 import CheckmarkFilled16 from "@carbon/icons-vue/lib/checkmark--filled/16";
 import ErrorFilled16 from "@carbon/icons-vue/lib/error--filled/16";

--- a/components/Ecosystem/EcosystemTestTable.vue
+++ b/components/Ecosystem/EcosystemTestTable.vue
@@ -52,7 +52,7 @@
 </template>
 
 <script setup lang="ts">
-//import "@carbon/web-components/es/components/tooltip/tooltip-icon.js";
+// import "@carbon/web-components/es/components/tooltip/tooltip-icon.js";
 import Information16 from "@carbon/icons-vue/lib/information/16";
 import CheckmarkFilled16 from "@carbon/icons-vue/lib/checkmark--filled/16";
 import ErrorFilled16 from "@carbon/icons-vue/lib/error--filled/16";

--- a/components/Events/Calendars/EventsCalendarsAppleInstructions.vue
+++ b/components/Events/Calendars/EventsCalendarsAppleInstructions.vue
@@ -13,5 +13,5 @@
 </template>
 
 <script setup lang="ts">
-import "@carbon/web-components/es/components/list/index.js";
+//import "@carbon/web-components/es/components/list/index.js";
 </script>

--- a/components/Events/Calendars/EventsCalendarsAppleInstructions.vue
+++ b/components/Events/Calendars/EventsCalendarsAppleInstructions.vue
@@ -13,5 +13,5 @@
 </template>
 
 <script setup lang="ts">
-//import "@carbon/web-components/es/components/list/index.js";
+// import "@carbon/web-components/es/components/list/index.js";
 </script>

--- a/components/Events/Calendars/EventsCalendarsGoogleInstructions.vue
+++ b/components/Events/Calendars/EventsCalendarsGoogleInstructions.vue
@@ -16,5 +16,5 @@
 </template>
 
 <script setup lang="ts">
-import "@carbon/web-components/es/components/list/index.js";
+//import "@carbon/web-components/es/components/list/index.js";
 </script>

--- a/components/Events/Calendars/EventsCalendarsGoogleInstructions.vue
+++ b/components/Events/Calendars/EventsCalendarsGoogleInstructions.vue
@@ -16,5 +16,5 @@
 </template>
 
 <script setup lang="ts">
-//import "@carbon/web-components/es/components/list/index.js";
+// import "@carbon/web-components/es/components/list/index.js";
 </script>

--- a/components/Events/Calendars/EventsCalendarsOutlookInstructions.vue
+++ b/components/Events/Calendars/EventsCalendarsOutlookInstructions.vue
@@ -13,5 +13,5 @@
 </template>
 
 <script setup lang="ts">
-import "@carbon/web-components/es/components/list/index.js";
+//import "@carbon/web-components/es/components/list/index.js";
 </script>

--- a/components/Events/Calendars/EventsCalendarsOutlookInstructions.vue
+++ b/components/Events/Calendars/EventsCalendarsOutlookInstructions.vue
@@ -13,5 +13,5 @@
 </template>
 
 <script setup lang="ts">
-//import "@carbon/web-components/es/components/list/index.js";
+// import "@carbon/web-components/es/components/list/index.js";
 </script>

--- a/components/Events/EventsSummerSchoolFaq.vue
+++ b/components/Events/EventsSummerSchoolFaq.vue
@@ -193,7 +193,7 @@
 </template>
 
 <script setup lang="ts">
-//import "@carbon/web-components/es/components/accordion/index.js";
+// import "@carbon/web-components/es/components/accordion/index.js";
 import { CtaClickedEventProp } from "~/types/segment";
 
 interface TrackedLink {

--- a/components/Events/EventsSummerSchoolFaq.vue
+++ b/components/Events/EventsSummerSchoolFaq.vue
@@ -193,7 +193,7 @@
 </template>
 
 <script setup lang="ts">
-import "@carbon/web-components/es/components/accordion/index.js";
+//import "@carbon/web-components/es/components/accordion/index.js";
 import { CtaClickedEventProp } from "~/types/segment";
 
 interface TrackedLink {

--- a/components/Landing/LandingQuickStart/LandingQuickStartProvidersCodeExamples.vue
+++ b/components/Landing/LandingQuickStart/LandingQuickStartProvidersCodeExamples.vue
@@ -44,7 +44,7 @@
 </template>
 
 <script setup lang="ts">
-import "@carbon/web-components/es/components/tabs/index.js";
+//import "@carbon/web-components/es/components/tabs/index.js";
 
 interface codeExample {
   name: string;

--- a/components/Landing/LandingQuickStart/LandingQuickStartProvidersCodeExamples.vue
+++ b/components/Landing/LandingQuickStart/LandingQuickStartProvidersCodeExamples.vue
@@ -44,7 +44,7 @@
 </template>
 
 <script setup lang="ts">
-//import "@carbon/web-components/es/components/tabs/index.js";
+// import "@carbon/web-components/es/components/tabs/index.js";
 
 interface codeExample {
   name: string;

--- a/components/Landing/LandingQuickStart/LandingQuickStartStartLocally.vue
+++ b/components/Landing/LandingQuickStart/LandingQuickStartStartLocally.vue
@@ -51,8 +51,9 @@
 </template>
 
 <script setup lang="ts">
-import "@carbon/web-components/es/components/accordion/index.js";
-import "@carbon/web-components/es/components/button/index.js";
+//import "@carbon/web-components/es/components/accordion/index.js";
+//import "@carbon/web-components/es/components/button/index.js";
+
 interface ChoicesGroup {
   title: string;
   id: string;

--- a/components/Landing/LandingQuickStart/LandingQuickStartStartLocally.vue
+++ b/components/Landing/LandingQuickStart/LandingQuickStartStartLocally.vue
@@ -51,8 +51,8 @@
 </template>
 
 <script setup lang="ts">
-//import "@carbon/web-components/es/components/accordion/index.js";
-//import "@carbon/web-components/es/components/button/index.js";
+// import "@carbon/web-components/es/components/accordion/index.js";
+// import "@carbon/web-components/es/components/button/index.js";
 
 interface ChoicesGroup {
   title: string;

--- a/components/Landing/QiskitCapabilitiesSection/LandingQiskitCapabilitiesSectionComponent.vue
+++ b/components/Landing/QiskitCapabilitiesSection/LandingQiskitCapabilitiesSectionComponent.vue
@@ -47,7 +47,7 @@
 </template>
 
 <script setup lang="ts">
-//import "@carbon/web-components/es/components/button/index.js";
+// import "@carbon/web-components/es/components/button/index.js";
 import Copy16 from "@carbon/icons-vue/lib/copy/16";
 import { useScrollBetweenSections } from "~/composables/useScrollBetweenSections";
 import type { CtaClickedEventProp } from "~/types/segment";

--- a/components/Landing/QiskitCapabilitiesSection/LandingQiskitCapabilitiesSectionComponent.vue
+++ b/components/Landing/QiskitCapabilitiesSection/LandingQiskitCapabilitiesSectionComponent.vue
@@ -47,7 +47,7 @@
 </template>
 
 <script setup lang="ts">
-import "@carbon/web-components/es/components/button/index.js";
+//import "@carbon/web-components/es/components/button/index.js";
 import Copy16 from "@carbon/icons-vue/lib/copy/16";
 import { useScrollBetweenSections } from "~/composables/useScrollBetweenSections";
 import type { CtaClickedEventProp } from "~/types/segment";

--- a/components/Learn/LearnContentMenuSection.vue
+++ b/components/Learn/LearnContentMenuSection.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script setup lang="ts">
-import "@qiskit/web-components/mega-menu-dropdown";
+//import "@qiskit/web-components/mega-menu-dropdown";
 import { LEARN_MEGA_MENU } from "~/constants/megaMenuLinks";
 
 const dropdownMenuContent = LEARN_MEGA_MENU;

--- a/components/Learn/LearnContentMenuSection.vue
+++ b/components/Learn/LearnContentMenuSection.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script setup lang="ts">
-//import "@qiskit/web-components/mega-menu-dropdown";
+// import "@qiskit/web-components/mega-menu-dropdown";
 import { LEARN_MEGA_MENU } from "~/constants/megaMenuLinks";
 
 const dropdownMenuContent = LEARN_MEGA_MENU;

--- a/components/Learn/LearnStartLearningSection.vue
+++ b/components/Learn/LearnStartLearningSection.vue
@@ -120,7 +120,7 @@
 </template>
 
 <script setup lang="ts">
-//import "@carbon/web-components/es/components/tabs/index.js";
+// import "@carbon/web-components/es/components/tabs/index.js";
 import { GeneralLink } from "~/constants/appLinks";
 
 type Course = {

--- a/components/Learn/LearnStartLearningSection.vue
+++ b/components/Learn/LearnStartLearningSection.vue
@@ -120,7 +120,7 @@
 </template>
 
 <script setup lang="ts">
-import "@carbon/web-components/es/components/tabs/index.js";
+//import "@carbon/web-components/es/components/tabs/index.js";
 import { GeneralLink } from "~/constants/appLinks";
 
 type Course = {

--- a/components/Ui/UiCard.vue
+++ b/components/Ui/UiCard.vue
@@ -68,8 +68,8 @@
 </template>
 
 <script setup lang="ts">
-//import "@carbon/web-components/es/components/tag/tag.js";
-//import "@carbon/web-components/es/components/tooltip/tooltip-icon.js";
+// import "@carbon/web-components/es/components/tag/tag.js";
+// import "@carbon/web-components/es/components/tooltip/tooltip-icon.js";
 import Information16 from "@carbon/icons-vue/lib/information/16";
 import { CtaClickedEventProp } from "~/types/segment";
 

--- a/components/Ui/UiCard.vue
+++ b/components/Ui/UiCard.vue
@@ -68,8 +68,8 @@
 </template>
 
 <script setup lang="ts">
-import "@carbon/web-components/es/components/tag/tag.js";
-import "@carbon/web-components/es/components/tooltip/tooltip-icon.js";
+//import "@carbon/web-components/es/components/tag/tag.js";
+//import "@carbon/web-components/es/components/tooltip/tooltip-icon.js";
 import Information16 from "@carbon/icons-vue/lib/information/16";
 import { CtaClickedEventProp } from "~/types/segment";
 

--- a/components/Ui/UiCodeSnippet.vue
+++ b/components/Ui/UiCodeSnippet.vue
@@ -28,7 +28,7 @@
 </template>
 
 <script setup lang="ts">
-//import "@carbon/web-components/es/components/button/index.js";
+// import "@carbon/web-components/es/components/button/index.js";
 
 interface Props {
   code: string;

--- a/components/Ui/UiCodeSnippet.vue
+++ b/components/Ui/UiCodeSnippet.vue
@@ -28,7 +28,7 @@
 </template>
 
 <script setup lang="ts">
-import "@carbon/web-components/es/components/button/index.js";
+//import "@carbon/web-components/es/components/button/index.js";
 
 interface Props {
   code: string;

--- a/components/Ui/UiDataTable.vue
+++ b/components/Ui/UiDataTable.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script setup lang="ts">
-//import "@carbon/web-components/es/components/data-table/index.js";
+// import "@carbon/web-components/es/components/data-table/index.js";
 import { GeneralLink } from "~/constants/appLinks";
 
 export interface TableRowElement {

--- a/components/Ui/UiDataTable.vue
+++ b/components/Ui/UiDataTable.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script setup lang="ts">
-import "@carbon/web-components/es/components/data-table/index.js";
+//import "@carbon/web-components/es/components/data-table/index.js";
 import { GeneralLink } from "~/constants/appLinks";
 
 export interface TableRowElement {

--- a/components/Ui/UiMultiSelect.vue
+++ b/components/Ui/UiMultiSelect.vue
@@ -20,8 +20,8 @@
 </template>
 
 <script setup lang="ts">
-import "@carbon/web-components/es/components/multi-select/index.js";
-import "@carbon/web-components/es/components/multi-select/multi-select-item.js";
+//import "@carbon/web-components/es/components/multi-select/index.js";
+//import "@carbon/web-components/es/components/multi-select/multi-select-item.js";
 
 defineEmits(["change-selection"]);
 

--- a/components/Ui/UiMultiSelect.vue
+++ b/components/Ui/UiMultiSelect.vue
@@ -20,8 +20,8 @@
 </template>
 
 <script setup lang="ts">
-//import "@carbon/web-components/es/components/multi-select/index.js";
-//import "@carbon/web-components/es/components/multi-select/multi-select-item.js";
+// import "@carbon/web-components/es/components/multi-select/index.js";
+// import "@carbon/web-components/es/components/multi-select/multi-select-item.js";
 
 defineEmits(["change-selection"]);
 

--- a/components/Ui/UiSyntaxHighlight.vue
+++ b/components/Ui/UiSyntaxHighlight.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script setup lang="ts">
-import "@carbon/web-components/es/components/button/index.js";
+//import "@carbon/web-components/es/components/button/index.js";
 import { CtaClickedEventProp } from "~/types/segment";
 
 interface Props {

--- a/components/Ui/UiSyntaxHighlight.vue
+++ b/components/Ui/UiSyntaxHighlight.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script setup lang="ts">
-//import "@carbon/web-components/es/components/button/index.js";
+// import "@carbon/web-components/es/components/button/index.js";
 import { CtaClickedEventProp } from "~/types/segment";
 
 interface Props {

--- a/components/providers/ProvidersContentAccordion.vue
+++ b/components/providers/ProvidersContentAccordion.vue
@@ -29,7 +29,7 @@
 </template>
 
 <script setup lang="ts">
-import "@carbon/web-components/es/components/accordion/index.js";
+//import "@carbon/web-components/es/components/accordion/index.js";
 import type { Provider } from "~/types/providers";
 
 interface Props {

--- a/components/providers/ProvidersContentAccordion.vue
+++ b/components/providers/ProvidersContentAccordion.vue
@@ -29,7 +29,7 @@
 </template>
 
 <script setup lang="ts">
-//import "@carbon/web-components/es/components/accordion/index.js";
+// import "@carbon/web-components/es/components/accordion/index.js";
 import type { Provider } from "~/types/providers";
 
 interface Props {

--- a/layouts/default-max.vue
+++ b/layouts/default-max.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script setup lang="ts">
-import "@qiskit/web-components/ui-shell";
+//import "@qiskit/web-components/ui-shell";
 
 const route = useRoute();
 const { trackClickEvent } = useSegment();

--- a/layouts/default-max.vue
+++ b/layouts/default-max.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script setup lang="ts">
-//import "@qiskit/web-components/ui-shell";
+// import "@qiskit/web-components/ui-shell";
 
 const route = useRoute();
 const { trackClickEvent } = useSegment();

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script setup lang="ts">
-//import "@qiskit/web-components/ui-shell";
+// import "@qiskit/web-components/ui-shell";
 
 const { trackClickEvent } = useSegment();
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script setup lang="ts">
-import "@qiskit/web-components/ui-shell";
+//import "@qiskit/web-components/ui-shell";
 
 const { trackClickEvent } = useSegment();
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -27,7 +27,7 @@ export default defineNuxtConfig({
       analyticsKey: IS_PRODUCTION
         ? "ffdYLviQze3kzomaINXNk6NwpY9LlXcw"
         : "zbHWEXPUfXm0K6C7HbegwB5ewDEC8o1H",
-      isAnalyticsEnabled: true,
+      isAnalyticsEnabled: false,
     },
   },
 
@@ -41,7 +41,7 @@ export default defineNuxtConfig({
     },
   },
 
-  ssr: false,
+  ssr: true,
 
   vue: {
     compilerOptions: {

--- a/pages/ecosystem.vue
+++ b/pages/ecosystem.vue
@@ -111,8 +111,8 @@
 </template>
 
 <script setup lang="ts">
-//import "@carbon/web-components/es/components/accordion/index.js";
-//import "@carbon/web-components/es/components/checkbox/index.js";
+// import "@carbon/web-components/es/components/accordion/index.js";
+// import "@carbon/web-components/es/components/checkbox/index.js";
 import StarFilled16 from "@carbon/icons-vue/lib/star--filled/16";
 import { GeneralLink } from "~/constants/appLinks";
 import rawMembers from "~/content/ecosystem/members.json";

--- a/pages/ecosystem.vue
+++ b/pages/ecosystem.vue
@@ -111,8 +111,8 @@
 </template>
 
 <script setup lang="ts">
-import "@carbon/web-components/es/components/accordion/index.js";
-import "@carbon/web-components/es/components/checkbox/index.js";
+//import "@carbon/web-components/es/components/accordion/index.js";
+//import "@carbon/web-components/es/components/checkbox/index.js";
 import StarFilled16 from "@carbon/icons-vue/lib/star--filled/16";
 import { GeneralLink } from "~/constants/appLinks";
 import rawMembers from "~/content/ecosystem/members.json";

--- a/pages/events/fall-fest.vue
+++ b/pages/events/fall-fest.vue
@@ -91,7 +91,7 @@
 </template>
 
 <script setup lang="ts">
-import "@carbon/web-components/es/components/tabs/index.js";
+//import "@carbon/web-components/es/components/tabs/index.js";
 import {
   header,
   agenda,

--- a/pages/events/fall-fest.vue
+++ b/pages/events/fall-fest.vue
@@ -91,7 +91,7 @@
 </template>
 
 <script setup lang="ts">
-//import "@carbon/web-components/es/components/tabs/index.js";
+// import "@carbon/web-components/es/components/tabs/index.js";
 import {
   header,
   agenda,

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -102,9 +102,9 @@
 </template>
 
 <script setup lang="ts">
-//import "@carbon/web-components/es/components/checkbox/index.js";
-//import "@carbon/web-components/es/components/code-snippet/index.js";
-//import "@carbon/web-components/es/components/tabs/index.js";
+// import "@carbon/web-components/es/components/checkbox/index.js";
+// import "@carbon/web-components/es/components/code-snippet/index.js";
+// import "@carbon/web-components/es/components/tabs/index.js";
 import {
   CommunityEvent,
   WORLD_REGION_OPTIONS,

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -102,9 +102,9 @@
 </template>
 
 <script setup lang="ts">
-import "@carbon/web-components/es/components/checkbox/index.js";
-import "@carbon/web-components/es/components/code-snippet/index.js";
-import "@carbon/web-components/es/components/tabs/index.js";
+//import "@carbon/web-components/es/components/checkbox/index.js";
+//import "@carbon/web-components/es/components/code-snippet/index.js";
+//import "@carbon/web-components/es/components/tabs/index.js";
 import {
   CommunityEvent,
   WORLD_REGION_OPTIONS,

--- a/pages/events/summer-school.vue
+++ b/pages/events/summer-school.vue
@@ -92,7 +92,7 @@
 </template>
 
 <script setup lang="ts">
-import "@carbon/web-components/es/components/tabs/index.js";
+//import "@carbon/web-components/es/components/tabs/index.js";
 import {
   header,
   mosaic,

--- a/pages/events/summer-school.vue
+++ b/pages/events/summer-school.vue
@@ -92,7 +92,7 @@
 </template>
 
 <script setup lang="ts">
-//import "@carbon/web-components/es/components/tabs/index.js";
+// import "@carbon/web-components/es/components/tabs/index.js";
 import {
   header,
   mosaic,

--- a/plugins/components.client.ts
+++ b/plugins/components.client.ts
@@ -1,0 +1,15 @@
+import "@carbon/web-components/es/components/accordion/index.js";
+import "@carbon/web-components/es/components/button/index.js";
+import "@carbon/web-components/es/components/checkbox/index.js";
+import "@carbon/web-components/es/components/code-snippet/index.js";
+import "@carbon/web-components/es/components/tooltip/tooltip-icon.js";
+import "@carbon/web-components/es/components/list/index.js";
+import "@carbon/web-components/es/components/tabs/index.js";
+import "@carbon/web-components/es/components/data-table/index.js";
+import "@carbon/web-components/es/components/multi-select/index.js";
+import "@carbon/web-components/es/components/multi-select/multi-select-item.js";
+import "@qiskit/web-components/ui-shell";
+import "@qiskit/web-components/mega-menu-dropdown";
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+export default defineNuxtPlugin(() => {});

--- a/plugins/components.client.ts
+++ b/plugins/components.client.ts
@@ -11,5 +11,4 @@ import "@carbon/web-components/es/components/multi-select/multi-select-item.js";
 import "@qiskit/web-components/ui-shell";
 import "@qiskit/web-components/mega-menu-dropdown";
 
-// eslint-disable-next-line @typescript-eslint/no-empty-function
 export default defineNuxtPlugin(() => {});


### PR DESCRIPTION
## Changes

Fixes web component imports

## Implementation details

In order to see the providers content, we need ssr. To enable ssr, we need some modifications when importing the web components

## How to read this PR

Open the web and check that the providers content is shown


