### PR TITLE
Fixed SuperstaQ Github Link

### DIFF
--- a/content/providers/list/5.multi-platforms.yaml
+++ b/content/providers/list/5.multi-platforms.yaml
@@ -234,7 +234,7 @@ providers:
     pip install qiskit-superstaq
   sourceCta:
     label: GitHub
-    url: https://github.com/SupertechLabs/qiskit-superstaq
+    url: https://github.com/Infleqtion/client-superstaq
   title: SuperstaQ
   websiteCta:
     label: Website


### PR DESCRIPTION
## Changes
Closes #3390 
Replaced the broken link on the SuperstaQ's Github link.