### PR TITLE
fix: replace broken links

### DIFF
--- a/constants/fallFest2022Content.ts
+++ b/constants/fallFest2022Content.ts
@@ -361,7 +361,7 @@ const helpfulResources: HelpfulResourcesSection = {
       description:
         "Prepare for the Fall Fest by reviewing the documentation and installing Qiskit.",
       cta: {
-        url: "https://qiskit.org/documentation/install.html",
+        url: "https://qiskit.org/documentation/getting_started.html#installation",
         label: "Install here",
         segment: {
           cta: "qiskit-install",

--- a/constants/summerSchool2022Content.ts
+++ b/constants/summerSchool2022Content.ts
@@ -317,7 +317,7 @@ const helpfulResources: HelpfulResourcesSection = {
       description:
         "Prepare for the Summer School by reviewing the documentation and installing Qiskit.",
       cta: {
-        url: "https://qiskit.org/documentation/install.html",
+        url: "https://qiskit.org/documentation/getting_started.html#installation",
         label: "Install here",
         segment: {
           cta: "qiskit-install",

--- a/constants/summerSchool2023Content.ts
+++ b/constants/summerSchool2023Content.ts
@@ -388,7 +388,7 @@ const helpfulResources: HelpfulResourcesSection = {
       description:
         "Prepare for the Summer School by reviewing the documentation and installing Qiskit.",
       cta: {
-        url: "https://qiskit.org/documentation/install.html",
+        url: "https://qiskit.org/documentation/getting_started.html#installation",
         label: "Install here",
         segment: {
           cta: "qiskit-install",


### PR DESCRIPTION
## Changes

Fixes #3345 

## Implementation details

Replaces broken links found in 3 areas
- [x] Summer School 2023 page - ([Preview link](https://qiskit-org-pr-3401.dcq4xc5i083.us-south.codeengine.appdomain.cloud/events/summer-school-2023))
- [x] Summer School 2022 page - ([Preview link](https://qiskit-org-pr-3401.dcq4xc5i083.us-south.codeengine.appdomain.cloud/events/summer-school-2022))
- [x] Fall Fest 2022 page - ([Preview link](https://qiskit-org-pr-3401.dcq4xc5i083.us-south.codeengine.appdomain.cloud/events/fall-fest))
  
