### PR TITLE
Fixed spelling on Massachusets

### DIFF
--- a/components/Learn/LearnStartLearningSection.vue
+++ b/components/Learn/LearnStartLearningSection.vue
@@ -524,7 +524,7 @@ const teachingSections: TeachingSection[] = [
       {
         title: "Introduction to Quantum Algorithms",
         instructor: "Peter Shor",
-        university: "Masachussetts Institute of Technology",
+        university: "Massachusetts Institute of Technology",
         cta: {
           label: "Go to this course",
           url: "https://learn.qiskit.org/syllabus/CFH-KBT",


### PR DESCRIPTION
## Changes
Fixes [#3302](https://github.com/Qiskit/qiskit.org/issues/3302) Corrected the spelling for Massachusets in the Learn Page.

## Implementation details
Simply corrected the word in the LearnStartLearningSection.vue file.

## Screenshots
<img width="1016" alt="Screenshot 2023-06-08 at 11 46 38" src="https://github.com/Qiskit/qiskit.org/assets/89911196/784664f0-cbb7-434a-8bd6-ba1377ddfdbb">
