### PR TITLE
revert/semantic html image commits

### DIFF
--- a/components/CourseOverviewPage.vue
+++ b/components/CourseOverviewPage.vue
@@ -16,12 +16,7 @@
         />
       </template>
       <template #image>
-        <nuxt-img
-          class="page-header-with-img__image"
-          format="webp"
-          sizes="sm:300px md:650px lg:500px xl:750px"
-          :src="headerImg"
-        />
+        <img class="page-header-with-img__image" :src="headerImg" />
       </template>
     </UiPageHeaderWithImage>
     <LearnPrerequisiteMaterialSection

--- a/components/Landing/HeroMoment/LandingHeroMomentComponent.vue
+++ b/components/Landing/HeroMoment/LandingHeroMomentComponent.vue
@@ -28,12 +28,6 @@
           :segment="getStartedLink.segment"
           :url="getStartedLink.url"
         />
-        <nuxt-img
-          class="hero-moment__container__image"
-          format="webp"
-          sizes="lg:500px xl:850px"
-          src="/images/landing-page/hero-illustration.png"
-        />
       </div>
     </MetalGrid>
   </article>
@@ -54,7 +48,6 @@ const getStartedLink: GeneralLink = {
   segment: { cta: "get-started", location: "hero-moment" },
 };
 
-// TODO: Fix hydration text content mismatch
 const qiskitPronunciation = Math.random() < 0.5 ? "[kiss-kit]" : "[quiss-kit]";
 </script>
 
@@ -85,26 +78,16 @@ const qiskitPronunciation = Math.random() < 0.5 ? "[kiss-kit]" : "[quiss-kit]";
   }
 
   &__container {
+    background-image: url("/images/landing-page/hero-illustration.png");
+    background-position: right center;
+    background-repeat: no-repeat;
+    background-size: contain;
     height: 100%;
-    overflow: hidden;
     padding-top: carbon.$spacing-10;
     pointer-events: none;
-    position: relative;
 
     @include carbon.breakpoint-down(md) {
       background-image: none;
-    }
-
-    &__image {
-      height: 100%;
-      position: absolute;
-      right: 0;
-      top: 0;
-      z-index: -1;
-
-      @include carbon.breakpoint-down(md) {
-        display: none;
-      }
     }
   }
 

--- a/components/Landing/LearnSection/LandingLearnSectionCard.vue
+++ b/components/Landing/LearnSection/LandingLearnSectionCard.vue
@@ -21,14 +21,7 @@
         </div>
       </div>
     </div>
-    <div class="cds--col-md learn-card__media">
-      <nuxt-img
-        class="learn-card__media__image"
-        format="webp"
-        sizes="sm:500px md:700 xl:1000"
-        src="/images/landing-page/learn-image.jpg"
-      />
-    </div>
+    <div class="cds--col-md learn-card__media" />
   </article>
 </template>
 
@@ -102,17 +95,11 @@ const learnLink: GeneralLink = {
   }
 
   &__media {
+    background-image: url("/images/landing-page/learn-image.jpg");
+    background-position: center 25%;
+    background-size: cover;
+    flex: 1;
     min-height: 12rem;
-    overflow: hidden;
-    padding: 0;
-    position: relative;
-
-    &__image {
-      height: 135%;
-      object-fit: cover;
-      position: absolute;
-      width: 100%;
-    }
   }
 
   &__cta {

--- a/components/Landing/QiskitCapabilitiesSection/LandingQiskitCapabilityCard.vue
+++ b/components/Landing/QiskitCapabilitiesSection/LandingQiskitCapabilityCard.vue
@@ -2,22 +2,18 @@
   <article>
     <div class="qiskit-capability-card__container">
       <div class="qiskit-capability-card__thumbnail">
-        <nuxt-img
+        <img
           class="qiskit-capability-card__thumbnail__media"
-          format="webp"
           :src="thumbnailResource"
-          width="160px"
         />
       </div>
       <div class="qiskit-capability-card__copy">
         <h3 class="qiskit-capability-card__title">
           {{ title }}
         </h3>
-        <nuxt-img
+        <img
           class="qiskit-capability-card__thumbnail__mobile"
-          format="webp"
           :src="thumbnailResource"
-          width="160px"
         />
         <div class="qiskit-capability-card__description">
           <p v-text="description" />
@@ -81,6 +77,7 @@ $card-img-width: 10rem;
 
     &__media {
       display: block;
+      width: 100%;
       width: $card-img-width;
     }
 

--- a/components/Learn/LearnCoursePagesSection.vue
+++ b/components/Learn/LearnCoursePagesSection.vue
@@ -30,11 +30,8 @@
       </div>
       <div v-if="activeCourse" class="course-pages-section__main__preview">
         <UiBasicLink :url="activeCourse.url">
-          <nuxt-img
+          <img
             class="course-pages-section__main__preview__image"
-            format="webp"
-            preload
-            sizes="md:500px lg:800px"
             :src="activeCoursePreviewImage"
           />
         </UiBasicLink>

--- a/components/Learn/LearnCoursePagesSection.vue
+++ b/components/Learn/LearnCoursePagesSection.vue
@@ -34,7 +34,7 @@
             class="course-pages-section__main__preview__image"
             format="webp"
             preload
-            sizes="md:650px lg:500px xl:750px"
+            sizes="md:500px lg:800px"
             :src="activeCoursePreviewImage"
           />
         </UiBasicLink>

--- a/components/Learn/LearnSketchedLogo.vue
+++ b/components/Learn/LearnSketchedLogo.vue
@@ -78,10 +78,8 @@
         class="sketched-logo__st1"
       />
     </svg>
-    <nuxt-img
+    <img
       class="sketched-logo__sketch"
-      format="webp"
-      sizes="sm:300px md:600px xxl:700px"
       src="/images/learn/logo-sketch-lines.png"
     />
   </div>

--- a/components/Metal/MetalBuildingSection.vue
+++ b/components/Metal/MetalBuildingSection.vue
@@ -59,12 +59,10 @@
           <!-- eslint-enable -->
         </div>
         <div class="building-section__media">
-          <nuxt-img
-            alt="Sketched illustration of a group standing in front of a whiteboard."
+          <img
             class="building-section__media-img"
-            format="webp"
-            sizes="lg:600px"
             src="/images/metal/whiteboard-dark.png"
+            alt="Sketched illustration of a group standing in front of a whiteboard."
           />
         </div>
       </div>

--- a/components/Metal/MetalCapabilitiesSection.vue
+++ b/components/Metal/MetalCapabilitiesSection.vue
@@ -11,32 +11,36 @@
             class="capabilities-section__card scrollable"
             :title="item.title"
             :description="item.description"
-            :video="item.video"
+            :visual-resource="item.visualResource"
           />
         </div>
         <div class="capabilities-section__scrolling-ui">
           <div
             v-for="(item, index) in capabilities"
-            :key="item.video"
-            class="capabilities-section__video-container"
+            :key="item.visualResource"
+            class="capabilities-section__visual-resource-container"
             :class="{
-              'capabilities-section__video-container_active': isActiveImage(
-                item,
-                index
-              ),
+              'capabilities-section__visual-resource-container_active':
+                isActiveImage(item, index),
             }"
           >
             <video
-              class="capabilities-section__video"
+              v-if="isVideo(item.visualResource)"
+              class="capabilities-section__visual-resource capabilities-section__visual-resource_type_video"
               loop
               autoplay
               muted
               playsinline
             >
-              <source :src="item.video" type="video/mp4" />
-              <source :src="item.video" type="video/ogg" />
+              <source :src="item.visualResource" type="video/mp4" />
+              <source :src="item.visualResource" type="video/ogg" />
               Your browser does not support video.
             </video>
+            <div
+              v-else
+              class="capabilities-section__visual-resource capabilities-section__visual-resource_type_image"
+              :style="{ 'background-image': `url(${item.visualResource})` }"
+            />
           </div>
         </div>
       </div>
@@ -56,6 +60,11 @@ const isActiveImage = (item: MetalCapability, index: number): boolean => {
     item.title === activeSection.value ||
     (activeSection.value === "" && index === 0)
   );
+};
+
+const isVideo = (url: string): boolean => {
+  const extension = url.substring(url.length - 4);
+  return extension === ".mp4";
 };
 </script>
 
@@ -118,7 +127,7 @@ const isActiveImage = (item: MetalCapability, index: number): boolean => {
     }
   }
 
-  &__video-container {
+  &__visual-resource-container {
     position: absolute;
     top: 0;
     opacity: 0;
@@ -131,8 +140,20 @@ const isActiveImage = (item: MetalCapability, index: number): boolean => {
     }
   }
 
-  &__video {
-    width: 100%;
+  &__visual-resource {
+    &_type {
+      &_image {
+        width: 100%;
+        height: 100%;
+        background-size: contain;
+        background-position: center top;
+        background-repeat: no-repeat;
+      }
+
+      &_video {
+        width: 100%;
+      }
+    }
   }
 }
 </style>

--- a/components/Metal/MetalCapabilityCard.vue
+++ b/components/Metal/MetalCapabilityCard.vue
@@ -12,22 +12,41 @@
         <!-- estlint-enable -->
       </div>
     </div>
-    <video class="capability-card__video" loop autoplay muted playsinline>
-      <source :src="video" type="video/mp4" />
-      <source :src="video" type="video/ogg" />
+    <video
+      v-if="isVideo"
+      class="capability-card__visual-resource"
+      loop
+      autoplay
+      muted
+      playsinline
+    >
+      <source :src="visualResource" type="video/mp4" />
+      <source :src="visualResource" type="video/ogg" />
       Your browser does not support video.
     </video>
+    <div
+      v-else
+      class="capability-card__visual-resource"
+      :style="{ 'background-image': `url(${visualResource})` }"
+    />
   </article>
 </template>
 
 <script setup lang="ts">
 interface Props {
+  visualResource: string;
   title: string;
   description: string;
-  video: string;
 }
 
-defineProps<Props>();
+const props = defineProps<Props>();
+
+const isVideo = computed<boolean>(() => {
+  const extension = props.visualResource.substring(
+    props.visualResource.length - 4
+  );
+  return extension === ".mp4";
+});
 </script>
 
 <style lang="scss" scoped>
@@ -80,7 +99,7 @@ defineProps<Props>();
     }
   }
 
-  &__video {
+  &__visual-resource {
     flex: 0 0 32rem;
     width: 100%;
     height: 100%;

--- a/components/Metal/MetalDarkHeader.vue
+++ b/components/Metal/MetalDarkHeader.vue
@@ -130,21 +130,20 @@
       </svg>
 
       <div class="dark-header__media">
-        <nuxt-img
+        <img
           class="dark-header__media-cryo"
-          format="webp"
-          sizes="sm:500px md:700px lg:900px"
           src="/images/metal/hero/cryo.png"
+          alt=""
         />
-        <nuxt-img
+        <img
           class="dark-header__media-transmon-outline"
-          format="webp"
           src="/images/metal/hero/transmon.svg"
+          alt=""
         />
-        <nuxt-img
+        <img
           class="dark-header__media-transmon"
-          format="webp"
           src="/images/metal/hero/transmon.png"
+          alt=""
         />
       </div>
     </div>

--- a/components/Metal/MetalFeatureCard.vue
+++ b/components/Metal/MetalFeatureCard.vue
@@ -4,14 +4,10 @@
       {{ title }}
     </h3>
     <div class="feature-card__content">
-      <div class="feature-card__image-container">
-        <nuxt-img
-          class="feature-card__image"
-          format="webp"
-          sizes="sm:300px md:600px lg:300px"
-          :src="image"
-        />
-      </div>
+      <div
+        class="feature-card__image"
+        :style="{ 'background-image': `url(${image})` }"
+      />
       <!-- TODO: HTML content should not be in strings but in components
       but lacking of a better solution given time constraints. -->
       <!-- eslint-disable vue/no-v-html -->
@@ -62,19 +58,16 @@ defineProps<Props>();
   }
 
   &__image {
-    height: 100%;
-    object-fit: contain;
-    position: absolute;
-    width: 100%;
-  }
-
-  &__image-container {
     flex: 0 0 14rem;
+    background-repeat: no-repeat;
+    background-size: 100%;
+    background-position: center;
     overflow: hidden;
-    position: relative;
 
     @include carbon.breakpoint-down(md) {
+      background-size: contain;
       height: 11rem;
+      width: auto;
     }
   }
 

--- a/components/Ui/UiCard.vue
+++ b/components/Ui/UiCard.vue
@@ -6,16 +6,14 @@
       'card_description-whole-size': descriptionWholeSize,
     }"
   >
-    <div v-if="image" class="card__image-container">
-      <nuxt-img
-        class="card__image"
-        :class="imageContain ? 'card__image_contain' : null"
-        format="webp"
-        loading="lazy"
-        sizes="sm:300px md:650px"
-        :src="image"
-      />
-    </div>
+    <div
+      v-if="image"
+      class="card__image"
+      :class="imageContain ? 'card__image_contain' : null"
+      :style="{
+        'background-image': `url(${image})`,
+      }"
+    />
     <div class="card__content">
       <header class="card__header">
         <div>
@@ -137,22 +135,12 @@ function hasTags(tags: string[] | TagTooltip[]) {
   }
 
   &__image {
-    background-color: qiskit.$background-color-light;
-    height: 100%;
-    object-fit: cover;
-    position: absolute;
-    width: 100%;
-
-    &_contain {
-      background-color: transparent;
-      object-fit: contain;
-    }
-  }
-
-  &__image-container {
     flex: 0 0 14rem;
+    background-color: qiskit.$background-color-light;
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-position: center;
     overflow: hidden;
-    position: relative;
 
     @include carbon.breakpoint-between(md, lg) {
       flex: 0 0 13rem;
@@ -161,6 +149,11 @@ function hasTags(tags: string[] | TagTooltip[]) {
     @include carbon.breakpoint-down(md) {
       height: 13rem;
       width: auto;
+    }
+
+    &_contain {
+      background-color: transparent;
+      background-size: contain;
     }
   }
 

--- a/components/Ui/UiCompactFeature.vue
+++ b/components/Ui/UiCompactFeature.vue
@@ -1,6 +1,6 @@
 <template>
   <article class="compact-feature">
-    <nuxt-img class="compact-feature__icon" :src="`/images/icons/${icon}`" />
+    <img class="compact-feature__icon" :src="`/images/icons/${icon}`" alt="" />
     <h3 class="h4 compact-feature__title">
       {{ title }}
     </h3>

--- a/components/Ui/UiMosaic.vue
+++ b/components/Ui/UiMosaic.vue
@@ -25,17 +25,12 @@
         </div>
         <div
           v-if="image"
-          class="mosaic__element-image-container"
-          :class="`mosaic__element-image-container_${position}`"
-        >
-          <nuxt-img
-            class="mosaic__element-image"
-            :class="`mosaic__element-image_${position}`"
-            format="webp"
-            sizes="sm:350px md:700px"
-            :src="image"
-          />
-        </div>
+          class="mosaic__element-image"
+          :class="`mosaic__element-image_${position}`"
+          :style="{
+            'background-image': `url(${image})`,
+          }"
+        ></div>
       </div>
     </dl>
   </section>
@@ -126,33 +121,38 @@ defineProps<Props>();
     }
 
     &-image {
-      height: 100%;
-      object-fit: cover;
-      position: absolute;
-
-      &_first,
-      &_fourth {
-        bottom: 0;
-        object-fit: contain;
-        right: 0;
-      }
-
-      &_second,
-      &_third {
-        width: 100%;
-      }
-    }
-
-    &-image-container {
       flex: 1 0 0;
-      overflow: hidden;
-      position: relative;
 
-      &_second,
-      &_third {
+      &_first {
+        background-position: right bottom;
+        background-size: contain;
+        background-repeat: no-repeat;
+      }
+
+      &_second {
+        background-position: center top;
+        background-size: cover;
+        background-repeat: no-repeat;
+
         @include carbon.breakpoint-down(lg) {
           min-height: 12rem;
         }
+      }
+
+      &_third {
+        background-position: center;
+        background-size: cover;
+        background-repeat: no-repeat;
+
+        @include carbon.breakpoint-down(md) {
+          min-height: 12rem;
+        }
+      }
+
+      &_fourth {
+        background-position: right bottom;
+        background-size: contain;
+        background-repeat: no-repeat;
       }
     }
 

--- a/constants/metalContent.ts
+++ b/constants/metalContent.ts
@@ -63,8 +63,8 @@ interface MetalCapability {
   title: string;
   /** The visible description of the feature */
   description: string;
-  /** The video of the feature */
-  video: string;
+  /** The image of the feature */
+  visualResource: string;
 }
 
 const METAL_CAPABILITIES: Array<MetalCapability> = [
@@ -72,20 +72,20 @@ const METAL_CAPABILITIES: Array<MetalCapability> = [
     title: "Design quantum systems",
     description:
       "Qiskit Metal enables chip prototyping in a matter of minutes. You can start from a convenient Python Jupyter notebook or take advantage of the user-friendly graphical user interface (GUI). Simply choose from a library of predefined quantum components, such as transmon qubits and coplanar resonators, and customize their parameters in real-time to fit your needs. Use the built-in algorithms to automatically connect components. Easily implement new experimental components using Python templates and examples.",
-    video: "/videos/metal/design-quantum-systems.mp4",
+    visualResource: "/videos/metal/design-quantum-systems.mp4",
   },
   {
     title: "Modeling quantum systems",
     description:
       "Metal helps automate the quantum electrodynamics modeling of quantum devices to predict their performance  and parameters, such as qubit frequencies, anharmonicities, couplings, and dissipation. Metal’s vision is to provide the abstraction layer needed to seamlessly interconnect with your favorite electromagnetic analysis tool (HFSS, Sonnet, CST, AWR, Comsol, …), dynamically rendering and co-simulating your design, at the whim of a click.",
-    video: "/videos/metal/modeling-quantum-systems.mp4",
+    visualResource: "/videos/metal/modeling-quantum-systems.mp4",
   },
   {
     title: "Analysis design performance",
     description: `Metal aims to give access to advanced quantum analysis techniques to calculate qubit frequencies, anharmonicities, and extract non-linear couplings, dissipation, and the full Hamiltonian of the quantum device, with percent-level accuracy.
                   <br><br>
                   We plan to include the Energy Participation Ratio (EPR), impedance analysis, and the lumped-oscillator model. We hope to further build up the quantum analysis library in collaboration with the community.`,
-    video: "/videos/metal/analysis-design-performance.mp4",
+    visualResource: "/videos/metal/analysis-design-performance.mp4",
   },
 ];
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -16,7 +16,7 @@ export default defineNuxtConfig({
     },
   },
 
-  modules: ["@nuxt/content", "@nuxt/image-edge"],
+  modules: ["@nuxt/content"],
 
   runtimeConfig: {
     // Keys within public are also exposed client-side
@@ -38,16 +38,6 @@ export default defineNuxtConfig({
       if (IS_PRODUCTION || GENERATE_CONTENT) {
         await generateContent();
       }
-    },
-  },
-
-  image: {
-    screens: {
-      sm: 320,
-      md: 672,
-      lg: 1056,
-      xl: 1312,
-      xxl: 1584,
     },
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@carbon/web-components": "^1.27.0",
         "@ibm/plex": "^6.3.0",
         "@nuxt/content": "^2.6.0",
-        "@nuxt/image-edge": "^1.0.0-28059208.2abef1b",
         "@nuxt/test-utils": "^3.4.1",
         "@nuxtjs/eslint-config-typescript": "^12.0.0",
         "@qiskit/web-components": "^0.15.0",
@@ -1505,29 +1504,6 @@
       "resolved": "https://registry.npmjs.org/@nuxt/devalue/-/devalue-2.0.0.tgz",
       "integrity": "sha512-YBI/6o2EBz02tdEJRBK8xkt3zvOFOWlLBf7WKYGBsSYSRtjjgrqPe2skp6VLLmKx5WbHHDNcW+6oACaurxGzeA==",
       "dev": true
-    },
-    "node_modules/@nuxt/image-edge": {
-      "version": "1.0.0-28059208.2abef1b",
-      "resolved": "https://registry.npmjs.org/@nuxt/image-edge/-/image-edge-1.0.0-28059208.2abef1b.tgz",
-      "integrity": "sha512-pW0C+RdA6d0kRsITMuRXLsXZ6fbzgXqIELkpS3z5ZwR5pWkmRmTbgED4MCajblG0P4nuySQl2r0RU4Ktf1LMAA==",
-      "dev": true,
-      "dependencies": {
-        "@nuxt/kit": "^3.4.0",
-        "consola": "^3.0.1",
-        "defu": "^6.1.2",
-        "h3": "^1.6.4",
-        "image-meta": "^0.1.1",
-        "node-fetch-native": "^1.1.0",
-        "ohash": "^1.0.0",
-        "pathe": "^1.1.0",
-        "ufo": "^1.1.1"
-      },
-      "engines": {
-        "node": "^14.16.0 || >=16.11.0"
-      },
-      "optionalDependencies": {
-        "ipx": "1.0.0"
-      }
     },
     "node_modules/@nuxt/kit": {
       "version": "3.4.1",
@@ -4652,13 +4628,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/cssfilter": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/cssnano": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-6.0.1.tgz",
@@ -4864,22 +4833,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/deep-eql": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
@@ -4890,16 +4843,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -6126,16 +6069,6 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -6731,13 +6664,6 @@
       "dependencies": {
         "git-up": "^7.0.0"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "dev": true,
-      "optional": true
     },
     "node_modules/github-slugger": {
       "version": "2.0.0",
@@ -7361,15 +7287,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/image-meta": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/image-meta/-/image-meta-0.1.1.tgz",
-      "integrity": "sha512-+oXiHwOEPr1IE5zY0tcBLED/CYcre15J4nwL50x3o0jxWqEkyjrusiKP3YSU+tr9fvJp33ZcP5Gpj2295g3aEw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.18.0"
-      }
-    },
     "node_modules/immutable": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
@@ -7555,36 +7472,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/ipx": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ipx/-/ipx-1.0.0.tgz",
-      "integrity": "sha512-iJoCDCj2LQZRmzMA2psoUJUcSoLa/iG4f1tBfl8eFgII3priRLwFNHpsiOkk6ZDrilOurXq0A+qQgmJhkZEtcg==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "consola": "^2.15.3",
-        "defu": "^6.1.2",
-        "destr": "^1.2.2",
-        "etag": "^1.8.1",
-        "image-meta": "^0.1.1",
-        "listhen": "^1.0.4",
-        "node-fetch-native": "^1.0.2",
-        "pathe": "^1.1.0",
-        "sharp": "^0.32.0",
-        "ufo": "^1.1.1",
-        "xss": "^1.0.14"
-      },
-      "bin": {
-        "ipx": "bin/ipx.mjs"
-      }
-    },
-    "node_modules/ipx/node_modules/consola": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
-      "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
-      "dev": true,
-      "optional": true
     },
     "node_modules/iron-webcrypto": {
       "version": "0.6.0",
@@ -9714,19 +9601,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -9823,13 +9697,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/mlly": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.2.0.tgz",
@@ -9883,13 +9750,6 @@
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
-    },
-    "node_modules/napi-build-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-      "dev": true,
-      "optional": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -9999,26 +9859,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/node-abi": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.40.0.tgz",
-      "integrity": "sha512-zNy02qivjjRosswoYmPi8hIKJRr8MpQyeKT6qlcq/OnOgA3Rhoae+IYOqsM9V5+JnHWmxKnWOT2GxvtqdtOCXA==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-addon-api": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
-      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
-      "dev": true,
-      "optional": true
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -11479,33 +11319,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
-      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -11636,17 +11449,6 @@
       "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
       "dev": true
     },
-    "node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
@@ -11707,32 +11509,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/rc9": {
@@ -12693,30 +12469,6 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "dev": true
     },
-    "node_modules/sharp": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.1.tgz",
-      "integrity": "sha512-kQTFtj7ldpUqSe8kDxoGLZc1rnMFU0AO2pqbX6pLy3b7Oj8ivJIdoKNwxHVQG2HN6XpHPJqCSM2nsma2gOXvOg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.1",
-        "node-addon-api": "^6.1.0",
-        "prebuild-install": "^7.1.1",
-        "semver": "^7.5.0",
-        "simple-get": "^4.0.1",
-        "tar-fs": "^2.1.1",
-        "tunnel-agent": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=14.15.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -12769,53 +12521,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
-    },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "optional": true
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "optional": true,
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
     },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
@@ -13644,26 +13349,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/tar-fs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-fs/node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -13967,19 +13652,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -15245,30 +14917,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/xss": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.14.tgz",
-      "integrity": "sha512-og7TEJhXvn1a7kzZGQ7ETjdQVS2UfZyTlsEdDOqvQF7GoxNfY+0YLCzBy1kPdsDDx4QuNAonQPddpsn6Xl/7sw==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "commander": "^2.20.3",
-        "cssfilter": "0.0.10"
-      },
-      "bin": {
-        "xss": "bin/xss"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/xss/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "optional": true
-    },
     "node_modules/xxhashjs": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/xxhashjs/-/xxhashjs-0.2.2.tgz",
@@ -16421,24 +16069,6 @@
       "resolved": "https://registry.npmjs.org/@nuxt/devalue/-/devalue-2.0.0.tgz",
       "integrity": "sha512-YBI/6o2EBz02tdEJRBK8xkt3zvOFOWlLBf7WKYGBsSYSRtjjgrqPe2skp6VLLmKx5WbHHDNcW+6oACaurxGzeA==",
       "dev": true
-    },
-    "@nuxt/image-edge": {
-      "version": "1.0.0-28059208.2abef1b",
-      "resolved": "https://registry.npmjs.org/@nuxt/image-edge/-/image-edge-1.0.0-28059208.2abef1b.tgz",
-      "integrity": "sha512-pW0C+RdA6d0kRsITMuRXLsXZ6fbzgXqIELkpS3z5ZwR5pWkmRmTbgED4MCajblG0P4nuySQl2r0RU4Ktf1LMAA==",
-      "dev": true,
-      "requires": {
-        "@nuxt/kit": "^3.4.0",
-        "consola": "^3.0.1",
-        "defu": "^6.1.2",
-        "h3": "^1.6.4",
-        "image-meta": "^0.1.1",
-        "ipx": "1.0.0",
-        "node-fetch-native": "^1.1.0",
-        "ohash": "^1.0.0",
-        "pathe": "^1.1.0",
-        "ufo": "^1.1.1"
-      }
     },
     "@nuxt/kit": {
       "version": "3.4.1",
@@ -18762,13 +18392,6 @@
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
     },
-    "cssfilter": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
-      "dev": true,
-      "optional": true
-    },
     "cssnano": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-6.0.1.tgz",
@@ -18919,16 +18542,6 @@
         "character-entities": "^2.0.0"
       }
     },
-    "decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "mimic-response": "^3.1.0"
-      }
-    },
     "deep-eql": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
@@ -18937,13 +18550,6 @@
       "requires": {
         "type-detect": "^4.0.0"
       }
-    },
-    "deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true,
-      "optional": true
     },
     "deep-is": {
       "version": "0.1.4",
@@ -19829,13 +19435,6 @@
         "strip-final-newline": "^3.0.0"
       }
     },
-    "expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "dev": true,
-      "optional": true
-    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -20287,13 +19886,6 @@
       "requires": {
         "git-up": "^7.0.0"
       }
-    },
-    "github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "dev": true,
-      "optional": true
     },
     "github-slugger": {
       "version": "2.0.0",
@@ -20751,12 +20343,6 @@
       "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true
     },
-    "image-meta": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/image-meta/-/image-meta-0.1.1.tgz",
-      "integrity": "sha512-+oXiHwOEPr1IE5zY0tcBLED/CYcre15J4nwL50x3o0jxWqEkyjrusiKP3YSU+tr9fvJp33ZcP5Gpj2295g3aEw==",
-      "dev": true
-    },
     "immutable": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
@@ -20892,35 +20478,6 @@
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
       "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
       "dev": true
-    },
-    "ipx": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ipx/-/ipx-1.0.0.tgz",
-      "integrity": "sha512-iJoCDCj2LQZRmzMA2psoUJUcSoLa/iG4f1tBfl8eFgII3priRLwFNHpsiOkk6ZDrilOurXq0A+qQgmJhkZEtcg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "consola": "^2.15.3",
-        "defu": "^6.1.2",
-        "destr": "^1.2.2",
-        "etag": "^1.8.1",
-        "image-meta": "^0.1.1",
-        "listhen": "^1.0.4",
-        "node-fetch-native": "^1.0.2",
-        "pathe": "^1.1.0",
-        "sharp": "^0.32.0",
-        "ufo": "^1.1.1",
-        "xss": "^1.0.14"
-      },
-      "dependencies": {
-        "consola": {
-          "version": "2.15.3",
-          "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz",
-          "integrity": "sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==",
-          "dev": true,
-          "optional": true
-        }
-      }
     },
     "iron-webcrypto": {
       "version": "0.6.0",
@@ -22421,13 +21978,6 @@
       "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
       "dev": true
     },
-    "mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true,
-      "optional": true
-    },
     "min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -22499,13 +22049,6 @@
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
     },
-    "mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true,
-      "optional": true
-    },
     "mlly": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.2.0.tgz",
@@ -22541,13 +22084,6 @@
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.2.tgz",
       "integrity": "sha512-7ZtY5KTCNheRGfEFxnedV5zFiORN1+Y1N6zvPTnHQd8ENUvfaDBeuJDZb2bN/oXwXxu3qkTXDzy57W5vAmDTBw==",
       "dev": true
-    },
-    "napi-build-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-      "dev": true,
-      "optional": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -22640,23 +22176,6 @@
           "dev": true
         }
       }
-    },
-    "node-abi": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.40.0.tgz",
-      "integrity": "sha512-zNy02qivjjRosswoYmPi8hIKJRr8MpQyeKT6qlcq/OnOgA3Rhoae+IYOqsM9V5+JnHWmxKnWOT2GxvtqdtOCXA==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "semver": "^7.3.5"
-      }
-    },
-    "node-addon-api": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
-      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
-      "dev": true,
-      "optional": true
     },
     "node-domexception": {
       "version": "1.0.0",
@@ -23657,27 +23176,6 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
-    "prebuild-install": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
-      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      }
-    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -23772,17 +23270,6 @@
       "integrity": "sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==",
       "dev": true
     },
-    "pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
     "punycode": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
@@ -23821,28 +23308,6 @@
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "dev": true
-    },
-    "rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "dependencies": {
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-          "dev": true,
-          "optional": true
-        }
-      }
     },
     "rc9": {
       "version": "2.1.0",
@@ -24569,23 +24034,6 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "dev": true
     },
-    "sharp": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.1.tgz",
-      "integrity": "sha512-kQTFtj7ldpUqSe8kDxoGLZc1rnMFU0AO2pqbX6pLy3b7Oj8ivJIdoKNwxHVQG2HN6XpHPJqCSM2nsma2gOXvOg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.1",
-        "node-addon-api": "^6.1.0",
-        "prebuild-install": "^7.1.1",
-        "semver": "^7.5.0",
-        "simple-get": "^4.0.1",
-        "tar-fs": "^2.1.1",
-        "tunnel-agent": "^0.6.0"
-      }
-    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -24629,25 +24077,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
-    },
-    "simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "dev": true,
-      "optional": true
-    },
-    "simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
     },
     "simple-swizzle": {
       "version": "0.2.2",
@@ -25272,28 +24701,6 @@
         }
       }
     },
-    "tar-fs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      },
-      "dependencies": {
-        "chownr": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
     "tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
@@ -25527,16 +24934,6 @@
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
           "dev": true
         }
-      }
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "safe-buffer": "^5.0.1"
       }
     },
     "type-check": {
@@ -26382,26 +25779,6 @@
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
       "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
       "dev": true
-    },
-    "xss": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.14.tgz",
-      "integrity": "sha512-og7TEJhXvn1a7kzZGQ7ETjdQVS2UfZyTlsEdDOqvQF7GoxNfY+0YLCzBy1kPdsDDx4QuNAonQPddpsn6Xl/7sw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "commander": "^2.20.3",
-        "cssfilter": "0.0.10"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true,
-          "optional": true
-        }
-      }
     },
     "xxhashjs": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@carbon/web-components": "^1.27.0",
     "@ibm/plex": "^6.3.0",
     "@nuxt/content": "^2.6.0",
-    "@nuxt/image-edge": "^1.0.0-28059208.2abef1b",
     "@nuxt/test-utils": "^3.4.1",
     "@nuxtjs/eslint-config-typescript": "^12.0.0",
     "@qiskit/web-components": "^0.15.0",


### PR DESCRIPTION
## Changes

Temporary fix for https://github.com/Qiskit/qiskit.org/issues/3226

However, we still want to use semantic HTML images, though we just need to investigate why images are fully working in our deployed previews, but some break in production.

## Implementation details

reverting two commits:
- https://github.com/Qiskit/qiskit.org/commit/d14ab7cef6b6803cb1a6eccb84eff9c0989fcddd
- https://github.com/Qiskit/qiskit.org/commit/e5e6efffd4d0f09e0896bbc0a0296cdad7890764

