### PR TITLE
fix broken imgs

### DIFF
--- a/components/Learn/LearnCoursePagesSection.vue
+++ b/components/Learn/LearnCoursePagesSection.vue
@@ -30,11 +30,16 @@
       </div>
       <div v-if="activeCourse" class="course-pages-section__main__preview">
         <UiBasicLink :url="activeCourse.url">
-          <nuxt-img
+          <!-- TODO: investigate why this particular img is not being populated -->
+          <!-- <nuxt-img
             class="course-pages-section__main__preview__image"
             format="webp"
             preload
             sizes="md:650px lg:500px xl:750px"
+            :src="activeCoursePreviewImage"
+          /> -->
+          <img
+            class="course-pages-section__main__preview__image"
             :src="activeCoursePreviewImage"
           />
         </UiBasicLink>

--- a/components/Metal/MetalDarkHeader.vue
+++ b/components/Metal/MetalDarkHeader.vue
@@ -138,7 +138,6 @@
         />
         <nuxt-img
           class="dark-header__media-transmon-outline"
-          format="webp"
           src="/images/metal/hero/transmon.svg"
         />
         <nuxt-img

--- a/components/Ui/UiCard.vue
+++ b/components/Ui/UiCard.vue
@@ -7,12 +7,18 @@
     }"
   >
     <div v-if="image" class="card__image-container">
-      <nuxt-img
+      <!-- TODO: investigate why this particular img is not being populated in past Events tab-->
+      <!-- <nuxt-img
         class="card__image"
         :class="imageContain ? 'card__image_contain' : null"
         format="webp"
         loading="lazy"
         sizes="sm:300px md:650px"
+        :src="image"
+      /> -->
+      <img
+        class="card__image"
+        :class="imageContain ? 'card__image_contain' : null"
         :src="image"
       />
     </div>


### PR DESCRIPTION
## Changes

Quick fix for https://github.com/Qiskit/qiskit.org/issues/3226

@eddybrando - feel free to dismiss / close this PR if you have a better solution


## Implementation details

- for images that aren't properly populating into their `/ipx` directory, I commented out the `<nuxt-img>` implementation, and used the regular `<img>` tag instead, for now. 
- for the `MetalDarkHeader` svg static src, I removed the `format="webp"`, after borrowing the idea from [this issue](https://github.com/nuxt/image/issues/822#issue-1705359329) in the Nuxt Image repo.

## How to test

```bash
git checkout fix/broken-imgs
npm run generate
nuxt start
```

Then visit the following pages:
- http://localhost:3000/learn/course/basics-quantum-information
- http://localhost:3000/metal
- http://localhost:3000/events > Past events tab



## Screenshots

<!--
  Optional.

  If relevant (e.g. UI changes are introduced), add screenshots or videos
  depicting the changes. Ideally, showing the before and after situations.
-->
