### PR TITLE
[ecosystem]: remove shuffling and fix sorting

### DIFF
--- a/hooks/ecosystem-conversion-utils.ts
+++ b/hooks/ecosystem-conversion-utils.ts
@@ -19,10 +19,7 @@ async function fetchMembers() {
         membersArray.push(member);
       });
     });
-    const convertedArray = membersArray.map((obj: any) => {
-      return toCamelCase(obj);
-    });
-    return convertedArray;
+    return membersArray.map((obj: any) => toCamelCase(obj));
   } catch (err) {
     // eslint-disable-next-line no-console
     console.error(err);

--- a/hooks/ecosystem-conversion-utils.ts
+++ b/hooks/ecosystem-conversion-utils.ts
@@ -22,8 +22,7 @@ async function fetchMembers() {
     const convertedArray = membersArray.map((obj: any) => {
       return toCamelCase(obj);
     });
-    const shuffled = fyShuffle(convertedArray);
-    return shuffled;
+    return convertedArray;
   } catch (err) {
     // eslint-disable-next-line no-console
     console.error(err);
@@ -41,16 +40,6 @@ async function fetchTiers() {
     // eslint-disable-next-line no-console
     console.error(err);
   }
-}
-
-function fyShuffle(array: any) {
-  for (let i = array.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    const temp = array[i];
-    array[i] = array[j];
-    array[j] = temp;
-  }
-  return array;
 }
 
 function toCamelCase(obj: any): any {

--- a/pages/ecosystem.vue
+++ b/pages/ecosystem.vue
@@ -125,8 +125,6 @@
 </template>
 
 <script setup lang="ts">
-import sortBy from "lodash/sortBy";
-import reverse from "lodash/reverse";
 import { Link } from "~/types/links";
 import rawMembers from "~/content/ecosystem/members.json";
 import rawTiers from "~/content/ecosystem/tiers.json";
@@ -246,14 +244,11 @@ function searchOnMembers(inputText: string) {
 }
 
 function sortMembers(membersToSort: Member[]) {
-  const membersOnAscOrder = sortBy(membersToSort, [
-    (member) =>
-      propToSortBy.value === "name" ? member.name.toLowerCase() : member.stars,
-  ]);
+  if (propToSortBy.value === "name")
+    return membersToSort.sort((a, b) => a.name.localeCompare(b.name));
 
-  return propToSortBy.value === "stars"
-    ? reverse(membersOnAscOrder)
-    : membersOnAscOrder;
+  if (propToSortBy.value === "stars")
+    return membersToSort.sort((a, b) => b.stars - a.stars);
 }
 </script>
 

--- a/pages/ecosystem.vue
+++ b/pages/ecosystem.vue
@@ -247,7 +247,7 @@ function searchOnMembers(inputText: string) {
 
 function sortMembers(membersToSort: Member[]) {
   const membersOnAscOrder = sortBy(membersToSort, [
-    `${propToSortBy.value}`,
+    (member) => member.name.toLowerCase(),
   ]) as Member[];
 
   return propToSortBy.value === "stars"

--- a/pages/ecosystem.vue
+++ b/pages/ecosystem.vue
@@ -247,8 +247,9 @@ function searchOnMembers(inputText: string) {
 
 function sortMembers(membersToSort: Member[]) {
   const membersOnAscOrder = sortBy(membersToSort, [
-    (member) => member.name.toLowerCase(),
-  ]) as Member[];
+    (member) =>
+      propToSortBy.value === "name" ? member.name.toLowerCase() : member.stars,
+  ]);
 
   return propToSortBy.value === "stars"
     ? reverse(membersOnAscOrder)


### PR DESCRIPTION
## Implementation details

- Removes randomization/shuffling of ecosystem members (since we're ordering them by `name`, by default)
- updates the `sortBy` implementation, so uppercase & lowercase are factored in the alphabetic order

#### Screenshot of the issue (showing that sorting was NOT working in the preview branch)
https://github.com/Qiskit/qiskit.org/assets/6276074/d0243b1f-ac20-4883-9246-755ed781c073

## Screenshots
(showing that sorting works alphabetically)

https://github.com/Qiskit/qiskit.org/assets/6276074/4881ba32-d3a5-43ef-8795-e14b8e8e7f29

