### PR TITLE
feat(error-page): single cta w/ separate handling for docs errors

### DIFF
--- a/error.vue
+++ b/error.vue
@@ -76,7 +76,7 @@ const backToDocsCta: Link = {
   },
 };
 
-const isDocumentationError = computed(() => {
+const isDocumentationError = computed<boolean>(() => {
   return (
     props.error.statusCode === 404 && route.path.startsWith("/documentation/")
   );

--- a/error.vue
+++ b/error.vue
@@ -12,16 +12,9 @@
               Or as we like to say, <span v-html="randomMessage" />
             </p>
             <UiCta
-              v-if="isDocumentationError"
-              :label="backToDocsCta.label"
-              :segment="backToDocsCta.segment"
-              :url="backToDocsCta.url"
-            />
-            <UiCta
-              v-else
-              :label="backToHomeCta.label"
-              :segment="backToHomeCta.segment"
-              :url="backToHomeCta.url"
+              :label="backToCta.label"
+              :segment="backToCta.segment"
+              :url="backToCta.url"
             />
           </div>
           <div class="cds--col-lg-8">
@@ -76,11 +69,9 @@ const backToDocsCta: Link = {
   },
 };
 
-const isDocumentationError = computed<boolean>(() => {
-  return (
-    props.error.statusCode === 404 && route.path.startsWith("/documentation/")
-  );
-});
+const backToCta = route.path.startsWith("/documentation/")
+  ? backToDocsCta
+  : backToHomeCta;
 
 const errorImgSrc = `/images/error-page/cat${getRandomInt(1, 9)}.png`;
 

--- a/error.vue
+++ b/error.vue
@@ -12,16 +12,16 @@
               Or as we like to say, <span v-html="randomMessage" />
             </p>
             <UiCta
-              :label="backToHomeCta.label"
-              :segment="backToHomeCta.segment"
-              :url="backToHomeCta.url"
-            />
-            <UiCta
-              class="error-page__ghost-btn"
+              v-if="isDocumentationError"
               :label="backToDocsCta.label"
               :segment="backToDocsCta.segment"
               :url="backToDocsCta.url"
-              kind="ghost"
+            />
+            <UiCta
+              v-else
+              :label="backToHomeCta.label"
+              :segment="backToHomeCta.segment"
+              :url="backToHomeCta.url"
             />
           </div>
           <div class="cds--col-lg-8">
@@ -46,6 +46,8 @@ interface Props {
   error: NuxtError;
 }
 
+const route = useRoute();
+
 const props = defineProps<Props>();
 
 const pageTitle = computed<string>(() => {
@@ -58,7 +60,7 @@ useHead({
 
 const backToHomeCta: Link = {
   url: "/",
-  label: "Back to Qiskit.org home",
+  label: "Back to Qiskit home page",
   segment: {
     cta: "back-to-home",
     location: "error-page",
@@ -67,12 +69,18 @@ const backToHomeCta: Link = {
 
 const backToDocsCta: Link = {
   url: "/documentation",
-  label: "Back to Qiskit Documentation",
+  label: "Back to Qiskit documentation",
   segment: {
     cta: "back-to-documentation",
     location: "error-page",
   },
 };
+
+const isDocumentationError = computed(() => {
+  return (
+    props.error.statusCode === 404 && route.path.startsWith("/documentation/")
+  );
+});
 
 const errorImgSrc = `/images/error-page/cat${getRandomInt(1, 9)}.png`;
 
@@ -119,10 +127,6 @@ function onClick(e: CustomEvent) {
   &__img {
     display: block;
     max-width: 100%;
-  }
-
-  &__ghost-btn {
-    padding: carbon.$spacing-05;
   }
 }
 


### PR DESCRIPTION
## Changes

Fixes #3361 

Co-authored by: @y4izus 

## Implementation details
- add a computed value for checking if the 404 `isDocumentationError`
  - if so, we render the back to Documentation CTA
  - else, show the normal back to Qiskit org home page CTA


## Preview
- unfortunately, the preview branch doesn't produce the Nuxt error page, and only results in nginx server errors
  
## Screenshots
(Showing dynamic error pages for a `500`, `404` from `/documentation/`, and regular `404`)


https://github.com/Qiskit/qiskit.org/assets/6276074/737ae425-028e-42e4-b694-6fe064aef9ba



