### PR TITLE
Update verify.yml

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -54,4 +54,4 @@ jobs:
       - run: npm ci
       - run: npm run generate
         env:
-          AIRTABLE_API_KEY: ${{secrets.AIRTABLE_API_KEY}}
+          AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}


### PR DESCRIPTION
## Changes

There are PRs  failing because the build job of the verify workflow doesn't set correctly the Airtable API Key.

This PR fixes this error.

Failing PRs:

- https://github.com/Qiskit/qiskit.org/pull/3380
- https://github.com/Qiskit/qiskit.org/pull/3379
- https://github.com/Qiskit/qiskit.org/pull/3378
- https://github.com/Qiskit/qiskit.org/pull/3377
- https://github.com/Qiskit/qiskit.org/pull/3347