### PR TITLE
feat(ecosystem-item-card): update alignment

### DIFF
--- a/components/Ecosystem/EcosystemItemCard.vue
+++ b/components/Ecosystem/EcosystemItemCard.vue
@@ -13,7 +13,7 @@
       :to="member.url"
       :secondary-cta="websiteCta"
     >
-      <div class="cds--row">
+      <div class="ecosystem-item-card__details">
         <span class="ecosystem-item-card__licence">
           {{ member.licence }}
         </span>
@@ -104,7 +104,11 @@ function formatTimestamp(timestamp: number): string {
   &__licence {
     font-size: 12px;
     margin-right: carbon.$spacing-05;
-    margin-left: carbon.$spacing-05;
+
+    @include carbon.breakpoint-down(md) {
+      margin-right: initial;
+      margin-bottom: carbon.$spacing-02;
+    }
   }
 
   &__stars {
@@ -118,6 +122,16 @@ function formatTimestamp(timestamp: number): string {
 
   &__description {
     margin-top: carbon.$spacing-05;
+  }
+
+  &__details {
+    display: flex;
+    align-items: center;
+
+    @include carbon.breakpoint-down(md) {
+      flex-direction: column;
+      align-items: initial;
+    }
   }
 }
 


### PR DESCRIPTION
## Changes

Fixes small alignment issue mentioned in [this comment ](https://github.com/Qiskit/qiskit.org/pull/3284#issuecomment-1598825276)

## Implementation details

- remove the `cds--row` class because it was only used for its display flex 
  - also, because when updating styles, I didn't want to target `.cds--row`
- used ecosystem card specific class name (`.__details`, which include license and GH stars for the card)
- added styles to respond at smaller viewports


## How to read this PR
- review styles please 

## Screenshots


https://github.com/Qiskit/qiskit.org/assets/6276074/3e750f77-5450-4e98-8429-e2db09c0fbb8

