### PR TITLE
feat(error-page): fix broken images

### DIFF
--- a/error.vue
+++ b/error.vue
@@ -25,10 +25,8 @@
             />
           </div>
           <div class="cds--col-lg-8">
-            <nuxt-img
+            <img
               class="error-page__img"
-              format="webp"
-              sizes="sm:300px md:650px lg:500px xl:750px"
               :src="errorImgSrc"
               alt="Playful illustration of a cat in a cardboard box"
             />


### PR DESCRIPTION
## Changes

Fixes #3331 

## Preview
https://qiskit-org-pr-3332.dcq4xc5i083.us-south.codeengine.appdomain.cloud/test

## What I tried
For some reason, when using `<nuxt-img>` and `npm run generate`, we're not having cat images generate in the optimized folders. I tried the following:

- testing a static image (not a dynamically created image), for example `cat1.png`
- upgrading the dependency and testing
- specifying "ipx" as the `provider` in nuxt.config
- disabling all nuxt-img instances, and leaving the `error.vue` instance, to see if it would render

In all these cases, the dynamically generated `cat<number>.png` image doesn't get transformed into the `.output/public/images/*` directories... 

(I _think_ it could be because the error.vue page isn't within the `/pages`? directory)


## Implementation details

This PR will revert to using a normal `<img>` tag until we can figure out what's happening with https://github.com/Qiskit/qiskit.org/issues/3226

