### PR TITLE
fix(learn): only render mega menu on client

### DIFF
--- a/components/Learn/LearnContentMenuSection.vue
+++ b/components/Learn/LearnContentMenuSection.vue
@@ -1,12 +1,14 @@
 <template>
   <section class="content-menu-section">
     <div class="content-menu-section__container">
-      <qiskit-mega-menu-dropdown
-        :content.prop="dropdownMenuContent"
-        class="content-menu-section__dropdown cds--col-md-4 cds--col-lg-4 cds--no-gutter"
-        segment-component-name="Textbook mega menu"
-        :track-performed-search="trackPerformedSearch"
-      />
+      <ClientOnly>
+        <qiskit-mega-menu-dropdown
+          :content.prop="dropdownMenuContent"
+          class="content-menu-section__dropdown cds--col-md-4 cds--col-lg-4 cds--no-gutter"
+          segment-component-name="Textbook mega menu"
+          :track-performed-search="trackPerformedSearch"
+        />
+      </ClientOnly>
     </div>
   </section>
 </template>

--- a/components/Learn/LearnPageHeader.vue
+++ b/components/Learn/LearnPageHeader.vue
@@ -7,13 +7,15 @@
         </div>
         <div>
           <h1 class="learn-header__headline">Qiskit Textbook</h1>
-          <qiskit-mega-menu-dropdown
-            :id="appMegaDropdownMenuId"
-            class="learn-header__dropdown cds--col-md-4 cds--col-lg-4 cds--no-gutter"
-            :content.prop="dropdownMenuContent"
-            segment-component-name="Textbook mega menu"
-            :track-performed-search="trackPerformedSearch"
-          />
+          <ClientOnly>
+            <qiskit-mega-menu-dropdown
+              :id="appMegaDropdownMenuId"
+              class="learn-header__dropdown cds--col-md-4 cds--col-lg-4 cds--no-gutter"
+              :content.prop="dropdownMenuContent"
+              segment-component-name="Textbook mega menu"
+              :track-performed-search="trackPerformedSearch"
+            />
+          </ClientOnly>
         </div>
         <UiCta
           class="learn-header__cta"


### PR DESCRIPTION
## Changes

<!--
  Required.

  Briefly describe the changes introduced by this pull request.
  Also link relevant issues with the "closes", "fixes" or "resolves" keywords,
  and add co-authors where appropriate with the "co-authored-by" keyword.

  Example:
  Implemented the functionality to update the user's name.
  Closes #42
  Co-authored-by: @octocat
-->

This PR fixes an issue introduced in https://github.com/Qiskit/qiskit.org/commit/ea4b340bbb4c52e4275a46cc14a4c1038f175fbf that resulted in the Qiskit Mega Menu web component not showing its content. This is solved by only rendering the web component on the client using the [<ClientOnly> component](https://nuxt.com/docs/api/components/client-only).