### PR TITLE
fix(footer): increase tap targets space

### DIFF
--- a/components/Footer/FooterSection.vue
+++ b/components/Footer/FooterSection.vue
@@ -63,7 +63,7 @@ withDefaults(defineProps<Props>(), {
     text-decoration: none;
     display: inline-block;
     width: 100%;
-    padding-bottom: carbon.$spacing-03;
+    margin-bottom: carbon.$spacing-04;
 
     &_theme_light {
       color: qiskit.$text-color-lighter;


### PR DESCRIPTION
## Changes

<!--
  Required.

  Briefly describe the changes introduced by this pull request.
  Also link relevant issues with the "closes", "fixes" or "resolves" keywords,
  and add co-authors where appropriate with the "co-authored-by" keyword.

  Example:
  Implemented the functionality to update the user's name.
  Closes #42
  Co-authored-by: @octocat
-->

This PR increases the space between the text links in the footer in order to have safe tab targets.

Closes #3198

## Implementation details

<!--
  Optional.

  If useful for the code review, describe implementation details and, if
  necessary, why a certain approach was chosen.

  Example:
  Changes are introduced to the controller and the database model. UI changes
  are not in the scope of this PR.
-->

We conducted a Lighthouse report in https://pagespeed.web.dev/ and it flag some tab targets (the footer links) which were not sized properly:

![image](https://github.com/Qiskit/qiskit.org/assets/22047320/d1260b66-5411-486f-8a84-8683bd13c5e8)

As pointed out in https://developer.chrome.com/docs/lighthouse/seo/tap-targets/, the tab targets should be at least 48x48 in size or have enough spacing between each other.

This PR changes the padding for margin to avoid increasing the vertical size of the tab target and increasing the space to the next footer link, and also increases the margin from 8px to 12px.

A Lighthouse audit conducted locally in the Chrome dev tools didn't flag the tab targets after the change.

## Screenshots

<!--
  Optional.

  If relevant (e.g. UI changes are introduced), add screenshots or videos
  depicting the changes. Ideally, showing the before and after situations.
-->

Before:

![image](https://github.com/Qiskit/qiskit.org/assets/22047320/ef69f12a-9ac1-43dc-be3a-4867b6b49d25)

After:

![image](https://github.com/Qiskit/qiskit.org/assets/22047320/05e79e82-ad34-420a-b89b-271b74d923a7)