### PR TITLE
feat(qgss23): update curriculum

### DIFF
--- a/constants/summerSchool2023Content.ts
+++ b/constants/summerSchool2023Content.ts
@@ -168,7 +168,13 @@ const week1Schedule: dailyAgenda[] = [
     day: "Wednesday, July 19",
     topic: "Creating Entanglement with Qiskit",
     speaker: "N. Bronn",
-    format: "Lecture",
+    format: "Lab",
+  },
+  {
+    day: "Wednesday, July 19",
+    topic: " ",
+    speaker: "N. Bronn, J. Watrous",
+    format: "Live Q&A",
   },
   {
     day: "Thursday, July 20",
@@ -286,6 +292,12 @@ const week2Schedule: dailyAgenda[] = [
     topic: "Noise Mitigation",
     speaker: "K. Sung",
     format: "Lab",
+  },
+  {
+    day: "Thursday, July 27",
+    topic: " ",
+    speaker: "K. Sung, J. Watrous",
+    format: "Live Q&A",
   },
   {
     day: "Friday, July 28",


### PR DESCRIPTION
## Changes

Addresses content update from Aaliyah shown here:

https://github.com/Qiskit/qiskit.org/assets/6276074/d138f4a3-9f42-4a1d-a076-27d1048a31d6




## Implementation details

- corrected N. Bronn's session from `Lecture` to `Lab`, as shown in the doc
- added 2 Live Q&A rows to the curriculum table 


## Preview link
