### PR TITLE
feat(ecosystem): add tier project count to feature cards

### DIFF
--- a/components/Ui/UiCompactFeature.vue
+++ b/components/Ui/UiCompactFeature.vue
@@ -7,6 +7,9 @@
     <div class="ui-compact-feature__description">
       {{ description }}
     </div>
+    <div v-if="detail" class="ui-compact-feature__detail">
+      {{ detail }}
+    </div>
   </article>
 </template>
 
@@ -15,6 +18,7 @@ interface Props {
   description: string;
   icon: string;
   title: string;
+  detail: string;
 }
 
 defineProps<Props>();
@@ -30,6 +34,7 @@ $feature-icon-size: 2.25rem;
   background-color: qiskit.$background-color-secondary;
   height: 100%;
   padding: carbon.$spacing-05;
+  position: relative;
 
   @include carbon.breakpoint-down(lg) {
     padding-bottom: carbon.$spacing-06;
@@ -52,6 +57,12 @@ $feature-icon-size: 2.25rem;
 
   &__description {
     color: qiskit.$text-color-white;
+  }
+
+  &__detail {
+    color: qiskit.$text-color-white;
+    position: absolute;
+    bottom: carbon.$spacing-05;
   }
 }
 </style>

--- a/components/Ui/UiJoinWithCards.vue
+++ b/components/Ui/UiJoinWithCards.vue
@@ -21,6 +21,7 @@
           :description="card.description"
           :icon="card.icon"
           :title="card.name"
+          :detail="card.detail"
         />
       </div>
     </div>
@@ -34,6 +35,7 @@ interface Card {
   name: string;
   description: string;
   icon: string;
+  detail: string;
 }
 
 interface Props {

--- a/pages/ecosystem.vue
+++ b/pages/ecosystem.vue
@@ -156,17 +156,20 @@ const joinSectionCards = [
   {
     name: "Main tier",
     description: "The main Qiskit packages maintained by IBM Quantum.",
+    detail: `${getTierProjectCount("Main")} projects`,
     icon: "quantum.svg",
   },
   {
     name: "Extensions tier",
     description: "IBM Quantum supported Qiskit extensions.",
+    detail: `${getTierProjectCount("Extensions")} projects`,
     icon: "transform--02.svg",
   },
   {
     name: "Community tier",
     description:
       "Software packages supported by the Qiskit community, not maintained by IBM Quantum.",
+    detail: `${getTierProjectCount("Community")} projects`,
     icon: "group.svg",
   },
 ];
@@ -301,6 +304,17 @@ const filteredMembersSorted = computed<Member[]>(() => {
 
   return filteredMembers.value.sort((a, b) => a.name.localeCompare(b.name));
 });
+
+function getTierProjectCount(tierName: string) {
+  const tierCount = members.reduce((acc, member) => {
+    if (member.tier === tierName) {
+      acc += 1;
+    }
+    return acc;
+  }, 0);
+
+  return tierCount;
+}
 </script>
 
 <style lang="scss" scoped>
@@ -399,6 +413,20 @@ const filteredMembersSorted = computed<Member[]>(() => {
 
   &::part(expando) {
     background-color: carbon.$cool-gray-20;
+  }
+}
+</style>
+
+<style lang="scss">
+@use "~/assets/scss/carbon.scss";
+
+.ecosystem-page__join-section {
+  .join-with-cards__feature {
+    height: 15.5rem;
+
+    @include carbon.breakpoint-down(md) {
+      height: 14.5rem;
+    }
   }
 }
 </style>


### PR DESCRIPTION
## Changes

Fixes #3472 

## Implementation details

- adds function to `getTierProjectCount`
- pass in count into the `joinSectionCards` to be used as a `detail` prop
- added `detail` prop to feature card, and conditionally render if exists
- styled overrides so the feature card is responsive

## How to read this PR

Please review

- method for getting project count (is this the best way?)
- the new `card.detail` prop added
- overriding styles added to ensure the Ecosystem page feature cards are responsive


## Screenshots

https://github.com/Qiskit/qiskit.org/assets/6276074/14ca8e39-d9a8-44d4-b470-f3979d3cbf84


