### PR TITLE
Hyphenate open-source when used as adjective

### DIFF
--- a/components/Landing/HeroMoment/LandingHeroMomentComponent.vue
+++ b/components/Landing/HeroMoment/LandingHeroMomentComponent.vue
@@ -10,7 +10,7 @@
           <h1
             class="cds--col-md-3 cds--col-lg-5 cds--col-xlg-6 cds--col-max-7 hero-moment__title"
           >
-            Your open source toolkit for useful quantum computing
+            Your open-source toolkit for useful quantum computing
           </h1>
         </div>
         <div class="cds--row">

--- a/components/Metal/MetalBuildingSection.vue
+++ b/components/Metal/MetalBuildingSection.vue
@@ -44,7 +44,7 @@
               >Introduction to Quantum Computing and Quantum Hardware</UiLink
             >
             summer school lectures series by Zlatko Minev on superconducting
-            qubits. Also, check out the open source
+            qubits. Also, check out the open-source
             <UiLink
               url="https://learn.qiskit.org/course/quantum-hardware-pulses/introduction-to-transmon-physics"
               >Qiskit textbook</UiLink

--- a/constants/summerSchool2022Content.ts
+++ b/constants/summerSchool2022Content.ts
@@ -48,7 +48,7 @@ const mosaic: MosaicSection = {
       position: "first",
       title: "Qiskit Textbook",
       description:
-        "The Qiskit Textbook is a free digital open source textbook that will teach you the concepts of quantum computing while you learn to use Qiskit.",
+        "The Qiskit Textbook is a free digital open-source textbook that will teach you the concepts of quantum computing while you learn to use Qiskit.",
       image: "/images/events/seminar-series/mosaic-experts.png",
       cta: {
         url: "/learn",

--- a/constants/summerSchool2023Content.ts
+++ b/constants/summerSchool2023Content.ts
@@ -72,7 +72,7 @@ const mosaic: MosaicSection = {
       position: "second",
       title: "Qiskit Textbook",
       description:
-        "The Qiskit Textbook is a free digital open source textbook that will teach you the concepts of quantum computing while you learn to use Qiskit.",
+        "The Qiskit Textbook is a free digital open-source textbook that will teach you the concepts of quantum computing while you learn to use Qiskit.",
       image: "/images/events/summer-school-2023/qiskit-textbook.jpg",
       altText: "",
       cta: {


### PR DESCRIPTION
## Changes

"open source" -> "open-source"

([Reference](https://learn.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/o/open-source))
