### PR TITLE
format typewritter effect headings

### DIFF
--- a/components/Ui/UiPageHeaderFixed.vue
+++ b/components/Ui/UiPageHeaderFixed.vue
@@ -1,5 +1,5 @@
 <template>
-  <header class="page-header-fixed" id="test-id">
+  <header class="page-header-fixed">
     <div class="cds--grid page-header-fixed__container">
       <div class="cds--row">
         <h1 class="cds--col-sm cds--col-md-7 cds--col-lg-10 cds--col-max-10">

--- a/components/Ui/UiPageHeaderFixed.vue
+++ b/components/Ui/UiPageHeaderFixed.vue
@@ -1,8 +1,8 @@
 <template>
-  <header class="page-header-fixed">
+  <header class="page-header-fixed" id="test-id">
     <div class="cds--grid page-header-fixed__container">
       <div class="cds--row">
-        <h1 class="cds--col-sm cds--col-md-6 cds--col-lg-10 cds--col-max-8">
+        <h1 class="cds--col-sm cds--col-md-7 cds--col-lg-10 cds--col-max-10">
           <slot />
         </h1>
       </div>
@@ -15,11 +15,9 @@
 @use "~/assets/scss/helpers/index.scss" as qiskit;
 
 .page-header-fixed {
-  @include qiskit.responsive-grid-bg-strip(
-    "/images/grid/grid-hero-learn.svg",
+  @include qiskit.responsive-grid-bg-strip("/images/grid/grid-hero-learn.svg",
     auto,
-    28rem
-  );
+    28rem);
 
   align-items: center;
   display: flex;

--- a/pages/advocates.vue
+++ b/pages/advocates.vue
@@ -4,9 +4,8 @@
       Connect with the<br />
       <UiTypewriterEffect
         :values="['enthusiasts', 'advocates', 'mentors', 'experts']"
-      />
-      from within<br />
-      the Qiskit community
+      /><br />
+      within the Qiskit community
     </UiPageHeaderFixed>
     <AdvocatesJoinSection />
     <AdvocatesMeetTheAdvocates />

--- a/pages/ecosystem.vue
+++ b/pages/ecosystem.vue
@@ -1,14 +1,12 @@
 <template>
   <main>
     <UiPageHeaderFixed class="ecosystem-header__hero">
-      <br />
-      Explore
+      Explore<br/>
       <UiTypewriterEffect
         :values="['core packages', 'tools', 'prototypes', 'community projects']"
       />
-      from Qiskit
-      <br />
-      and the Qiskit community
+      <br/>
+      from Qiskit and the Qiskit community
     </UiPageHeaderFixed>
     <section id="ecosystem" class="cds--grid ecosystem">
       <h2>Ecosystem Resources</h2>

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -3,8 +3,8 @@
     <UiPageHeaderFixed>
       Join
       <UiTypewriterEffect
-      :values="['unconferences']"
-      /><br/>
+        :values="['events', 'hackathons', 'camps', 'unconferences', 'talks']"
+      />
       from the world&rsquo;s largest quantum computing community
     </UiPageHeaderFixed>
     <div class="cds--grid">

--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -3,8 +3,8 @@
     <UiPageHeaderFixed>
       Join
       <UiTypewriterEffect
-        :values="['events', 'hackathons', 'camps', 'unconferences', 'talks']"
-      />
+      :values="['unconferences']"
+      /><br/>
       from the world&rsquo;s largest quantum computing community
     </UiPageHeaderFixed>
     <div class="cds--grid">

--- a/pages/providers.vue
+++ b/pages/providers.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="providers-page">
     <UiPageHeaderFixed>
-      Run Qiskit compiled circuits on
-      <UiTypewriterEffect :values="['real hardware', 'simulators']" />
+      Run Qiskit compiled <br />circuits on
+      <br /><UiTypewriterEffect :values="['real hardware', 'simulators']" />
     </UiPageHeaderFixed>
     <section id="contentContainer" class="cds--grid page-section">
       <div class="cds--row">


### PR DESCRIPTION
## Changes

Fixes #1104 content jump issue for typewritter effect.

## Diagnostic

The typewriter effect causes the text to change the number of lines it occupies. When the text after the change occupies a number of lines that allows it to continue to be seen, it remains centered in the header correctly.

When it occupies such a number of lines that it would no longer be seen, the browser forces the content to continue to be seen which causes a vertical displacement of the entire content. (The video below shows how the content is displaced).

## Implementation details

To fix the error, line breaks have been set in the header text so that it does not cause new lines at any resolution.

## How to read this PR

Check the following pages with multiple resolutions:

- Ecosystem
- Events
- Providers
- Advocates

If you scroll at the middle of the heading, the content below it should not move when the typewritter effect starts.

## Screenshots

https://github.com/Qiskit/qiskit.org/assets/7396204/32efa257-beaf-4776-9cd8-fa7f486b4845

