### PR TITLE
new preview build to generate static site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ static/sw.js
 content/events/*.json
 content/ecosystem/members.json
 content/advocates/advocates.jon
+
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,22 +2,25 @@
 
 FROM node:18-alpine AS build
 
+ARG SITE_URL
+ENV SITE_URL $SITE_URL
+
+ARG AIRTABLE_API_KEY
+ENV AIRTABLE_API_KEY $AIRTABLE_API_KEY
+
 WORKDIR /qiskit.org
 
 COPY . .
 
 RUN npm ci
-RUN npm run build
+RUN npm run generate
 
 # Serve
+FROM nginx:alpine AS serve
 
-FROM node:18-alpine
+WORKDIR /app
 
-COPY --from=build /qiskit.org/.output ./.output/
+COPY --from=build /qiskit.org/.output/public /usr/share/nginx/html/
+COPY ./nginx.preview.conf /etc/nginx/nginx.conf
 
-ENV NUXT_HOST=0.0.0.0
-ENV NUXT_PORT=3000
-
-EXPOSE 3000
-
-CMD ["node", ".output/server/index.mjs"]
+EXPOSE 80

--- a/nginx.preview.conf
+++ b/nginx.preview.conf
@@ -1,0 +1,19 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    include mime.types;
+    sendfile on;
+
+    server {
+        listen 80;
+        listen [::]:80;
+
+        root /usr/share/nginx/html;
+
+        autoindex off;
+
+        gzip_static on;
+    }
+}


### PR DESCRIPTION
## Changes

Fixes #3321 

## Implementation details

New Dockerfile that builds the site and serve it with nginx instead of nodejs.

AIRTABLE_API_KEY is now required for build the site.
