### PR TITLE
fix(providers): support missing CTAs

### DIFF
--- a/components/Providers/Accordion/ProvidersAccordionContent.vue
+++ b/components/Providers/Accordion/ProvidersAccordionContent.vue
@@ -33,7 +33,7 @@
 import { TextLink } from "~/types/links";
 import { ProviderCodeExample } from "~/types/providers";
 
-export interface AccordionLayoutProps {
+interface Props {
   title: string;
   description: string;
   installation: string;
@@ -43,7 +43,7 @@ export interface AccordionLayoutProps {
   codeExamples: ProviderCodeExample[];
 }
 
-const props = defineProps<AccordionLayoutProps>();
+const props = defineProps<Props>();
 
 const ctas = computed(() => {
   const ctas = [];

--- a/components/Providers/Accordion/ProvidersAccordionContent.vue
+++ b/components/Providers/Accordion/ProvidersAccordionContent.vue
@@ -17,7 +17,7 @@
     </div>
     <div class="providers-accordion-content__cta-group">
       <UiCta
-        v-for="cta in validCtas"
+        v-for="cta in ctas"
         :key="cta.label"
         kind="ghost"
         :url="cta.url"
@@ -37,19 +37,28 @@ export interface AccordionLayoutProps {
   title: string;
   description: string;
   installation: string;
-  websiteCta: TextLink;
-  docsCta: TextLink;
-  sourceCta: TextLink;
+  docsCta?: TextLink;
+  sourceCta?: TextLink;
+  websiteCta?: TextLink;
   codeExamples: ProviderCodeExample[];
 }
 
 const props = defineProps<AccordionLayoutProps>();
 
-// FIX: This should already be checked by the GeneralLink type
-const validCtas = computed(() => {
-  return [props.websiteCta, props.docsCta, props.sourceCta].filter(
-    (cta) => cta.url !== null
-  );
+const ctas = computed(() => {
+  const ctas = [];
+
+  if (props.websiteCta) {
+    ctas.push(props.websiteCta);
+  }
+  if (props.docsCta) {
+    ctas.push(props.docsCta);
+  }
+  if (props.sourceCta) {
+    ctas.push(props.sourceCta);
+  }
+
+  return ctas;
 });
 </script>
 

--- a/content/providers/list/1.primitives.yaml
+++ b/content/providers/list/1.primitives.yaml
@@ -73,7 +73,4 @@ providers:
     label: GitHub
     url: https://github.com/Qiskit/qiskit-aer
   title: Aer
-  websiteCta:
-    label: null
-    url: null
 title: Native Primitives

--- a/content/providers/list/3.local-simulators.yaml
+++ b/content/providers/list/3.local-simulators.yaml
@@ -36,9 +36,6 @@ providers:
     label: GitHub
     url: https://github.com/Qiskit/qiskit-aer
   title: Aer
-  websiteCta:
-    label: null
-    url: null
 - codeExamples:
   - fullCode: |-
       from mqt import ddsim

--- a/content/providers/list/5.multi-platforms.yaml
+++ b/content/providers/list/5.multi-platforms.yaml
@@ -74,9 +74,6 @@ providers:
   installation: |-
     pip install qiskit
     pip install "azure-quantum[qiskit]"
-  sourceCta:
-    label: null
-    url: null
   title: Azure Quantum
   websiteCta:
     label: Website
@@ -117,9 +114,6 @@ providers:
     label: GitHub
     url: https://github.com/gaqqie/gaqqie
   title: Gaqqie
-  websiteCta:
-    label: Website
-    url: null
 - codeExamples:
   - fullCode: |-
       from qiskit_qcware import QcwareProvider
@@ -197,9 +191,6 @@ providers:
   installation: |-
     pip install qiskit
     pip install strangeworks-qiskit
-  sourceCta:
-    label: GitHub
-    url: null
   title: Strangeworks
   websiteCta:
     label: Website
@@ -229,9 +220,6 @@ providers:
     runMethod: backend
   description: SuperstaQ is a hardware-agnostic software platform that connects applications
     to quantum computers from IBM Quantum, IonQ, and Rigetti.
-  docsCta:
-    label: Docs
-    url: null
   installation: |-
     pip install qiskit
     pip install qiskit-superstaq

--- a/content/providers/quick-start/data.yaml
+++ b/content/providers/quick-start/data.yaml
@@ -222,9 +222,6 @@
     label: GitHub
     url: https://github.com/Qiskit/qiskit-aer
   title: Aer
-  websiteCta:
-    label: null
-    url: null
 - codeExamples:
   - fullCode: |-
       from qiskit_braket_provider import AWSBraketProvider
@@ -466,9 +463,6 @@
   installation: |-
     pip install qiskit
     pip install "azure-quantum[qiskit]"
-  sourceCta:
-    label: null
-    url: null
   title: Azure Quantum
   websiteCta:
     label: Website
@@ -558,9 +552,6 @@
     label: GitHub
     url: https://github.com/gaqqie/gaqqie
   title: Gaqqie
-  websiteCta:
-    label: Website
-    url: null
 - codeExamples:
   - fullCode: |-
       from qiskit_ionq import IonQProvider
@@ -1291,9 +1282,6 @@
   installation: |-
     pip install qiskit
     pip install strangeworks-qiskit
-  sourceCta:
-    label: GitHub
-    url: null
   title: Strangeworks
   websiteCta:
     label: Website
@@ -1365,9 +1353,6 @@
     runMethod: estimator
   description: SuperstaQ is a hardware-agnostic software platform that connects applications
     to quantum computers from IBM Quantum, IonQ, and Rigetti.
-  docsCta:
-    label: Docs
-    url: null
   installation: |-
     pip install qiskit
     pip install qiskit-superstaq


### PR DESCRIPTION
## Changes

<!--
  Required.

  Briefly describe the changes introduced by this pull request.
  Also link relevant issues with the "closes", "fixes" or "resolves" keywords,
  and add co-authors where appropriate with the "co-authored-by" keyword.

  Example:
  Implemented the functionality to update the user's name.
  Closes #42
  Co-authored-by: @octocat
-->

This PR supports the providers data missing CTAs.

Closes #3146

## Implementation details

<!--
  Optional.

  If useful for the code review, describe implementation details and, if
  necessary, why a certain approach was chosen.

  Example:
  Changes are introduced to the controller and the database model. UI changes
  are not in the scope of this PR.
-->

Some providers don't have certain URLs (website, source or docs). We changed the props in **components/Providers/Accordion/ProvidersAccordionContent.vue** to accept the CTAs optionally.

We also removed the CTA objects from the providers data files when the CTA had the URL `null`.
