### PR TITLE
[ecosystem]: add results count to tab and relocate description

### DIFF
--- a/components/Ecosystem/EcosystemItemCard.vue
+++ b/components/Ecosystem/EcosystemItemCard.vue
@@ -4,10 +4,9 @@
       class="ecosystem-item-card"
       :title="member.name"
       :tags="member.labels"
-      :tooltip-tags="[
+      :primary-tags="[
         {
           label: member.tier,
-          description: tierDescription,
         },
       ]"
       cta-label="Go to repo"

--- a/components/Ecosystem/EcosystemItemCard.vue
+++ b/components/Ecosystem/EcosystemItemCard.vue
@@ -42,7 +42,6 @@ import { Member } from "~/types/ecosystem";
 
 interface Props {
   member: Member;
-  tierDescription: string;
 }
 
 const props = defineProps<Props>();

--- a/components/Ecosystem/EcosystemItemCard.vue
+++ b/components/Ecosystem/EcosystemItemCard.vue
@@ -4,11 +4,7 @@
       class="ecosystem-item-card"
       :title="member.name"
       :tags="member.labels"
-      :primary-tags="[
-        {
-          label: member.tier,
-        },
-      ]"
+      :primary-tag="member.tier"
       cta-label="Go to repo"
       :segment="{
         cta: `go-to-repo-${member.name}`,

--- a/components/Ui/UiCard.vue
+++ b/components/Ui/UiCard.vue
@@ -44,7 +44,7 @@
               {{ tag }}
             </bx-tag>
           </div>
-          <bx-tag class="card__tag" type="purple">
+          <bx-tag v-if="primaryTag" class="card__tag" type="purple">
             {{ primaryTag }}
           </bx-tag>
         </div>

--- a/components/Ui/UiCard.vue
+++ b/components/Ui/UiCard.vue
@@ -129,7 +129,7 @@ const ctaLink = computed(() => ({
 }));
 
 // TODO: Refactor to do a cleaner check for "tags" and "tooltip tags" (https://github.com/Qiskit/qiskit.org/pull/2935#discussion_r1088770246)
-function hasTags(tags: string[] | PrimaryTag[]) {
+function hasTags(tags: string[]) {
   return Array.isArray(tags) && tags.length > 0;
 }
 </script>

--- a/components/Ui/UiCard.vue
+++ b/components/Ui/UiCard.vue
@@ -44,15 +44,9 @@
               {{ tag }}
             </bx-tag>
           </div>
-          <div v-if="hasTags(primaryTags)" class="card__tags">
-            <div
-              v-for="tag in primaryTags"
-              :key="tag.label"
-              class="card__custom-pill"
-            >
-              {{ tag.label }}
-            </div>
-          </div>
+          <bx-tag class="card__tag" type="purple">
+            {{ primaryTag }}
+          </bx-tag>
         </div>
       </header>
       <div class="card__body">
@@ -85,11 +79,6 @@
 <script setup lang="ts">
 import { Link } from "~/types/links";
 import { CtaClickedEventProp } from "~/types/segment";
-
-export interface PrimaryTag {
-  // the short string label for inside the tag
-  label: string;
-}
 
 interface Props {
   descriptionWholeSize?: boolean;
@@ -212,6 +201,10 @@ function hasTags(tags: string[]) {
     white-space: nowrap;
   }
 
+  &__tags {
+    margin-right: carbon.$spacing-03;
+  }
+
   &__title {
     flex: 1;
     margin-bottom: carbon.$spacing-02;
@@ -273,37 +266,6 @@ bx-tag {
   min-width: 0;
 
   &:last-child {
-    margin-right: 0;
-  }
-}
-</style>
-
-<style lang="scss">
-@use "~/assets/scss/carbon.scss";
-@use "~/assets/scss/helpers/index.scss" as qiskit;
-
-.card {
-  &__custom-pill {
-    @include carbon.type-style("label-01");
-
-    background-color: qiskit.$tag-background-color;
-    color: qiskit.$tag-text-color;
-    display: inline-flex;
-    min-width: 0;
-    max-width: 100%;
-    min-height: 1.5rem;
-    align-items: center;
-    justify-content: center;
-    padding: carbon.$spacing-02 carbon.$spacing-03;
-    margin: carbon.$spacing-02 carbon.$spacing-03 carbon.$spacing-02
-      carbon.$spacing-03;
-    border-radius: 6.9375rem;
-    cursor: default;
-    vertical-align: middle;
-    word-break: break-word;
-  }
-
-  &__custom-pill:last-child {
     margin-right: 0;
   }
 }

--- a/components/Ui/UiCard.vue
+++ b/components/Ui/UiCard.vue
@@ -166,6 +166,10 @@ function hasTags(tags: string[]) {
     }
   }
 
+  &__body {
+    overflow-wrap: break-word;
+  }
+
   &__content {
     padding: carbon.$spacing-05 carbon.$spacing-07;
     flex: 1;

--- a/components/Ui/UiCard.vue
+++ b/components/Ui/UiCard.vue
@@ -118,7 +118,7 @@ const props = withDefaults(defineProps<Props>(), {
   tags: () => [],
   to: "",
   secondaryCta: undefined,
-  primaryTags: () => [],
+  primaryTag: undefined,
   verticalLayout: false,
 });
 

--- a/components/Ui/UiCard.vue
+++ b/components/Ui/UiCard.vue
@@ -44,16 +44,13 @@
               {{ tag }}
             </bx-tag>
           </div>
-          <div v-if="hasTags(tooltipTags)" class="card__tags">
+          <div v-if="hasTags(primaryTags)" class="card__tags">
             <div
-              v-for="tag in tooltipTags"
+              v-for="tag in primaryTags"
               :key="tag.label"
               class="card__custom-pill"
             >
               {{ tag.label }}
-              <bx-tooltip-icon :body-text="tag.description" direction="bottom">
-                <Information16 class="card__tooltip__icon" />
-              </bx-tooltip-icon>
             </div>
           </div>
         </div>
@@ -86,17 +83,12 @@
 </template>
 
 <script setup lang="ts">
-// import "@carbon/web-components/es/components/tag/tag.js";
-// import "@carbon/web-components/es/components/tooltip/tooltip-icon.js";
-import Information16 from "@carbon/icons-vue/lib/information/16";
 import { Link } from "~/types/links";
 import { CtaClickedEventProp } from "~/types/segment";
 
-export interface TagTooltip {
+export interface PrimaryTag {
   // the short string label for inside the tag
   label: string;
-  // the description for the tooltip
-  description: string;
 }
 
 interface Props {
@@ -111,7 +103,7 @@ interface Props {
   title: string;
   to?: string;
   secondaryCta?: Link | null;
-  tooltipTags?: TagTooltip[];
+  primaryTags?: PrimaryTag[];
   verticalLayout?: boolean;
 }
 
@@ -126,7 +118,7 @@ const props = withDefaults(defineProps<Props>(), {
   tags: () => [],
   to: "",
   secondaryCta: undefined,
-  tooltipTags: () => [],
+  primaryTags: () => [],
   verticalLayout: false,
 });
 
@@ -137,7 +129,7 @@ const ctaLink = computed(() => ({
 }));
 
 // TODO: Refactor to do a cleaner check for "tags" and "tooltip tags" (https://github.com/Qiskit/qiskit.org/pull/2935#discussion_r1088770246)
-function hasTags(tags: string[] | TagTooltip[]) {
+function hasTags(tags: string[] | PrimaryTag[]) {
   return Array.isArray(tags) && tags.length > 0;
 }
 </script>
@@ -224,13 +216,6 @@ function hasTags(tags: string[] | TagTooltip[]) {
     flex: 1;
     margin-bottom: carbon.$spacing-02;
   }
-
-  &__tooltip {
-    &__icon {
-      fill: carbon.$white;
-      margin-left: carbon.$spacing-02;
-    }
-  }
 }
 
 .card_vertical {
@@ -290,12 +275,6 @@ bx-tag {
   &:last-child {
     margin-right: 0;
   }
-}
-
-bx-tooltip-icon {
-  --cds-inverse-02: #{carbon.$cool-gray-90};
-
-  line-height: 0;
 }
 </style>
 

--- a/components/Ui/UiCard.vue
+++ b/components/Ui/UiCard.vue
@@ -103,7 +103,7 @@ interface Props {
   title: string;
   to?: string;
   secondaryCta?: Link | null;
-  primaryTags?: PrimaryTag[];
+  primaryTag?: string;
   verticalLayout?: boolean;
 }
 

--- a/pages/ecosystem.vue
+++ b/pages/ecosystem.vue
@@ -40,7 +40,7 @@
               :target="`panel${tierName}`"
               :value="`${tierName}`"
             >
-              {{ `${tierName} (${getFilteredResultsCount(tierName)})` }}
+              {{ `${tierName} (${getFilteredMembers(tierName).length})` }}
             </bx-tab>
           </bx-tabs>
           <div class="ecosystem__tiers__description">
@@ -102,11 +102,11 @@
               :aria-labelledby="`tab${tierName}`"
             >
               <div
-                v-if="filteredMembers.length > 0"
+                v-if="getFilteredMembers(tierName).length > 0"
                 class="cds--row ecosystem__members"
               >
                 <EcosystemItemCard
-                  v-for="member in sortMembers(filteredMembers)"
+                  v-for="member in sortMembers(getFilteredMembers(tierName))"
                   :key="member.name"
                   class="cds--col-sm-4 cds--col-xlg-8"
                   :member="member"
@@ -186,17 +186,14 @@ const selectedTierDescription = computed(() => {
   return tier?.description || "";
 });
 
-const filteredMembers = computed(() => {
+function getFilteredMembers(tierName: string) {
   if (!members) {
     return [];
   }
 
-  const filteredMembersByTier = membersByTier[selectedTab.value];
-  return filterMembers(filteredMembersByTier);
-});
+  const filteredMembersByTier = membersByTier[tierName];
 
-function filterMembers(membersToFilter: Member[]): Member[] {
-  let result = membersToFilter;
+  let result = filteredMembersByTier;
 
   if (searchedText.value !== "") {
     result = result.filter((member) =>
@@ -261,12 +258,6 @@ function sortMembers(membersToSort: Member[]) {
   return propToSortBy.value === "stars"
     ? reverse(membersOnAscOrder)
     : membersOnAscOrder;
-}
-
-function getFilteredResultsCount(tierName: string): number {
-  const filteredMembersByTier = membersByTier[tierName];
-  const filteredMembersCount = filterMembers(filteredMembersByTier).length;
-  return filteredMembersCount;
 }
 </script>
 

--- a/pages/ecosystem.vue
+++ b/pages/ecosystem.vue
@@ -40,7 +40,7 @@
               :target="`panel${tierName}`"
               :value="`${tierName}`"
             >
-              {{ tierName }}
+              {{ tierName }} ({{ getFilteredResultsCount(tierName) }})
             </bx-tab>
           </bx-tabs>
         </client-only>
@@ -184,8 +184,11 @@ const filteredMembers = computed(() => {
   }
 
   const filteredMembersByTier = membersByTier[selectedTab.value];
+  return filterMembers(filteredMembersByTier);
+});
 
-  let result = filteredMembersByTier;
+function filterMembers(membersToFilter: Member[]): Member[] {
+  let result = membersToFilter;
 
   if (searchedText.value !== "") {
     result = result.filter((member) =>
@@ -202,7 +205,7 @@ const filteredMembers = computed(() => {
   }
 
   return result;
-});
+}
 
 function selectTab(tab: string) {
   selectedTab.value = tab;
@@ -250,6 +253,12 @@ function sortMembers(membersToSort: Member[]) {
   return propToSortBy.value === "stars"
     ? reverse(membersOnAscOrder)
     : membersOnAscOrder;
+}
+
+function getFilteredResultsCount(tierName: string): number {
+  const filteredMembersByTier = membersByTier[tierName];
+  const filteredMembersCount = filterMembers(filteredMembersByTier).length;
+  return filteredMembersCount;
 }
 </script>
 

--- a/pages/ecosystem.vue
+++ b/pages/ecosystem.vue
@@ -44,7 +44,7 @@
             </bx-tab>
           </bx-tabs>
           <div class="ecosystem__tiers__description">
-            {{ selectedTierDescription }}
+            {{ getSelectedTierDescription() }}
           </div>
         </client-only>
       </div>
@@ -110,7 +110,6 @@
                   :key="member.name"
                   class="cds--col-sm-4 cds--col-xlg-8"
                   :member="member"
-                  :tier-description="getTierDescription(member.tier)"
                 />
               </div>
               <p v-else class="cds--col">
@@ -181,10 +180,10 @@ const membersByTier: MembersByTier = tiersNames.reduce((acc, tierName) => {
 
 const categoryFiltersAsString = computed(() => categoryFilters.value.join(","));
 
-const selectedTierDescription = computed(() => {
+function getSelectedTierDescription() {
   const tier = tiers.find((tier) => tier.name === selectedTab.value);
   return tier?.description || "";
-});
+}
 
 function getFilteredMembers(tierName: string) {
   if (!members) {
@@ -214,11 +213,6 @@ function getFilteredMembers(tierName: string) {
 
 function selectTab(tab: string) {
   selectedTab.value = tab;
-}
-
-function getTierDescription(tierName: string): string {
-  const tier = tiers.find((tier: any) => tier.name === tierName);
-  return tier?.description || "";
 }
 
 function setSortValue(inputValue: string) {

--- a/pages/ecosystem.vue
+++ b/pages/ecosystem.vue
@@ -40,7 +40,7 @@
               :target="`panel${tierName}`"
               :value="`${tierName}`"
             >
-              {{ tierName }} ({{ getFilteredResultsCount(tierName) }})
+              {{ `${tierName} (${getFilteredResultsCount(tierName)})` }}
             </bx-tab>
           </bx-tabs>
           <div class="cds--row">

--- a/pages/ecosystem.vue
+++ b/pages/ecosystem.vue
@@ -43,12 +43,8 @@
               {{ `${tierName} (${getFilteredResultsCount(tierName)})` }}
             </bx-tab>
           </bx-tabs>
-          <div class="cds--row">
-            <div class="cds--col">
-              <div class="ecosystem__tiers__description">
-                {{ selectedTierDescription }}
-              </div>
-            </div>
+          <div class="ecosystem__tiers__description">
+            {{ selectedTierDescription }}
           </div>
         </client-only>
       </div>

--- a/pages/ecosystem.vue
+++ b/pages/ecosystem.vue
@@ -43,6 +43,13 @@
               {{ tierName }} ({{ getFilteredResultsCount(tierName) }})
             </bx-tab>
           </bx-tabs>
+          <div class="cds--row">
+            <div class="cds--col">
+              <div class="ecosystem__tiers__description">
+                {{ selectedTierDescription }}
+              </div>
+            </div>
+          </div>
         </client-only>
       </div>
       <UiFiltersResultsLayout>
@@ -178,6 +185,11 @@ const membersByTier: MembersByTier = tiersNames.reduce((acc, tierName) => {
 
 const categoryFiltersAsString = computed(() => categoryFilters.value.join(","));
 
+const selectedTierDescription = computed(() => {
+  const tier = tiers.find((tier) => tier.name === selectedTab.value);
+  return tier?.description || "";
+});
+
 const filteredMembers = computed(() => {
   if (!members) {
     return [];
@@ -268,6 +280,10 @@ function getFilteredResultsCount(tierName: string): number {
 .ecosystem {
   &__tiers {
     margin-top: carbon.$spacing-10;
+
+    &__description {
+      padding-top: carbon.$spacing-05;
+    }
   }
 
   &__tier-panel {


### PR DESCRIPTION
## Changes

Closes https://github.com/Qiskit/qiskit.org/issues/3323
Fixes https://github.com/Qiskit/qiskit.org/issues/3120

## Preview 
https://qiskit-org-pr-3322.dcq4xc5i083.us-south.codeengine.appdomain.cloud/ecosystem

## Implementation details

- adds filtered results count to each tab
  - abstracted repeated code in `filteredMembers` and `getFilteredResultsCount`, into `filterMembers` function
- removed the notion of tooltip tags, from card tags
  - instead, using `primaryTag`

## Screenshots
- showing dynamic filtered resuls count in each tab
- showing the relocation of the tier description (to beneath the tab)
- showing fixed gutter / responsive issue, caused by Tooltip Tag

https://github.com/Qiskit/qiskit.org/assets/6276074/8d0b1aea-592b-4839-85d0-ab80ea686e70



