### PR TITLE
fix(seo): removed duplicated meta description tag from head

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,7 +2,6 @@ import fetchEvents from "./hooks/update-events";
 import fetchAdvocates from "./hooks/update-advocates";
 import fetchEcosystemMembers from "./hooks/update-ecosystem";
 import { generateMocks } from "./hooks/mock/mock-service";
-import pkg from "./package.json";
 
 const { AIRTABLE_API_KEY, GENERATE_CONTENT, NODE_ENV, SITE_URL, MOCK_CONTENT } =
   process.env;
@@ -10,14 +9,6 @@ const IS_PRODUCTION = NODE_ENV === "production";
 
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
-  app: {
-    head: {
-      meta: [
-        { hid: "description", name: "description", content: pkg.description },
-      ],
-    },
-  },
-
   modules: ["@nuxt/content", "@nuxt/image-edge", "nuxt-schema-org"],
 
   schemaOrg: {


### PR DESCRIPTION
## Changes

Fix  #3429

Removes duplicated meta description tag in DOM head.


## Implementation details

Removes generic meta description tag which is applied to all pages by `nuxt.config.js`. This leaves `useSeoMeta` as the sole provider of page description tags, which applies unique descriptions to each page for SEO purposes.


## Screenshots

Note 1: In the before screenshot the second description tag uses the description text from the homepage since nuxt is not configured to apply unique descriptions to each page. Keeping `useSeoMeta` seems like the preferred choice of the two options since now in the after image the sole description is specific to the advocates page.

Note 2: `og:description` uses the same text as `description`, but it is a different tag name so is not a straight up duplicate tag. `og:description` gets its text from the same source as `useSeoMeta` and is page specific.

**Before**

![image](https://github.com/Qiskit/qiskit.org/assets/134723582/9ef9b62f-23f8-4283-8df1-daaeb773d145)

**After**

![image](https://github.com/Qiskit/qiskit.org/assets/134723582/81174dc7-a390-4415-bb5d-d75e7ab817d5)




