### PR TITLE
Show upcoming events 2 months in advance

### DIFF
--- a/hooks/update-events.ts
+++ b/hooks/update-events.ts
@@ -9,7 +9,7 @@ export default async function (apiKey: string, outputFolder: string) {
     "Add to Event Site"
   );
   const upcomingCommunityEvents =
-    await communityEventsAirtableRecords.fetchCommunityEvents(31);
+    await communityEventsAirtableRecords.fetchCommunityEvents(62);
   const pastCommunityEvents =
     await communityEventsAirtableRecords.fetchCommunityEvents(-31);
 


### PR DESCRIPTION
## Changes

Widens the range of time to determine which upcoming events to display up to two months (62 days).
Solves #3202 