### PR TITLE
Add alt text to current images

### DIFF
--- a/components/Advocates/AdvocatesItemCard.vue
+++ b/components/Advocates/AdvocatesItemCard.vue
@@ -4,6 +4,7 @@
     :image="image"
     :title="name"
     :tags="formattedRegion"
+    image-description="Advocate Picture"
   >
     <div v-if="location" class="advocate-card__location">
       <Map20 class="advocate-card__icon" />

--- a/components/Advocates/AdvocatesItemCard.vue
+++ b/components/Advocates/AdvocatesItemCard.vue
@@ -4,7 +4,7 @@
     :image="image"
     :title="name"
     :tags="formattedRegion"
-    :image-description="name + ` photo`"
+    :image-description="name + ` profile photo`"
   >
     <div v-if="location" class="advocate-card__location">
       <Map20 class="advocate-card__icon" />

--- a/components/Advocates/AdvocatesItemCard.vue
+++ b/components/Advocates/AdvocatesItemCard.vue
@@ -4,7 +4,7 @@
     :image="image"
     :title="name"
     :tags="formattedRegion"
-    :image-description="`${name} profile photo`"
+    :alt-text="`${name} profile photo`"
   >
     <div v-if="location" class="advocate-card__location">
       <Map20 class="advocate-card__icon" />

--- a/components/Advocates/AdvocatesItemCard.vue
+++ b/components/Advocates/AdvocatesItemCard.vue
@@ -4,7 +4,7 @@
     :image="image"
     :title="name"
     :tags="formattedRegion"
-    image-description="Advocate Picture"
+    :image-description="name + ` photo`"
   >
     <div v-if="location" class="advocate-card__location">
       <Map20 class="advocate-card__icon" />

--- a/components/Advocates/AdvocatesItemCard.vue
+++ b/components/Advocates/AdvocatesItemCard.vue
@@ -4,7 +4,7 @@
     :image="image"
     :title="name"
     :tags="formattedRegion"
-    :image-description="name + ` profile photo`"
+    :image-description="`${name} profile photo`"
   >
     <div v-if="location" class="advocate-card__location">
       <Map20 class="advocate-card__icon" />

--- a/components/Events/EventsItemCard.vue
+++ b/components/Events/EventsItemCard.vue
@@ -8,7 +8,7 @@
     :cta-label="ctaLabel"
     :segment="segment"
     :vertical-layout="verticalLayout"
-    :image-description="altText"
+    :alt="alt"
   >
     <div class="item-card__description">
       <slot v-if="$slots.default" />
@@ -45,7 +45,7 @@ interface Props {
   types?: string[];
   title: string;
   image: string;
-  altText?: string;
+  alt: string;
   institution?: string;
   location?: string;
   date?: string;
@@ -58,7 +58,7 @@ interface Props {
 
 withDefaults(defineProps<Props>(), {
   types: () => [],
-  altText: "Event or seminar image",
+  alt: "Event or seminar image",
   institution: "",
   ctaLabel: "Join the event",
   date: undefined,

--- a/components/Events/EventsItemCard.vue
+++ b/components/Events/EventsItemCard.vue
@@ -8,7 +8,7 @@
     :cta-label="ctaLabel"
     :segment="segment"
     :vertical-layout="verticalLayout"
-    :alt="alt"
+    :alt-text="altText"
   >
     <div class="item-card__description">
       <slot v-if="$slots.default" />
@@ -45,7 +45,7 @@ interface Props {
   types?: string[];
   title: string;
   image: string;
-  alt: string;
+  altText: string;
   institution?: string;
   location?: string;
   date?: string;
@@ -58,7 +58,7 @@ interface Props {
 
 withDefaults(defineProps<Props>(), {
   types: () => [],
-  alt: "Event image",
+  altText: "Event image",
   institution: "",
   ctaLabel: "Join the event",
   date: undefined,

--- a/components/Events/EventsItemCard.vue
+++ b/components/Events/EventsItemCard.vue
@@ -58,7 +58,7 @@ interface Props {
 
 withDefaults(defineProps<Props>(), {
   types: () => [],
-  alt: "Event or seminar image",
+  alt: "Event image",
   institution: "",
   ctaLabel: "Join the event",
   date: undefined,

--- a/components/Events/EventsItemCard.vue
+++ b/components/Events/EventsItemCard.vue
@@ -8,6 +8,7 @@
     :cta-label="ctaLabel"
     :segment="segment"
     :vertical-layout="verticalLayout"
+    :image-description="altText"
   >
     <div class="item-card__description">
       <slot v-if="$slots.default" />
@@ -44,6 +45,7 @@ interface Props {
   types?: string[];
   title: string;
   image: string;
+  altText?: string;
   institution?: string;
   location?: string;
   date?: string;
@@ -56,6 +58,7 @@ interface Props {
 
 withDefaults(defineProps<Props>(), {
   types: () => [],
+  altText: "Event or seminar image",
   institution: "",
   ctaLabel: "Join the event",
   date: undefined,

--- a/components/Landing/HeroMoment/LandingHeroMomentComponent.vue
+++ b/components/Landing/HeroMoment/LandingHeroMomentComponent.vue
@@ -33,6 +33,7 @@
           format="webp"
           sizes="lg:500px xl:850px"
           src="/images/landing-page/hero-illustration.png"
+          alt="Drawing of two people working on a Quantum Computer"
         />
       </div>
     </MetalGrid>

--- a/components/Landing/LearnSection/LandingLearnSectionCard.vue
+++ b/components/Landing/LearnSection/LandingLearnSectionCard.vue
@@ -27,6 +27,7 @@
         format="webp"
         sizes="sm:500px md:700 xl:1000"
         src="/images/landing-page/learn-image.jpg"
+        alt="Group of students looking into a laptop"
       />
     </div>
   </article>

--- a/components/Landing/QiskitCapabilitiesSection/LandingQiskitCapabilityCard.vue
+++ b/components/Landing/QiskitCapabilitiesSection/LandingQiskitCapabilityCard.vue
@@ -7,6 +7,7 @@
           format="webp"
           :src="thumbnailResource"
           width="160px"
+          alt=""
         />
       </div>
       <div class="qiskit-capability-card__copy">
@@ -18,6 +19,7 @@
           format="webp"
           :src="thumbnailResource"
           width="160px"
+          alt=""
         />
         <div class="qiskit-capability-card__description">
           <p v-text="description" />

--- a/components/Metal/MetalCapabilitiesSection.vue
+++ b/components/Metal/MetalCapabilitiesSection.vue
@@ -28,6 +28,7 @@
           >
             <video
               class="capabilities-section__video"
+              alt="short Video showcasing the GUI"
               loop
               autoplay
               muted

--- a/components/Metal/MetalDarkHeader.vue
+++ b/components/Metal/MetalDarkHeader.vue
@@ -135,15 +135,18 @@
           format="webp"
           sizes="sm:500px md:700px lg:900px"
           src="/images/metal/hero/cryo.png"
+          alt="drawing of the inside of a Quantum computer focused on the chip"
         />
         <nuxt-img
           class="dark-header__media-transmon-outline"
           src="/images/metal/hero/transmon.svg"
+          alt="drawing of the inside of a Quantum computer focused on the chip"
         />
         <nuxt-img
           class="dark-header__media-transmon"
           format="webp"
           src="/images/metal/hero/transmon.png"
+          alt="drawing of the inside of a Quantum computer focused on the chip"
         />
       </div>
     </div>

--- a/components/Metal/MetalFeatureCard.vue
+++ b/components/Metal/MetalFeatureCard.vue
@@ -9,6 +9,7 @@
           class="feature-card__image"
           format="webp"
           sizes="sm:300px md:600px lg:300px"
+          alt=""
           :src="image"
         />
       </div>

--- a/components/Ui/UiCard.vue
+++ b/components/Ui/UiCard.vue
@@ -18,6 +18,7 @@
       /> -->
       <img
         class="card__image"
+        :alt="imageDescription"
         :class="imageContain ? 'card__image_contain' : null"
         :src="image"
       />
@@ -93,6 +94,7 @@ interface Props {
   ctaLabel?: string;
   image?: string;
   imageContain?: boolean;
+  imageDescription?: string;
   segment?: CtaClickedEventProp | undefined;
   subtitle?: string;
   tags?: string[];
@@ -107,6 +109,7 @@ const props = withDefaults(defineProps<Props>(), {
   ctaLabel: "",
   image: "",
   imageContain: false,
+  imageDescription: "No description available",
   segment: undefined,
   subtitle: "",
   tags: () => [],

--- a/components/Ui/UiCard.vue
+++ b/components/Ui/UiCard.vue
@@ -18,7 +18,7 @@
       /> -->
       <img
         class="card__image"
-        :alt="imageDescription"
+        :alt="alt"
         :class="imageContain ? 'card__image_contain' : null"
         :src="image"
       />
@@ -94,7 +94,7 @@ interface Props {
   ctaLabel?: string;
   image?: string;
   imageContain?: boolean;
-  imageDescription?: string;
+  alt?: string;
   segment?: CtaClickedEventProp | undefined;
   subtitle?: string;
   tags?: string[];
@@ -109,7 +109,7 @@ const props = withDefaults(defineProps<Props>(), {
   ctaLabel: "",
   image: "",
   imageContain: false,
-  imageDescription: "No description available",
+  alt: "No description available",
   segment: undefined,
   subtitle: "",
   tags: () => [],

--- a/components/Ui/UiCard.vue
+++ b/components/Ui/UiCard.vue
@@ -18,7 +18,7 @@
       /> -->
       <img
         class="card__image"
-        :alt="alt"
+        :alt="altText"
         :class="imageContain ? 'card__image_contain' : null"
         :src="image"
       />
@@ -94,7 +94,7 @@ interface Props {
   ctaLabel?: string;
   image?: string;
   imageContain?: boolean;
-  alt?: string;
+  altText?: string;
   segment?: CtaClickedEventProp | undefined;
   subtitle?: string;
   tags?: string[];
@@ -109,7 +109,7 @@ const props = withDefaults(defineProps<Props>(), {
   ctaLabel: "",
   image: "",
   imageContain: false,
-  alt: "No description available",
+  altText: "No description available",
   segment: undefined,
   subtitle: "",
   tags: () => [],

--- a/components/Ui/UiMosaic.vue
+++ b/components/Ui/UiMosaic.vue
@@ -7,7 +7,7 @@
           title,
           description,
           image,
-          alt,
+          altText,
           cta,
         } in mosaicElements"
         :key="title"
@@ -41,7 +41,7 @@
             format="webp"
             sizes="sm:350px md:700px"
             :src="image"
-            :alt="alt"
+            :alt="altText"
           />
         </div>
       </div>

--- a/components/Ui/UiMosaic.vue
+++ b/components/Ui/UiMosaic.vue
@@ -2,7 +2,14 @@
   <section class="mosaic">
     <dl class="mosaic__layout">
       <div
-        v-for="{ position, title, description, image, cta } in mosaicElements"
+        v-for="{
+          position,
+          title,
+          description,
+          image,
+          alt,
+          cta,
+        } in mosaicElements"
         :key="title"
         class="mosaic__element"
         :class="`mosaic__element_${position}`"
@@ -34,6 +41,7 @@
             format="webp"
             sizes="sm:350px md:700px"
             :src="image"
+            :alt="alt"
           />
         </div>
       </div>

--- a/constants/summerSchool2023Content.ts
+++ b/constants/summerSchool2023Content.ts
@@ -28,7 +28,7 @@ const header = {
   cardSectionHeading: "About the event:",
   card: {
     image: "/images/events/summer-school-2023/summer-school-2023-logo.png",
-    alt: "Summer School logo: Cnot gate next to a Haddamard gate.",
+    altText: "Summer School logo: Cnot gate next to a Haddamard gate.",
     title: "Qiskit Global Summer School 2023: Theory To Implementation",
     description:
       "The Qiskit Global Summer School returns as a two-week intensive course focused on the foundations of quantum computing and more!",
@@ -58,7 +58,7 @@ const mosaic: MosaicSection = {
       description:
         "Join us for engaging lectures, tips & tricks, tutorials, community updates and access to exclusive Qiskit content!",
       image: "/images/learn/other-platforms/youtube.png",
-      alt: "",
+      altText: "",
       cta: {
         url: "https://www.youtube.com/@qiskit",
         label: "Watch and subscribe",
@@ -74,7 +74,7 @@ const mosaic: MosaicSection = {
       description:
         "The Qiskit Textbook is a free digital open source textbook that will teach you the concepts of quantum computing while you learn to use Qiskit.",
       image: "/images/events/summer-school-2023/qiskit-textbook.jpg",
-      alt: "",
+      altText: "",
       cta: {
         url: "/learn",
         label: "Read the Textbook",
@@ -90,7 +90,7 @@ const mosaic: MosaicSection = {
       description:
         "IBM offers cloud access to the most advanced quantum computers available. Learn, develop, and run programs with our quantum applications and systems.",
       image: "/images/events/summer-school-2022/chip.png",
-      alt: "",
+      altText: "",
       cta: {
         url: "https://quantum-computing.ibm.com/login",
         label: "Explore IBM Quantum",
@@ -107,7 +107,7 @@ const mosaic: MosaicSection = {
         "The Qiskit Global Summer School 2021 coursework, lab, and lecture materials are now available online.",
       image:
         "/images/learn/summer-school/quantum-computing-and-quantum-learning-2021/header.png",
-      alt: "",
+      altText: "",
       cta: {
         url: "https://qiskit.org/learn/summer-school/quantum-computing-and-quantum-learning-2021",
         label: "Start the course",

--- a/constants/summerSchool2023Content.ts
+++ b/constants/summerSchool2023Content.ts
@@ -28,7 +28,7 @@ const header = {
   cardSectionHeading: "About the event:",
   card: {
     image: "/images/events/summer-school-2023/summer-school-2023-logo.png",
-    alt: "summer School logo: Cnot gate next to a Haddamard gate.",
+    alt: "Summer School logo: Cnot gate next to a Haddamard gate.",
     title: "Qiskit Global Summer School 2023: Theory To Implementation",
     description:
       "The Qiskit Global Summer School returns as a two-week intensive course focused on the foundations of quantum computing and more!",

--- a/constants/summerSchool2023Content.ts
+++ b/constants/summerSchool2023Content.ts
@@ -28,6 +28,7 @@ const header = {
   cardSectionHeading: "About the event:",
   card: {
     image: "/images/events/summer-school-2023/summer-school-2023-logo.png",
+    alt: "summer School logo: Cnot gate next to a Haddamard gate.",
     title: "Qiskit Global Summer School 2023: Theory To Implementation",
     description:
       "The Qiskit Global Summer School returns as a two-week intensive course focused on the foundations of quantum computing and more!",
@@ -57,6 +58,7 @@ const mosaic: MosaicSection = {
       description:
         "Join us for engaging lectures, tips & tricks, tutorials, community updates and access to exclusive Qiskit content!",
       image: "/images/learn/other-platforms/youtube.png",
+      alt: "",
       cta: {
         url: "https://www.youtube.com/@qiskit",
         label: "Watch and subscribe",
@@ -72,6 +74,7 @@ const mosaic: MosaicSection = {
       description:
         "The Qiskit Textbook is a free digital open source textbook that will teach you the concepts of quantum computing while you learn to use Qiskit.",
       image: "/images/events/summer-school-2023/qiskit-textbook.jpg",
+      alt: "",
       cta: {
         url: "/learn",
         label: "Read the Textbook",
@@ -87,6 +90,7 @@ const mosaic: MosaicSection = {
       description:
         "IBM offers cloud access to the most advanced quantum computers available. Learn, develop, and run programs with our quantum applications and systems.",
       image: "/images/events/summer-school-2022/chip.png",
+      alt: "",
       cta: {
         url: "https://quantum-computing.ibm.com/login",
         label: "Explore IBM Quantum",
@@ -103,6 +107,7 @@ const mosaic: MosaicSection = {
         "The Qiskit Global Summer School 2021 coursework, lab, and lecture materials are now available online.",
       image:
         "/images/learn/summer-school/quantum-computing-and-quantum-learning-2021/header.png",
+      alt: "",
       cta: {
         url: "https://qiskit.org/learn/summer-school/quantum-computing-and-quantum-learning-2021",
         label: "Start the course",

--- a/hooks/event-conversion-utils.ts
+++ b/hooks/event-conversion-utils.ts
@@ -249,6 +249,7 @@ class EventsAirtableRecords extends AirtableRecords {
       regions: (record.get(this.recordFields!.regions) as WorldRegion[]) || [
         WORLD_REGIONS.tbd,
       ],
+      speaker: (record.get(this.recordFields!.speaker) as string) || "",
       title: (record.get(this.recordFields!.name) as string) || "",
       to: (record.get(this.recordFields!.website) as string) || "",
       abstract: record.get(this.recordFields!.abstract) || "",

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -66,7 +66,7 @@
             <div class="cds--col-sm-4 cds--col-xlg-8">
               <UiCard
                 :image="emptyCard.img"
-                image-description="Warning sign icon"
+                alt-text="Warning sign icon"
                 :title="emptyCard.title"
               >
                 <div class="event-page__empty-card-description">

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -86,7 +86,7 @@
                 :types="eventItem.types"
                 :title="eventItem.title"
                 :image="eventItem.image"
-                :alt-text="altTextSorting(eventItem)"
+                :alt-text="getEventAltText(eventItem)"
                 :location="eventItem.location"
                 :date="eventItem.date"
                 :time="eventItem.startDateAndTime"
@@ -204,7 +204,7 @@ const filteredEvents = computed(() => {
     });
   }
 });
-function altTextSorting(event: any) {
+function getEventAltText(event: any) {
   if (event.title.includes("Seminar")) {
     if (event.speaker !== "") {
       return event.speaker + " photo";

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -86,7 +86,7 @@
                 :types="eventItem.types"
                 :title="eventItem.title"
                 :image="eventItem.image"
-                :alt="getEventAltText(eventItem)"
+                :alt-text="getEventAltText(eventItem)"
                 :location="eventItem.location"
                 :date="eventItem.date"
                 :time="eventItem.startDateAndTime"

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -207,12 +207,12 @@ const filteredEvents = computed(() => {
 function getEventAltText(event: any) {
   if (event.types[0] === "Talks") {
     if (event.speaker !== "") {
-      return event.speaker + " photo";
+      return `${event.speaker} profile photo`;
     } else {
       return "Seminar speaker photo";
     }
   } else {
-    return event.title + " event picture";
+    return `${event.title} event picture`;
   }
 }
 const noEvents = computed(() => filteredEvents.value.length === 0);

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -66,7 +66,7 @@
             <div class="cds--col-sm-4 cds--col-xlg-8">
               <UiCard
                 :image="emptyCard.img"
-                image-description="Warning sing icon"
+                image-description="Warning sign icon"
                 :title="emptyCard.title"
               >
                 <div class="event-page__empty-card-description">

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -82,6 +82,7 @@
                 :types="eventItem.types"
                 :title="eventItem.title"
                 :image="eventItem.image"
+                :alt-text="altTextSorting(eventItem)"
                 :location="eventItem.location"
                 :date="eventItem.date"
                 :time="eventItem.startDateAndTime"
@@ -199,7 +200,20 @@ const filteredEvents = computed(() => {
     });
   }
 });
-
+function altTextSorting(event: any){
+  if (event.title.includes('Seminar')){
+    if (event.speaker !== ""){
+      return event.speaker + " photo"
+    }
+    else{
+      return "Seminar speaker photo"
+    }
+  }
+  else{
+    return event.title + " event picture"
+  }
+  
+}
 const noEvents = computed(() => filteredEvents.value.length === 0);
 
 const regionFiltersAsString = computed(() => regionFilters.value.join(","));

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -86,7 +86,7 @@
                 :types="eventItem.types"
                 :title="eventItem.title"
                 :image="eventItem.image"
-                :alt-text="getEventAltText(eventItem)"
+                :alt="getEventAltText(eventItem)"
                 :location="eventItem.location"
                 :date="eventItem.date"
                 :time="eventItem.startDateAndTime"
@@ -205,7 +205,7 @@ const filteredEvents = computed(() => {
   }
 });
 function getEventAltText(event: any) {
-  if (event.title.includes("Seminar")) {
+  if (event.types[0] === "Talks") {
     if (event.speaker !== "") {
       return event.speaker + " photo";
     } else {

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -200,19 +200,16 @@ const filteredEvents = computed(() => {
     });
   }
 });
-function altTextSorting(event: any){
-  if (event.title.includes('Seminar')){
-    if (event.speaker !== ""){
-      return event.speaker + " photo"
+function altTextSorting(event: any) {
+  if (event.title.includes("Seminar")) {
+    if (event.speaker !== "") {
+      return event.speaker + " photo";
+    } else {
+      return "Seminar speaker photo";
     }
-    else{
-      return "Seminar speaker photo"
-    }
+  } else {
+    return event.title + " event picture";
   }
-  else{
-    return event.title + " event picture"
-  }
-  
 }
 const noEvents = computed(() => filteredEvents.value.length === 0);
 

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -64,7 +64,11 @@
         <template #results>
           <div v-if="noEvents" class="cds--row">
             <div class="cds--col-sm-4 cds--col-xlg-8">
-              <UiCard :image="emptyCard.img" :title="emptyCard.title">
+              <UiCard
+                :image="emptyCard.img"
+                image-description="Warning sing icon"
+                :title="emptyCard.title"
+              >
                 <div class="event-page__empty-card-description">
                   {{ emptyCard.description }}
                 </div>

--- a/pages/events/summer-school-2023.vue
+++ b/pages/events/summer-school-2023.vue
@@ -31,7 +31,11 @@
         <UiCta class="summer-school-page__cta" v-bind="header.cta" />
       </template>
       <template #card>
-        <EventsItemCard v-bind="headerData.card" vertical-layout>
+        <EventsItemCard
+          v-bind="headerData.card"
+          :alt-text="header.card.alt"
+          vertical-layout
+        >
           {{ headerData.card.description }}
         </EventsItemCard>
       </template>

--- a/pages/events/summer-school-2023.vue
+++ b/pages/events/summer-school-2023.vue
@@ -33,7 +33,7 @@
       <template #card>
         <EventsItemCard
           v-bind="headerData.card"
-          :alt-text="header.card.alt"
+          :alt-text="header.card.altText"
           vertical-layout
         >
           {{ headerData.card.description }}

--- a/types/events.ts
+++ b/types/events.ts
@@ -44,6 +44,7 @@ type CommunityEvent = {
   // See also:
   // https://github.com/Qiskit/qiskit.org/issues/527
   location: string;
+  speaker: string;
   regions: WorldRegion[];
   date: string;
   startDate: string;

--- a/types/uiComponents.ts
+++ b/types/uiComponents.ts
@@ -5,7 +5,7 @@ type MosaicElement = {
   title: string;
   description: string;
   image: string;
-  alt: string;
+  altText: string;
   cta?: Link;
 };
 

--- a/types/uiComponents.ts
+++ b/types/uiComponents.ts
@@ -5,6 +5,7 @@ type MosaicElement = {
   title: string;
   description: string;
   image: string;
+  alt: string;
   cta?: Link;
 };
 


### PR DESCRIPTION
## Changes

Added alt descriptions to all images on the website. Some of them are dynamic, some are not. Following the guidelines in [W3C](https://www.w3.org/WAI/tutorials/images/) on Images, those icons or images that were only meant to be decorative, have been assigned the alt value "", `alt=""` .

This PR closes #3189 

## Implementation details with Screenshots

Alt descriptions where added to the following pages:

### **Homepage**

- Background image from header (_Drawing of two people working on a Quantum Computer_)
________________________
- Icons on the capabilities section (empty string)

<img width="364" alt="Screenshot 2023-05-30 at 16 59 14" src="https://github.com/Qiskit/qiskit.org/assets/108661074/b171f38e-7a25-4cee-8ca7-c5f670981218">

________________________
- image from the learn with qiskit section

<img width="1223" alt="Screenshot 2023-05-30 at 16 58 15" src="https://github.com/Qiskit/qiskit.org/assets/108661074/7e081c81-ab68-468e-ad6b-fd7483792ea6">

### **Events**

- Regular events: alt text includes the name of the event 
<img width="639" alt="Screenshot 2023-05-30 at 16 46 38" src="https://github.com/Qiskit/qiskit.org/assets/108661074/10988d50-1bb4-4bf5-98e3-a021820c84da">

________________________
- Seminars: alt text reads the name of the speaker + photo

<img width="638" alt="Screenshot 2023-05-30 at 16 57 01" src="https://github.com/Qiskit/qiskit.org/assets/108661074/1391106a-38dc-42c0-bd23-703d13ab87d4">


________________________
- No events found
<img width="642" alt="Screenshot 2023-05-30 at 16 44 55" src="https://github.com/Qiskit/qiskit.org/assets/108661074/0be68671-8c9b-42b4-95fa-ac565ab872ed">

### **Advocates**

- Photographs from advocates: alt text includes the name of the advocate
<img width="640" alt="Screenshot 2023-05-30 at 16 57 32" src="https://github.com/Qiskit/qiskit.org/assets/108661074/08f8cff5-d89a-4735-919b-06e465d2a7b7">

### **Summer school '23**

- Logo: alt text includes description of this year's logo _(summer School logo: Cnot gate next to a Haddamard gate.)_
<img width="471" alt="Screenshot 2023-05-31 at 13 12 31" src="https://github.com/Qiskit/qiskit.org/assets/108661074/607db60a-96ad-40e1-bc5b-dad6078de5c4">

### **Ecosystem and Providers**

These pages had no images.
