### PR TITLE
fix(404): documentation link

### DIFF
--- a/error.vue
+++ b/error.vue
@@ -61,7 +61,7 @@ const backToHomeCta: TextLink = {
 };
 
 const backToDocsCta: TextLink = {
-  url: "/documentation",
+  url: "https://qiskit.org/documentation/",
   label: "Back to Qiskit documentation",
   segment: {
     cta: "back-to-documentation",


### PR DESCRIPTION
Ensure that the documentation link gets treated as an external link logically.

## Changes

<!--
  Required.

  Briefly describe the changes introduced by this pull request.
  Also link relevant issues with the "closes", "fixes" or "resolves" keywords,
  and add co-authors where appropriate with the "co-authored-by" keyword.

  Example:
  Implemented the functionality to update the user's name.
  Closes #42
  Co-authored-by: @octocat
-->

This PR fixes the `/documentation` link in the 404 pages.

## Implementation details

<!--
  Optional.

  If useful for the code review, describe implementation details and, if
  necessary, why a certain approach was chosen.

  Example:
  Changes are introduced to the controller and the database model. UI changes
  are not in the scope of this PR.
-->

Error pages that pointed to `/documentation` had a non-working CTA. We needed to pass the absolute URL (`https://qiskit.org/documentation/`) to ensure that our links' logic treats this link as an external link logically instead of attempting to use internal Nuxt routing logic.

## How to read this PR

<!--
  Optional.

  If useful for the code review, add some guidance for how to read this PR,
  including links to preview builds.

  Example:
  Please start reviewing the changes to the controller files. Then check the
  changes to the database files. This way, you will have more context about the
  changes made to the database model.
  You can test the changes at https://preview-42.example.com/profile/update
-->

In the preview build (or locally), go to a page like `/documentation/this-page-does-not-exist` to get an error page with the documentation CTA, and test if the CTA works when clicked.
