### PR TITLE
fix: remove incorrect links to readings

### DIFF
--- a/pages/learn/course/multiple-qubits-and-entanglement.vue
+++ b/pages/learn/course/multiple-qubits-and-entanglement.vue
@@ -78,24 +78,6 @@ const references: string[] = [];
 const externalRecommendedReadingsPreamble = "";
 const links: RecommendedReading[] = [
   {
-    url: "http://mmrc.amss.cas.cn/tlb/201702/W020170224608149940643.pdf",
-    author: "Michael Nielsen, et al.,",
-    label: "Quantum Computation and Quantum Information (Chapter 1)",
-    segment: {
-      cta: "quantum-computation-and-quantum-information",
-      location: "external-recommended-readings",
-    },
-  },
-  {
-    url: "http://mmrc.amss.cas.cn/tlb/201702/W020170224608149125645.pdf",
-    author: "Phillip Kaye, et al.,",
-    label: "An Introduction to Quantum Computing (Chapters 1-3)",
-    segment: {
-      cta: "an-introduction-to-quantum-computing",
-      location: "external-recommended-readings",
-    },
-  },
-  {
     url: "https://homepages.cwi.nl/~rdewolf/qcnotes.pdf",
     author: "Ronald de Wolf,",
     label: "Quantum Computing: Lecture Notes (Chapters 1 and 2)",

--- a/pages/learn/course/quantum-protocols-and-quantum-algorithms.vue
+++ b/pages/learn/course/quantum-protocols-and-quantum-algorithms.vue
@@ -86,24 +86,6 @@ const references: string[] = [];
 const externalRecommendedReadingsPreamble = "";
 const links: RecommendedReading[] = [
   {
-    url: "http://mmrc.amss.cas.cn/tlb/201702/W020170224608149940643.pdf",
-    author: "Michael Nielsen, et al.,",
-    label: "Quantum Computation and Quantum Information (Chapters 4-6)",
-    segment: {
-      cta: "quantum-computation-and-quantum-information-ch-4-6",
-      location: "external-recommended-readings",
-    },
-  },
-  {
-    url: "http://mmrc.amss.cas.cn/tlb/201702/W020170224608149125645.pdf",
-    author: "Phillip Kaye, et al.,",
-    label: "An Introduction to Quantum Computing (Chapters 5-8)",
-    segment: {
-      cta: "quantum-computing-lecture-notes",
-      location: "external-recommended-readings",
-    },
-  },
-  {
     url: "http://cleve.iqc.uwaterloo.ca/resources/QIC-710-F21/Qic710QuantumAlgorithmsPart1.pdf",
     author: "Richard Cleve,",
     label: "Quantum Information Processing — Quantum Algorithms I",

--- a/pages/learn/course/quantum-states-and-qubits.vue
+++ b/pages/learn/course/quantum-states-and-qubits.vue
@@ -77,24 +77,6 @@ const references: string[] = [];
 const externalRecommendedReadingsPreamble = "";
 const links: RecommendedReading[] = [
   {
-    url: "http://mmrc.amss.cas.cn/tlb/201702/W020170224608149940643.pdf",
-    author: "Michael Nielsen, et al.,",
-    label: "Quantum Computation and Quantum Information (Chapter 1)",
-    segment: {
-      cta: "quantum-computation-and-quantum-information-ch-1",
-      location: "external-recommended-readings",
-    },
-  },
-  {
-    url: "http://mmrc.amss.cas.cn/tlb/201702/W020170224608149125645.pdf",
-    author: "Phillip Kaye, et al.,",
-    label: "An Introduction to Quantum Computing (Chapters 1-3)",
-    segment: {
-      cta: "introduction-to-quantum-computing-ch-1-3",
-      location: "external-recommended-readings",
-    },
-  },
-  {
     url: "https://arxiv.org/abs/1907.09415",
     author: "Ronald de Wolf,",
     label: "Quantum Computing: Lecture Notes (Chapters 1 and 2)",

--- a/pages/learn/summer-school/quantum-computing-and-quantum-learning-2021.vue
+++ b/pages/learn/summer-school/quantum-computing-and-quantum-learning-2021.vue
@@ -73,15 +73,6 @@ const references: string[] = [];
 const externalRecommendedReadingsPreamble = "";
 const links: RecommendedReading[] = [
   {
-    url: "http://mmrc.amss.cas.cn/tlb/201702/W020170224608149940643.pdf",
-    author: "Nielsen & Chuang,",
-    label: "Quantum Computation and Quantum Information",
-    segment: {
-      cta: "qc-qi-pdf",
-      location: "external-recommended-readings",
-    },
-  },
-  {
     url: "https://www.deeplearningbook.org/",
     author: "Ian Goodfellow et al.,",
     label: "Deep Learning",


### PR DESCRIPTION
## Changes

Part of https://github.com/Qiskit/qiskit.org/issues/3473

## Implementation details

- removed links that we know take users to an unwanted URL

