### PR TITLE
perf(ecosystem): quicker list changes

### DIFF
--- a/components/Ecosystem/EcosystemItemCard.vue
+++ b/components/Ecosystem/EcosystemItemCard.vue
@@ -65,6 +65,7 @@ const hasTestsResults = computed(() => props.member.testsResults.length !== 0);
 const testRows = computed(() => {
   if (props.member.testsResults) {
     return props.member.testsResults.map((res) => {
+      // TODO: Format properties during data fetching instead for better performance.
       const timestamp = formatTimestamp(res.timestamp);
       // Convert package name to title case
       let packageName;

--- a/hooks/ecosystem-conversion-utils.ts
+++ b/hooks/ecosystem-conversion-utils.ts
@@ -19,6 +19,10 @@ async function fetchMembers() {
         membersArray.push(member);
       });
     });
+
+    // Sort ecosystem projects alphabetically
+    membersArray.sort((a, b) => a.name.localeCompare(b.name));
+
     return membersArray.map((obj: any) => toCamelCase(obj));
   } catch (err) {
     // eslint-disable-next-line no-console

--- a/pages/ecosystem.vue
+++ b/pages/ecosystem.vue
@@ -45,7 +45,7 @@
             </bx-tab>
           </bx-tabs>
           <div class="ecosystem__tiers__description">
-            {{ getSelectedTierDescription() }}
+            {{ selectedTierDescription }}
           </div>
         </client-only>
       </div>
@@ -171,6 +171,14 @@ const tiers = rawTiers as Tier[];
 const tiersNames = tiers.map((tier) => tier.name);
 const selectedTab = ref<string>("Main");
 
+const selectedTier = computed<Tier | undefined>(() => {
+  return tiers.find((tier) => tier.name === selectedTab.value);
+});
+
+const selectedTierDescription = computed<string>(() => {
+  return selectedTier.value?.description ?? "";
+});
+
 function updateSelectedTab(tab: string) {
   selectedTab.value = tab;
 }
@@ -180,6 +188,27 @@ function updateSelectedTab(tab: string) {
  */
 const categoryFilters = ref<string[]>([]);
 const categoryFiltersAsString = computed(() => categoryFilters.value.join(","));
+
+function updateCategoryFilter(filterValue: string, isChecked: boolean) {
+  if (isChecked) {
+    categoryFilters.value.push(filterValue);
+  } else {
+    const index = categoryFilters.value.indexOf(filterValue);
+    if (index !== -1) {
+      categoryFilters.value.splice(index, 1);
+    }
+  }
+}
+
+function updateCategoryFilters(newCategoryFilters: string) {
+  const newCategoryFiltersAsArray =
+    newCategoryFilters === "" ? [] : newCategoryFilters.split(",");
+  categoryFilters.value = newCategoryFiltersAsArray;
+}
+
+function isCategoryFilterChecked(filterValue: string): boolean {
+  return categoryFilters.value.includes(filterValue);
+}
 
 /**
  * Search term
@@ -258,32 +287,6 @@ const membersCategories = members.map((member) => member.labels);
 const sortedMembersCategories = [...new Set(membersCategories.flat())].sort(
   (a, b) => a.localeCompare(b)
 );
-
-function getSelectedTierDescription() {
-  const tier = tiers.find((tier) => tier.name === selectedTab.value);
-  return tier?.description || "";
-}
-
-function updateCategoryFilter(filterValue: string, isChecked: boolean) {
-  if (isChecked) {
-    categoryFilters.value.push(filterValue);
-  } else {
-    const index = categoryFilters.value.indexOf(filterValue);
-    if (index !== -1) {
-      categoryFilters.value.splice(index, 1);
-    }
-  }
-}
-
-function updateCategoryFilters(newCategoryFilters: string) {
-  const newCategoryFiltersAsArray =
-    newCategoryFilters === "" ? [] : newCategoryFilters.split(",");
-  categoryFilters.value = newCategoryFiltersAsArray;
-}
-
-function isCategoryFilterChecked(filterValue: string): boolean {
-  return categoryFilters.value.includes(filterValue);
-}
 </script>
 
 <style lang="scss" scoped>

--- a/pages/ecosystem.vue
+++ b/pages/ecosystem.vue
@@ -54,7 +54,7 @@
           <UiFieldset class="ecosystem__categories" label="Category">
             <client-only>
               <bx-checkbox
-                v-for="category in sortedMembersCategories"
+                v-for="category in categoryFilterOptionsSorted"
                 :key="category"
                 :checked="isCategoryFilterChecked(category)"
                 :label-text="category"
@@ -70,7 +70,7 @@
           <div class="ecosystem__categories__multiselect">
             <UiMultiSelect
               label="Category"
-              :options="sortedMembersCategories"
+              :options="categoryFilterOptionsSorted"
               :value="categoryFiltersAsString"
               @change-selection="updateCategoryFilters($event)"
             />
@@ -186,6 +186,11 @@ function updateSelectedTab(tab: string) {
 /**
  * Category filters
  */
+const categoryFilterOptions = members.map((member) => member.labels);
+const categoryFilterOptionsSorted = [
+  ...new Set(categoryFilterOptions.flat()),
+].sort((a, b) => a.localeCompare(b));
+
 const categoryFilters = ref<string[]>([]);
 const categoryFiltersAsString = computed(() => categoryFilters.value.join(","));
 
@@ -282,11 +287,6 @@ const filteredMembersFromSelectedTierSorted = computed<Member[]>(() => {
   // The list of members is sorted by name by default.
   return filteredMembersFromSelectedTier.value;
 });
-
-const membersCategories = members.map((member) => member.labels);
-const sortedMembersCategories = [...new Set(membersCategories.flat())].sort(
-  (a, b) => a.localeCompare(b)
-);
 </script>
 
 <style lang="scss" scoped>

--- a/pages/ecosystem.vue
+++ b/pages/ecosystem.vue
@@ -102,21 +102,23 @@
               role="tabpanel"
               :aria-labelledby="`tab${tierName}`"
             >
-              <div
-                v-if="getFilteredMembers(tierName).length > 0"
-                class="cds--row ecosystem__members"
-              >
-                <EcosystemItemCard
-                  v-for="member in sortMembers(getFilteredMembers(tierName))"
-                  :key="member.name"
-                  class="cds--col-sm-4 cds--col-xlg-8"
-                  :member="member"
-                />
-              </div>
-              <p v-else class="cds--col">
-                Try using wider search criteria, or consider
-                <UiLink v-bind="joinAction">joining the ecosystem. </UiLink>
-              </p>
+              <template v-if="selectedTab === tierName">
+                <div
+                  v-if="getFilteredMembers(tierName).length > 0"
+                  class="cds--row ecosystem__members"
+                >
+                  <EcosystemItemCard
+                    v-for="member in sortMembers(getFilteredMembers(tierName))"
+                    :key="member.name"
+                    class="cds--col-sm-4 cds--col-xlg-8"
+                    :member="member"
+                  />
+                </div>
+                <p v-else class="cds--col">
+                  Try using wider search criteria, or consider
+                  <UiLink v-bind="joinAction">joining the ecosystem. </UiLink>
+                </p>
+              </template>
             </div>
           </div>
         </template>

--- a/pages/ecosystem.vue
+++ b/pages/ecosystem.vue
@@ -173,12 +173,16 @@ const membersCategories = members.map((member) => member.labels);
 const sortedMembersCategories = [...new Set(membersCategories.flat())].sort(
   (a, b) => a.localeCompare(b)
 );
-const membersByTier: MembersByTier = tiersNames.reduce((acc, tierName) => {
-  return {
-    ...acc,
-    ...{ [tierName]: members.filter((member) => member.tier === tierName) },
-  };
-}, {});
+
+const membersByTier = computed<MembersByTier>(() => {
+  const result: MembersByTier = {};
+
+  tiersNames.forEach((tierName) => {
+    result[tierName] = members.filter((member) => member.tier === tierName);
+  });
+
+  return result;
+});
 
 const categoryFiltersAsString = computed(() => categoryFilters.value.join(","));
 
@@ -192,7 +196,7 @@ function getFilteredMembers(tierName: string) {
     return [];
   }
 
-  const filteredMembersByTier = membersByTier[tierName];
+  const filteredMembersByTier = membersByTier.value[tierName];
 
   let result = filteredMembersByTier;
 


### PR DESCRIPTION
## Changes

<!--
  Required.

  Briefly describe the changes introduced by this pull request.
  Also link relevant issues with the "closes", "fixes" or "resolves" keywords,
  and add co-authors where appropriate with the "co-authored-by" keyword.

  Example:
  Implemented the functionality to update the user's name.
  Closes #42
  Co-authored-by: @octocat
-->

This PR improves the performance of the ecosystem page when changing the selected tier, the category filters or the sorting option.

We are still able to improve our performance further by moving some data formatting functions from Vue components to the fetching function that stored external data.

I still think that we can continue improving the performance, but we'll have to dig deeper. This might be a task for a later point in time.

Fixes #3370 

## Implementation details

<!--
  Optional.

  If useful for the code review, describe implementation details and, if
  necessary, why a certain approach was chosen.

  Example:
  Changes are introduced to the controller and the database model. UI changes
  are not in the scope of this PR.
-->

I used [computed properties instead of methods](https://vuejs.org/guide/essentials/computed.html#computed-caching-vs-methods) to leverage caching based on the reactive properties.

I also avoided to render the content of the tabs that were not active.

I also changed the order in which we performed certain operations on the members list to optimise the space and time complexity.

Finally, I sorted the ecosystem project members by name by default during the fetching function, so that we can avoid having to sort during rendering.