### PR TITLE
fix(seo): remove layouts for faster redirects

### DIFF
--- a/pages/learn/intro-qc-qh.vue
+++ b/pages/learn/intro-qc-qh.vue
@@ -6,3 +6,12 @@
     />
   </head>
 </template>
+
+<script setup lang="ts">
+definePageMeta({
+  layout: false,
+  pageTitle:
+    "2020 Qiskit global summer school on quantum computing and quantum hardware",
+  routeName: "introduction-to-quantum-computing-and-quantum-hardware-2020",
+});
+</script>

--- a/pages/overview.vue
+++ b/pages/overview.vue
@@ -1,6 +1,13 @@
-<!-- eslint-disable vue/multi-word-component-names -->
 <template>
   <head>
     <meta http-equiv="refresh" content="0; URL=/" />
   </head>
 </template>
+
+<script setup lang="ts">
+definePageMeta({
+  layout: false,
+  pageTitle: "Qiskit",
+  routeName: "qiskit-landing-page",
+});
+</script>

--- a/pages/textbook-beta/index.vue
+++ b/pages/textbook-beta/index.vue
@@ -1,6 +1,13 @@
-<!-- eslint-disable vue/multi-word-component-names -->
 <template>
   <head>
     <meta http-equiv="refresh" content="0; URL=/learn" />
   </head>
 </template>
+
+<script setup lang="ts">
+definePageMeta({
+  layout: false,
+  pageTitle: "Qiskit Textbook",
+  routeName: "learn",
+});
+</script>

--- a/pages/textbook-beta/summer-school/quantum-computing-and-quantum-learning-2021.vue
+++ b/pages/textbook-beta/summer-school/quantum-computing-and-quantum-learning-2021.vue
@@ -6,3 +6,11 @@
     />
   </head>
 </template>
+
+<script setup lang="ts">
+definePageMeta({
+  layout: false,
+  pageTitle: "2021 Qiskit Global Summer School on Quantum Machine Learning",
+  routeName: "quantum-computing-and-quantum-learning-2021",
+});
+</script>


### PR DESCRIPTION
## Changes

<!--
  Required.

  Briefly describe the changes introduced by this pull request.
  Also link relevant issues with the "closes", "fixes" or "resolves" keywords,
  and add co-authors where appropriate with the "co-authored-by" keyword.

  Example:
  Implemented the functionality to update the user's name.
  Closes #42
  Co-authored-by: @octocat
-->

This PR removes the use of the default layout for the pages that are used only for redirection.

Related to #1997

## Implementation details

<!--
  Optional.

  If useful for the code review, describe implementation details and, if
  necessary, why a certain approach was chosen.

  Example:
  Changes are introduced to the controller and the database model. UI changes
  are not in the scope of this PR.
-->

We have some pages that we keep to redirect users to other pages.

The redirections are set to happen as soon as possible (0ms) but currently the client is trying to load the layout first, which includes the standard header and footer, which take some time to load. Only after the layout is loaded, the redirection happens.

This delay might be the reason why search engines like Google are still ranking these pages even though they are 301s and only their target should be indexed.

By not using any Nuxt layout, we can expect the redirections to happen faster and maybe the 301 pages will be removed from the SERPs.