### PR TITLE
fix: use full img path for twitter meta

### DIFF
--- a/pages/events/summer-school-2023.vue
+++ b/pages/events/summer-school-2023.vue
@@ -113,7 +113,8 @@ definePageMeta({
 const title = "Qiskit Global Summer School 2023";
 const description =
   "The Qiskit Global Summer School 2023 is a two-week intensive summer school designed to empower the next generation of quantum researchers and developers with the skills and know-how to explore quantum applications on their own.";
-const image = "/images/events/summer-school-2023/summer-school-2023-logo.png";
+const image =
+  "https://qiskit.org/images/events/summer-school-2023/summer-school-2023-logo.png";
 const pageUrl = "https://qiskit.org/events/summer-school-2023";
 
 useHead({


### PR DESCRIPTION
## Changes

Closes #3233 

## Implementation details

- Use full image path

## How to review

**If you have a Twitter account**
1. Use the [Twitter Card Validator tool](https://cards-dev.twitter.com/validator), and paste in the 
2. Paste in the Summer School 2023 preview URL `https://qiskit-org-pr-3234.dcq4xc5i083.us-south.codeengine.appdomain.cloud/events/summer-school-2023` 

**If you don't have a Twitter account**
1. Use a tool like [Tweetpik's Twitter Card Validator tool](https://tweetpik.com/twitter-card-validator)
2. Paste in the Summer School 2023 preview URL `https://qiskit-org-pr-3234.dcq4xc5i083.us-south.codeengine.appdomain.cloud/events/summer-school-2023`


## Screenshots
![Screenshot 2023-05-18 at 7 14 17 AM](https://github.com/Qiskit/qiskit.org/assets/6276074/84593e81-9b89-4875-a435-0b5b3abcdf10)

