### PR TITLE
feat(qgss23): temp disable cta

### DIFF
--- a/constants/summerSchool2023Content.ts
+++ b/constants/summerSchool2023Content.ts
@@ -11,8 +11,8 @@ const header = {
     },
   },
   cta: {
-    label: "Register today",
-    url: "https://www.eventbrite.com/e/2023-qiskit-early-access-summer-school-tickets-629462869387",
+    label: "Registration coming soon!",
+    url: " ",
     segment: {
       cta: "register",
       location: "header",
@@ -27,8 +27,8 @@ const header = {
     location: "Online",
     date: "July 17 – 28, 2023",
     time: "",
-    to: "https://www.eventbrite.com/e/2023-qiskit-early-access-summer-school-tickets-629462869387",
-    ctaLabel: "Learn more",
+    to: "",
+    ctaLabel: "",
     segment: {
       cta: "ibm-research-blog",
       location: "header",

--- a/pages/events/summer-school-2023.vue
+++ b/pages/events/summer-school-2023.vue
@@ -25,7 +25,11 @@
           FAQ below!
         </p>
         <p>See you soon!</p>
-        <UiCta class="summer-school-page__cta" v-bind="header.cta" />
+        <UiCta
+          class="summer-school-page__cta"
+          v-bind="header.cta"
+          kind="secondary"
+        />
       </template>
       <template #card>
         <EventsItemCard v-bind="headerData.card" vertical-layout>
@@ -182,6 +186,7 @@ const helpfulResourcesData = helpfulResources;
 
 <style lang="scss" scoped>
 @use "~/assets/scss/carbon.scss";
+@use "~/assets/scss/helpers/index.scss" as qiskit;
 
 .summer-school-page {
   display: flex;
@@ -218,6 +223,12 @@ const helpfulResourcesData = helpfulResources;
 
   &__cta {
     margin-top: carbon.$spacing-07;
+    pointer-events: none;
+    color: qiskit.$text-color-light;
+
+    &:deep(.cta__icon) {
+      display: none;
+    }
   }
 }
 </style>


### PR DESCRIPTION
## Changes

Following requests from Aaliyah (Community Event Manager), we should disable the registration CTA at first, so we can soft launch the page. Once the event is live, we can make a small PR to update the CTA.

Note: we've done this in the past, w/ previous summer school events. I also shared this preview link w/ Aaliyah and she gave it a 👍🏼 

## Implementation details

- removed eventbrite links for now
- updated CTA to use `kind="secondary"`
- used css to hide link icon


## Preview 
https://qiskit-org-pr-3228.dcq4xc5i083.us-south.codeengine.appdomain.cloud/events/summer-school-2023

## Screenshots
![Screenshot 2023-05-17 at 12 21 04 PM (2)](https://github.com/Qiskit/qiskit.org/assets/6276074/b7dd64d0-82e6-470d-9211-9881f61423dd)


