### PR TITLE
fix: broken images

### DIFF
--- a/components/Learn/LearnCoursePagesSection.vue
+++ b/components/Learn/LearnCoursePagesSection.vue
@@ -28,23 +28,29 @@
           Page preview
         </div>
       </div>
-      <div v-if="activeCourse" class="course-pages-section__main__preview">
-        <UiBasicLink :url="activeCourse.url">
-          <nuxt-img
-            class="course-pages-section__main__preview__image"
-            format="webp"
-            preload
-            sizes="md:650px lg:500px xl:750px"
-            :src="activeCoursePreviewImage"
+
+      <template v-for="course in courses" :key="course.label">
+        <div
+          v-if="course.label === activeCourseLabel"
+          class="course-pages-section__main__preview"
+        >
+          <UiBasicLink :url="course.url">
+            <nuxt-img
+              class="course-pages-section__main__preview__image"
+              format="webp"
+              preload
+              sizes="md:650px lg:500px xl:750px"
+              :src="`${props.imgBase}/${course.image}`"
+            />
+          </UiBasicLink>
+          <UiCta
+            label="Go to page"
+            class="course-pages-section__main__preview__cta"
+            :segment="course.segment"
+            :url="course.url"
           />
-        </UiBasicLink>
-        <UiCta
-          label="Go to page"
-          class="course-pages-section__main__preview__cta"
-          :segment="activeCourse.segment"
-          :url="activeCourse.url"
-        />
-      </div>
+        </div>
+      </template>
     </main>
   </section>
 </template>
@@ -59,32 +65,11 @@ interface Props {
 
 const props = defineProps<Props>();
 
-const activeCourseLabel = ref("");
-
-const activeCourse = computed(() => {
-  const activeCourse = props.courses.find(
-    ({ label }) => label === activeCourseLabel.value
-  );
-  return activeCourse || null;
-});
-
-const activeCoursePreviewImage = computed(() => {
-  if (!activeCourse.value) {
-    return "";
-  }
-
-  const imageUrlBase = props.imgBase;
-
-  return `${imageUrlBase}/${activeCourse.value.image}`;
-});
+const activeCourseLabel = ref(props.courses[0].label);
 
 const selectCourse = (courseLabel: string) => {
   activeCourseLabel.value = courseLabel;
 };
-
-onMounted(() => {
-  selectCourse(props.courses[0].label);
-});
 </script>
 
 <style lang="scss" scoped>

--- a/components/Metal/MetalDarkHeader.vue
+++ b/components/Metal/MetalDarkHeader.vue
@@ -138,7 +138,6 @@
         />
         <nuxt-img
           class="dark-header__media-transmon-outline"
-          format="webp"
           src="/images/metal/hero/transmon.svg"
         />
         <nuxt-img

--- a/components/Ui/UiCard.vue
+++ b/components/Ui/UiCard.vue
@@ -7,12 +7,10 @@
     }"
   >
     <div v-if="image" class="card__image-container">
-      <nuxt-img
+      <!-- TODO: Replace with NuxtImg withouth breaking the "events" page -->
+      <img
         class="card__image"
         :class="imageContain ? 'card__image_contain' : null"
-        format="webp"
-        loading="lazy"
-        sizes="sm:300px md:650px"
         :src="image"
       />
     </div>

--- a/pages/events/summer-school-2023.vue
+++ b/pages/events/summer-school-2023.vue
@@ -113,8 +113,7 @@ definePageMeta({
 const title = "Qiskit Global Summer School 2023";
 const description =
   "The Qiskit Global Summer School 2023 is a two-week intensive summer school designed to empower the next generation of quantum researchers and developers with the skills and know-how to explore quantum applications on their own.";
-const image =
-  "https://qiskit.org/images/events/summer-school-2023/summer-school-2023-logo.png";
+const image = "/images/events/summer-school-2023/summer-school-2023-logo.png";
 const pageUrl = "https://qiskit.org/events/summer-school-2023";
 
 useHead({


### PR DESCRIPTION
## Changes

<!--
  Required.

  Briefly describe the changes introduced by this pull request.
  Also link relevant issues with the "closes", "fixes" or "resolves" keywords,
  and add co-authors where appropriate with the "co-authored-by" keyword.

  Example:
  Implemented the functionality to update the user's name.
  Closes #42
  Co-authored-by: @octocat
-->

This PR fixes the issues with some images not loading after the implementation of [NuxtImg](https://v1.image.nuxtjs.org/) with https://github.com/Qiskit/qiskit.org/pull/3210.

Closes #3226 
Co-authored-by: @techtolentino 

## Implementation details

<!--
  Optional.

  If useful for the code review, describe implementation details and, if
  necessary, why a certain approach was chosen.

  Example:
  Changes are introduced to the controller and the database model. UI changes
  are not in the scope of this PR.
-->

* For the learn pages: Changed the render logic
* For the metal page: Don't convert SVG to webp (by @techtolentino in https://github.com/Qiskit/qiskit.org/pull/3236)
* For the events page: Don't use NuxtImg (by @techtolentino in https://github.com/Qiskit/qiskit.org/pull/3236)

## How to test

Testing in the deployed preview build is no good since it runs with a Node server and provides different results.

To test it as close as possible to the production build, run locally `npm run generate && npm run preview`