### PR TITLE
Create brokenlink-check.yml

### DIFF
--- a/.github/workflows/brokenlink-check.yml
+++ b/.github/workflows/brokenlink-check.yml
@@ -12,4 +12,9 @@ jobs:
         uses: ruzickap/action-my-broken-link-checker@v2
         with:
           url: https://qiskit.org
-          cmd_params: "--buffer-size=8192 --max-connections=10 --color=always --skip-tls-verification --exclude=\"(stubs|mylabs.dev|linkedin.com)\" --timeout=60"
+          cmd_params: --buffer-size=8192 \
+                      --max-connections=10 \
+                      --color=always \
+                      --skip-tls-verification \
+                      --exclude="(stubs|https://qiskit.org/documentation)" \
+                      --timeout=60

--- a/.github/workflows/brokenlink-check.yml
+++ b/.github/workflows/brokenlink-check.yml
@@ -12,9 +12,4 @@ jobs:
         uses: ruzickap/action-my-broken-link-checker@v2
         with:
           url: https://qiskit.org
-          cmd_params: --buffer-size=8192 \
-                      --max-connections=10 \
-                      --color=always \
-                      --skip-tls-verification \
-                      --exclude="(stubs|https://qiskit.org/documentation)" \
-                      --timeout=60
+          cmd_params: "--buffer-size=8192 --max-connections=10 --color=always --skip-tls-verification --exclude=\"(stubs|https://qiskit.org/documentation)\" --timeout=60"

--- a/.github/workflows/brokenlink-check.yml
+++ b/.github/workflows/brokenlink-check.yml
@@ -1,0 +1,15 @@
+name: Links
+
+on:
+  workflow_dispatch:
+
+jobs:
+  my-broken-link-checker:
+    name: Check broken links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check
+        uses: ruzickap/action-my-broken-link-checker@v2
+        with:
+          url: https://qiskit.org
+          cmd_params: "--buffer-size=8192 --max-connections=10 --color=always --skip-tls-verification --exclude=\"(stubs|mylabs.dev|linkedin.com)\" --timeout=60"

--- a/.github/workflows/brokenlink-check.yml
+++ b/.github/workflows/brokenlink-check.yml
@@ -12,4 +12,4 @@ jobs:
         uses: ruzickap/action-my-broken-link-checker@v2
         with:
           url: https://qiskit.org
-          cmd_params: "--buffer-size=8192 --max-connections=10 --color=always --skip-tls-verification --exclude=\"(stubs|https://qiskit.org/documentation)\" --timeout=60"
+          cmd_params: "--buffer-size=8192 --max-connections=10 --color=always --skip-tls-verification --exclude=\"(https://qiskit.org/documentation|https://qiskit.org/ecosystem/.*)\" --timeout=60"


### PR DESCRIPTION
Fixes #3366

New workflow to find broken links on qiskit.org

## Changes

This workflow prints logs with the broken links  it finds on every page of qiskit.org

## Implementation details

Ideally, it should open a PR with the broken links but, with the initial test, there are so many links that it is not able to finish the execution. We should fix the links it finds now and when it is a more manageable amount, study how to automatically open the PRs.

## How to read this PR

 I attatch a text file with the logs it finds. In this example, some links are included because they give a time out. I thinks those error should not be addressed at the first time and increase the default timeout limit (already increased at 60s).
