### PR TITLE
Updated tag design

### DIFF
--- a/assets/scss/helpers/_variables.scss
+++ b/assets/scss/helpers/_variables.scss
@@ -45,8 +45,8 @@ $button-active-text-color-secondary: carbon.$white-0;
 $button-background-color-tertiary: carbon.$cool-gray-90;
 $button-background-color-tertiary-dark: carbon.$purple-70;
 $button-text-color-tertiary: carbon.$purple-40;
-$tag-background-color: carbon.$purple-70;
-$tag-text-color: carbon.$white-0;
+$tag-background-color: carbon.$purple-30;
+$tag-text-color: carbon.$purple-80;
 
 // Other variables
 

--- a/components/Advocates/AdvocatesItemCard.vue
+++ b/components/Advocates/AdvocatesItemCard.vue
@@ -3,14 +3,13 @@
     class="advocate-card"
     :image="image"
     :title="name"
-    :tags="formattedRegion"
-    :alt-text="`${name} profile photo`"
+    :primary-tag="formattedRegion"
   >
     <div v-if="location" class="advocate-card__location">
       <Map20 class="advocate-card__icon" />
       {{ location }}
     </div>
-    <div v-if="slackUsername" class="advocate-card__contact">
+    <div class="advocate-card__contact">
       <LogoSlack20 class="advocate-card__icon" />
       <UiLink :url="`https://qiskit.slack.com/team/${slackId}`">
         @{{ slackUsername }}
@@ -42,7 +41,7 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 // Tags on AppCard is an Array
-const formattedRegion = computed(() => (props.region ? [props.region] : []));
+const formattedRegion = computed(() => (props.region ? props.region : []));
 
 const location = computed(() =>
   [props.city, props.country].filter((e) => !!e).join(", ")
@@ -65,8 +64,8 @@ const location = computed(() =>
     align-items: center;
   }
 
-  &__contact {
-    margin-top: carbon.$spacing-03;
+  &__location {
+    margin-bottom: carbon.$spacing-03;
   }
 
   &__icon {

--- a/components/Ui/UiCard.vue
+++ b/components/Ui/UiCard.vue
@@ -44,18 +44,9 @@
               {{ tag }}
             </bx-tag>
           </div>
-          <div v-if="hasTags(tooltipTags)" class="card__tags">
-            <div
-              v-for="tag in tooltipTags"
-              :key="tag.label"
-              class="card__custom-pill"
-            >
-              {{ tag.label }}
-              <bx-tooltip-icon :body-text="tag.description" direction="bottom">
-                <Information16 class="card__tooltip__icon" />
-              </bx-tooltip-icon>
-            </div>
-          </div>
+          <bx-tag v-if="primaryTag" class="card__tag" type="purple">
+            {{ primaryTag }}
+          </bx-tag>
         </div>
       </header>
       <div class="card__body">
@@ -86,18 +77,8 @@
 </template>
 
 <script setup lang="ts">
-// import "@carbon/web-components/es/components/tag/tag.js";
-// import "@carbon/web-components/es/components/tooltip/tooltip-icon.js";
-import Information16 from "@carbon/icons-vue/lib/information/16";
 import { Link } from "~/types/links";
 import { CtaClickedEventProp } from "~/types/segment";
-
-export interface TagTooltip {
-  // the short string label for inside the tag
-  label: string;
-  // the description for the tooltip
-  description: string;
-}
 
 interface Props {
   descriptionWholeSize?: boolean;
@@ -111,7 +92,7 @@ interface Props {
   title: string;
   to?: string;
   secondaryCta?: Link | null;
-  tooltipTags?: TagTooltip[];
+  primaryTag?: string[];
   verticalLayout?: boolean;
 }
 
@@ -126,7 +107,7 @@ const props = withDefaults(defineProps<Props>(), {
   tags: () => [],
   to: "",
   secondaryCta: undefined,
-  tooltipTags: () => [],
+  primaryTag: undefined,
   verticalLayout: false,
 });
 
@@ -137,7 +118,7 @@ const ctaLink = computed(() => ({
 }));
 
 // TODO: Refactor to do a cleaner check for "tags" and "tooltip tags" (https://github.com/Qiskit/qiskit.org/pull/2935#discussion_r1088770246)
-function hasTags(tags: string[] | TagTooltip[]) {
+function hasTags(tags: string[]) {
   return Array.isArray(tags) && tags.length > 0;
 }
 </script>
@@ -184,6 +165,9 @@ function hasTags(tags: string[] | TagTooltip[]) {
       width: auto;
     }
   }
+  &__body {
+    overflow-wrap: break-word;
+  }
 
   &__content {
     padding: carbon.$spacing-05 carbon.$spacing-07;
@@ -220,16 +204,13 @@ function hasTags(tags: string[] | TagTooltip[]) {
     white-space: nowrap;
   }
 
+  &__tags {
+    margin-right: carbon.$spacing-03;
+  }
+
   &__title {
     flex: 1;
     margin-bottom: carbon.$spacing-02;
-  }
-
-  &__tooltip {
-    &__icon {
-      fill: carbon.$white;
-      margin-left: carbon.$spacing-02;
-    }
   }
 }
 
@@ -288,43 +269,6 @@ bx-tag {
   min-width: 0;
 
   &:last-child {
-    margin-right: 0;
-  }
-}
-
-bx-tooltip-icon {
-  --cds-inverse-02: #{carbon.$cool-gray-90};
-
-  line-height: 0;
-}
-</style>
-
-<style lang="scss">
-@use "~/assets/scss/carbon.scss";
-@use "~/assets/scss/helpers/index.scss" as qiskit;
-
-.card {
-  &__custom-pill {
-    @include carbon.type-style("label-01");
-
-    background-color: qiskit.$tag-background-color;
-    color: qiskit.$tag-text-color;
-    display: inline-flex;
-    min-width: 0;
-    max-width: 100%;
-    min-height: 1.5rem;
-    align-items: center;
-    justify-content: center;
-    padding: carbon.$spacing-02 carbon.$spacing-03;
-    margin: carbon.$spacing-02 carbon.$spacing-03 carbon.$spacing-02
-      carbon.$spacing-03;
-    border-radius: 6.9375rem;
-    cursor: default;
-    vertical-align: middle;
-    word-break: break-word;
-  }
-
-  &__custom-pill:last-child {
     margin-right: 0;
   }
 }


### PR DESCRIPTION
## Changes
### 
New fix to the issue https://github.com/Qiskit/qiskit.org/issues/2852.
Restructured the layout of the. tags in the UI cards so they do not overlap anymore. Also changed the colour of the text and of the background of the tag.
Co-authored-by: @techtolentino

## Implementation details
### 
Changed the display on the UI card file and changed the colour of the background and text on the variables file, which apply to the ecosystem and advocates pages' cards.


## Screenshots
A screenshot with the extended version and with the narrowed version
<img width="264" alt="Screenshot 2023-06-27 at 14 29 44" src="https://github.com/Qiskit/qiskit.org/assets/89911196/6808ffe9-5507-4b16-b6ff-941b6f09b360">
<img width="928" alt="Screenshot 2023-06-27 at 14 29 24" src="https://github.com/Qiskit/qiskit.org/assets/89911196/8054da9e-67ee-4968-b50b-1854f7f32db8">
