### PR TITLE
Fix- Changed the EcosystemTestTable toolTip content background-color to dark

### DIFF
--- a/components/Ecosystem/EcosystemTestTable.vue
+++ b/components/Ecosystem/EcosystemTestTable.vue
@@ -131,7 +131,6 @@ bx-table-cell {
 }
 bx-tooltip-icon {
   --cds-inverse-02: #{carbon.$cool-gray-90};
-  
   line-height: 0;
 }
 </style>

--- a/components/Ecosystem/EcosystemTestTable.vue
+++ b/components/Ecosystem/EcosystemTestTable.vue
@@ -129,4 +129,9 @@ bx-table-cell {
   background-color: carbon.$cool-gray-10;
   border-bottom: 1px solid carbon.$cool-gray-30;
 }
+bx-tooltip-icon {
+  --cds-inverse-02: #{carbon.$cool-gray-90};
+  
+  line-height: 0;
+}
 </style>

--- a/components/Ecosystem/EcosystemTestTable.vue
+++ b/components/Ecosystem/EcosystemTestTable.vue
@@ -129,8 +129,8 @@ bx-table-cell {
   background-color: carbon.$cool-gray-10;
   border-bottom: 1px solid carbon.$cool-gray-30;
 }
+
 bx-tooltip-icon {
   --cds-inverse-02: #{carbon.$cool-gray-90};
-  line-height: 0;
 }
 </style>


### PR DESCRIPTION
## Changes
[EcosystemTestTable]: Tooltip is using the wrong color


## Implementation details
Changed the EcosystemTestTable toolTip content background-color to dark
closes #3208 

## How to read this PR


## Screenshots

![image](https://github.com/Qiskit/qiskit.org/assets/55488549/9ad0b8c8-f3ad-4498-ad7e-0db43824baa2)


<!--
  Optional.

  If relevant (e.g. UI changes are introduced), add screenshots or videos
  depicting the changes. Ideally, showing the before and after situations.


https://github.com/Qiskit/qiskit.org/assets/55488549/2cab9d30-0c17-4fc7-9b5c-3cf4251d065d


-->
https://github.com/Qiskit/qiskit.org/assets/55488549/2cab9d30-0c17-4fc7-9b5c-3cf4251d065d
