### PR TITLE
feat: remove redirect pages

### DIFF
--- a/pages/learn/intro-qc-qh.vue
+++ b/pages/learn/intro-qc-qh.vue
@@ -1,8 +1,0 @@
-<template>
-  <head>
-    <meta
-      http-equiv="refresh"
-      content="0; URL=/learn/summer-school/introduction-to-quantum-computing-and-quantum-hardware-2020"
-    />
-  </head>
-</template>

--- a/pages/overview.vue
+++ b/pages/overview.vue
@@ -1,6 +1,0 @@
-<!-- eslint-disable vue/multi-word-component-names -->
-<template>
-  <head>
-    <meta http-equiv="refresh" content="0; URL=/" />
-  </head>
-</template>

--- a/pages/textbook-beta/index.vue
+++ b/pages/textbook-beta/index.vue
@@ -1,6 +1,0 @@
-<!-- eslint-disable vue/multi-word-component-names -->
-<template>
-  <head>
-    <meta http-equiv="refresh" content="0; URL=/learn" />
-  </head>
-</template>

--- a/pages/textbook-beta/summer-school/quantum-computing-and-quantum-learning-2021.vue
+++ b/pages/textbook-beta/summer-school/quantum-computing-and-quantum-learning-2021.vue
@@ -1,8 +1,0 @@
-<template>
-  <head>
-    <meta
-      http-equiv="refresh"
-      content="0; URL=/learn/summer-school/quantum-computing-and-quantum-learning-2021"
-    />
-  </head>
-</template>


### PR DESCRIPTION
We now have server-side redirection in place, so we no longer need client-side redirection for these pages.

## Changes

<!--
  Required.

  Briefly describe the changes introduced by this pull request.
  Also link relevant issues with the "closes", "fixes" or "resolves" keywords,
  and add co-authors where appropriate with the "co-authored-by" keyword.

  Example:
  Implemented the functionality to update the user's name.
  Closes #42
  Co-authored-by: @octocat
-->

This PR removes the pages that were used for client-side redirection since we now have server-side redirection in place for those routes.

This change should also result in search engines understanding that these routes are 301 redirects and that they shouldn't be indexed as individual search results.

Closes #1997

## Implementation details

<!--
  Optional.

  If useful for the code review, describe implementation details and, if
  necessary, why a certain approach was chosen.

  Example:
  Changes are introduced to the controller and the database model. UI changes
  are not in the scope of this PR.
-->

As mentioned in https://github.com/Qiskit/qiskit.org/issues/1997#issuecomment-1544076829, I created a PR to add server-side redirects to the pages that were being redirected client-side. Since that PR got merged, now we have proper server redirection in place and we can remove these pages that were only used for redirection.

You can check that the server-side redirection is in place by visiting a site like https://www.redirect-checker.org/ to test each route.