### PR TITLE
feat(ecosystem): move tiers to tabs and add search bar

### DIFF
--- a/pages/ecosystem.vue
+++ b/pages/ecosystem.vue
@@ -44,6 +44,11 @@
               {{ tierName }}
             </bx-tab>
           </bx-tabs>
+          <bx-search
+            class="ecosystem__search"
+            placeholder="Search using keywords like algorithms, simulator, or machine learning"
+            @bx-search-input="searchOnMembers($event.detail.value)"
+          />
           <div
             v-for="tierName in tiersNames"
             :id="`panel${tierName}`"
@@ -52,12 +57,6 @@
             role="tabpanel"
             :aria-labelledby="`tab${tierName}`"
           >
-            <bx-search
-              class="ecosystem__search"
-              placeholder="Search using keywords like algorithms, simulator, or machine learning"
-              @bx-search-input="searchOnMembers($event.detail.value)"
-            />
-
             <div class="cds--row ecosystem__members">
               <div
                 v-for="member in filteredMembers"
@@ -245,6 +244,7 @@ const joinAction: Link = {
   }
 
   &__search {
+    margin-top: carbon.$spacing-06;
     --cds-field-01: #{carbon.$cool-gray-10};
     --cds-field-04: #{carbon.$cool-gray-30};
   }

--- a/pages/ecosystem.vue
+++ b/pages/ecosystem.vue
@@ -52,69 +52,62 @@
             role="tabpanel"
             :aria-labelledby="`tab${tierName}`"
           >
-            <bx-data-table page-size="2" start="0">
-              <bx-table-toolbar role="section">
-                <bx-table-toolbar-content tabindex="">
-                  <bx-table-toolbar-search
-                    role="search"
-                    @bx-search-input="searchOnMembers($event.detail.value)"
-                  ></bx-table-toolbar-search>
-                </bx-table-toolbar-content>
-              </bx-table-toolbar>
+            <bx-search
+              class="ecosystem__search"
+              placeholder="Search using keywords like algorithms, simulator, or machine learning"
+              @bx-search-input="searchOnMembers($event.detail.value)"
+            />
 
-              <div class="cds--row ecosystem__members">
-                <div
-                  v-for="member in filteredMembers"
-                  :key="member.name"
-                  class="cds--col-sm-4 cds--col-xlg-8"
+            <div class="cds--row ecosystem__members">
+              <div
+                v-for="member in filteredMembers"
+                :key="member.name"
+                class="cds--col-sm-4 cds--col-xlg-8"
+              >
+                <UiCard
+                  class="project-card"
+                  :title="member.name"
+                  :tags="member.labels"
+                  :tooltip-tags="[
+                    {
+                      label: member.tier,
+                      description: getTierDescription(member.tier),
+                    },
+                  ]"
+                  cta-label="Go to repo"
+                  :segment="{
+                    cta: `go-to-repo-${member.name}`,
+                    location: 'ecosystem-card',
+                  }"
+                  :to="member.url"
                 >
-                  <UiCard
-                    class="project-card"
-                    :title="member.name"
-                    :tags="member.labels"
-                    :tooltip-tags="[
-                      {
-                        label: member.tier,
-                        description: getTierDescription(member.tier),
-                      },
-                    ]"
-                    cta-label="Go to repo"
-                    :segment="{
-                      cta: `go-to-repo-${member.name}`,
-                      location: 'ecosystem-card',
-                    }"
-                    :to="member.url"
-                  >
-                    <div class="cds--row">
-                      <p class="project-card__license">
-                        {{ member.licence }}
-                      </p>
-                      <div class="project-card__star">
-                        <StarFilled16 />
-                        <p class="project-card__star-val">
-                          {{ member.stars }}
-                        </p>
-                      </div>
-                    </div>
-                    <p>
-                      {{ member.description }}
+                  <div class="cds--row">
+                    <p class="project-card__license">
+                      {{ member.licence }}
                     </p>
-                  </UiCard>
-                  <bx-accordion v-if="member.testsResults.length != 0">
-                    <bx-accordion-item
-                      class="bx-accordion__item"
-                      :title-text="`Test Results (${formatTimestamp(
-                        member.updatedAt
-                      )})`"
-                    >
-                      <EcosystemTestTable
-                        :filtered-data="getTestRows(member)"
-                      />
-                    </bx-accordion-item>
-                  </bx-accordion>
-                </div>
+                    <div class="project-card__star">
+                      <StarFilled16 />
+                      <p class="project-card__star-val">
+                        {{ member.stars }}
+                      </p>
+                    </div>
+                  </div>
+                  <p>
+                    {{ member.description }}
+                  </p>
+                </UiCard>
+                <bx-accordion v-if="member.testsResults.length != 0">
+                  <bx-accordion-item
+                    class="bx-accordion__item"
+                    :title-text="`Test Results (${formatTimestamp(
+                      member.updatedAt
+                    )})`"
+                  >
+                    <EcosystemTestTable :filtered-data="getTestRows(member)" />
+                  </bx-accordion-item>
+                </bx-accordion>
               </div>
-            </bx-data-table>
+            </div>
           </div>
         </client-only>
       </div>
@@ -249,6 +242,11 @@ const joinAction: Link = {
 
   &__tier-panel {
     margin-top: carbon.$spacing-07;
+  }
+
+  &__search {
+    --cds-field-01: #{carbon.$cool-gray-10};
+    --cds-field-04: #{carbon.$cool-gray-30};
   }
 
   &__members {

--- a/pages/ecosystem.vue
+++ b/pages/ecosystem.vue
@@ -65,7 +65,7 @@
               <div class="cds--row ecosystem__members">
                 <div
                   v-for="member in filteredMembers"
-                  :key="member.title"
+                  :key="member.name"
                   class="cds--col-sm-4 cds--col-xlg-8"
                 >
                   <UiCard
@@ -131,6 +131,10 @@ import rawMembers from "~/content/ecosystem/members.json";
 import rawTiers from "~/content/ecosystem/tiers.json";
 import type { Member, Tier } from "~/types/ecosystem";
 
+interface MembersByTier {
+  [key: string]: Member[];
+}
+
 const members = rawMembers as Member[];
 const tiers = rawTiers as Tier[];
 
@@ -156,6 +160,10 @@ const searchedText = ref<string>("");
 
 const tiersNames = tiers.map((tier) => tier.name);
 
+const membersByTier: MembersByTier = tiersNames.reduce((acc, tierName) => {
+  return { ...acc, ...{ [tierName]: getMembersByTier(tierName) } };
+}, {});
+
 const selectTab = (tab: string) => {
   selectedTab.value = tab;
 };
@@ -169,16 +177,14 @@ const filteredMembers = computed(() => {
 
   return searchedText.value === ""
     ? filteredMembersByTier
-    : filteredMembersByTier.filter((member) =>
-        member.description
-          .toLowerCase()
-          .includes(searchedText.value.toLowerCase())
+    : filteredMembersByTier.filter(
+        (member) =>
+          member.description
+            .toLowerCase()
+            .includes(searchedText.value.toLowerCase()) ||
+          member.name.toLowerCase().includes(searchedText.value.toLowerCase())
       );
 });
-
-const membersByTier = tiersNames.reduce((acc, tierName) => {
-  return { ...acc, ...{ [tierName]: getMembersByTier(tierName) } };
-}, {});
 
 function getMembersByTier(tier: Member["tier"]) {
   return members.filter((member) => member.tier === tier);

--- a/pages/ecosystem.vue
+++ b/pages/ecosystem.vue
@@ -27,85 +27,80 @@
         :label="joinAction.label"
         :url="joinAction.url"
       />
-      <UiFiltersResultsLayout class="ecosystem__filters-result-section">
-        <template #filters-on-m-l-screen>
-          <UiFieldset label="Tier">
-            <client-only>
-              <bx-checkbox
-                v-for="option in tiers"
-                :key="option.name"
-                class="ecosystem__filters-result-section__tiers"
-                :checked="isTierFilterChecked(option.name)"
-                :label-text="option.name"
-                :value="option.name"
-                @bx-checkbox-changed="
-                  updateTierFilter(option.name, $event.target.checked)
-                "
-              />
-            </client-only>
-          </UiFieldset>
-        </template>
-        <template #filters-on-s-screen>
-          <UiMultiSelect
-            label="Tier"
-            :options="tiersNames"
-            :value="tierFiltersAsString"
-            @change-selection="updateTierFilters($event)"
-          />
-        </template>
-        <template #results>
-          <div class="cds--row">
-            <div
-              v-for="(member, index) in filteredMembers"
-              :key="index"
-              class="cds--col-sm-4 cds--col-xlg-8"
+      <div class="ecosystem__tiers">
+        <client-only>
+          <bx-tabs trigger-content="Select an item" value="Main">
+            <bx-tab
+              v-for="tierName in tiersNames"
+              :id="`tab${tierName}`"
+              :key="tierName"
+              :target="`panel${tierName}`"
+              :value="`${tierName}`"
             >
-              <UiCard
-                class="project-card"
-                :title="member.name"
-                :tags="member.labels"
-                :tooltip-tags="[
-                  {
-                    label: member.tier,
-                    description: getTierDescription(member.tier),
-                  },
-                ]"
-                cta-label="Go to repo"
-                :segment="{
-                  cta: `go-to-repo-${member.name}`,
-                  location: 'ecosystem-card',
-                }"
-                :to="member.url"
+              {{ tierName }}
+            </bx-tab>
+          </bx-tabs>
+          <div
+            v-for="tierName in tiersNames"
+            :id="`panel${tierName}`"
+            :key="tierName"
+            class="ecosystem__tier-panel"
+            role="tabpanel"
+            :aria-labelledby="`tab${tierName}`"
+          >
+            <div class="cds--row">
+              <div
+                v-for="(member, index) in getMembersByTier(tierName)"
+                :key="index"
+                class="cds--col-sm-4 cds--col-xlg-8"
               >
-                <div class="cds--row">
-                  <p class="project-card__license">
-                    {{ member.licence }}
-                  </p>
-                  <div class="project-card__star">
-                    <StarFilled16 />
-                    <p class="project-card__star-val">
-                      {{ member.stars }}
-                    </p>
-                  </div>
-                </div>
-                <p>
-                  {{ member.description }}
-                </p>
-              </UiCard>
-              <bx-accordion v-if="member.testsResults.length != 0">
-                <bx-accordion-item
-                  class="bx-accordion__item"
-                  :title-text="`Test Results (${formatTimestamp(
-                    member.updatedAt
-                  )})`"
+                <UiCard
+                  class="project-card"
+                  :title="member.name"
+                  :tags="member.labels"
+                  :tooltip-tags="[
+                    {
+                      label: member.tier,
+                      description: getTierDescription(member.tier),
+                    },
+                  ]"
+                  cta-label="Go to repo"
+                  :segment="{
+                    cta: `go-to-repo-${member.name}`,
+                    location: 'ecosystem-card',
+                  }"
+                  :to="member.url"
                 >
-                  <EcosystemTestTable :filtered-data="getTestRows(member)" />
-                </bx-accordion-item>
-              </bx-accordion>
+                  <div class="cds--row">
+                    <p class="project-card__license">
+                      {{ member.licence }}
+                    </p>
+                    <div class="project-card__star">
+                      <StarFilled16 />
+                      <p class="project-card__star-val">
+                        {{ member.stars }}
+                      </p>
+                    </div>
+                  </div>
+                  <p>
+                    {{ member.description }}
+                  </p>
+                </UiCard>
+                <bx-accordion v-if="member.testsResults.length != 0">
+                  <bx-accordion-item
+                    class="bx-accordion__item"
+                    :title-text="`Test Results (${formatTimestamp(
+                      member.updatedAt
+                    )})`"
+                  >
+                    <EcosystemTestTable :filtered-data="getTestRows(member)" />
+                  </bx-accordion-item>
+                </bx-accordion>
+              </div>
             </div>
           </div>
-        </template>
-      </UiFiltersResultsLayout>
+        </client-only>
+      </div>
     </section>
   </main>
 </template>
@@ -141,8 +136,6 @@ useHead({
 
 const tierFilters = ref<string[]>([]);
 
-const tierFiltersAsString = computed(() => tierFilters.value.join(","));
-
 const filteredMembers = computed(() => {
   if (!members) {
     return [];
@@ -154,6 +147,10 @@ const filteredMembers = computed(() => {
     ? members
     : members.filter((member) => tierFilters.value.includes(member.tier));
 });
+
+function getMembersByTier(tier: Member["tier"]) {
+  return members.filter((member) => member.tier === tier);
+}
 
 const tiersNames = computed(() => tiers.map((tier) => tier.name));
 
@@ -222,8 +219,14 @@ const joinAction: Link = {
 <style lang="scss" scoped>
 @use "~/assets/scss/carbon.scss";
 
-.ecosystem__filters-result-section {
-  margin-top: carbon.$spacing-10;
+.ecosystem {
+  &__tiers {
+    margin-top: carbon.$spacing-10;
+  }
+
+  &__tier-panel {
+    margin-top: carbon.$spacing-07;
+  }
 }
 
 .cds--col-sm-4 {

--- a/pages/ecosystem.vue
+++ b/pages/ecosystem.vue
@@ -165,7 +165,7 @@ const filteredMembers = computed(() => {
     return [];
   }
 
-  const filteredMembersByTier = membersByTier[selectedTab.value]
+  const filteredMembersByTier = membersByTier[selectedTab.value];
 
   return searchedText.value === ""
     ? filteredMembersByTier
@@ -173,7 +173,7 @@ const filteredMembers = computed(() => {
         member.description
           .toLowerCase()
           .includes(searchedText.value.toLowerCase())
-  );
+      );
 });
 
 const membersByTier = tiersNames.reduce((acc, tierName) => {

--- a/pages/ecosystem.vue
+++ b/pages/ecosystem.vue
@@ -245,6 +245,7 @@ const joinAction: Link = {
 
   &__search {
     margin-top: carbon.$spacing-06;
+
     --cds-field-01: #{carbon.$cool-gray-10};
     --cds-field-04: #{carbon.$cool-gray-30};
   }


### PR DESCRIPTION
## Changes

Fix https://github.com/Qiskit/qiskit.org/issues/3273
Fix https://github.com/Qiskit/qiskit.org/issues/2927

## Implementation details

- Now the tiers are on tabs
- A search bar is added. Right now is only searching on the card description

## How to read this PR

Go to https://qiskit-org-pr-3278.dcq4xc5i083.us-south.codeengine.appdomain.cloud/ecosystem

- Tiers tabs should work
- Each tab only shows the members that are on that tier
- Search works both for searching on the description and on the title

**Out of scope**
- A solution when there are no results on the search

## Screenshots

<img width="1200" alt="Captura de pantalla 2023-05-31 a las 15 28 32" src="https://github.com/Qiskit/qiskit.org/assets/17231966/5998ab89-743f-4ff0-9749-22bbcb2995d5">

