### PR TITLE
3476 summer school remove register cta

### DIFF
--- a/constants/summerSchool2023Content.ts
+++ b/constants/summerSchool2023Content.ts
@@ -17,14 +17,6 @@ const header = {
       location: "header",
     },
   },
-  cta: {
-    label: "Register now!",
-    url: "https://qisk.it/QGSS23REG",
-    segment: {
-      cta: "register",
-      location: "header",
-    },
-  },
   cardSectionHeading: "About the event:",
   card: {
     image: "/images/events/summer-school-2023/summer-school-2023-logo.png",

--- a/constants/summerSchool2023Content.ts
+++ b/constants/summerSchool2023Content.ts
@@ -27,7 +27,7 @@ const header = {
     location: "Online",
     date: "July 17 – 28, 2023",
     time: "",
-    to: "https://qisk.it/QGSS23REG",
+    to: "",
     ctaLabel: "View the event",
     segment: {
       cta: "ibm-research-blog",

--- a/pages/events/summer-school-2023.vue
+++ b/pages/events/summer-school-2023.vue
@@ -193,10 +193,6 @@ useSchemaOrg([
     }
   }
 
-  &__cta {
-    margin-top: carbon.$spacing-07;
-  }
-
   &__header-card {
     :deep(.card__image-container) {
       flex: 0 0 24rem;

--- a/pages/events/summer-school-2023.vue
+++ b/pages/events/summer-school-2023.vue
@@ -27,13 +27,7 @@
           </UiLinkText>
           for more details. For any questions, please check out our FAQ below!
         </p>
-        <p>See you soon!</p>
-        <UiCta
-          class="summer-school-2023-page__cta"
-          :url="headerCta.url"
-          :label="headerCta.label"
-          :segment="headerCta.segment"
-        />
+        <p>See you next year!</p>
       </template>
       <template #card>
         <EventsCard
@@ -145,7 +139,6 @@ useSeoMeta({
 
 const agendaColumnsDataTable: string[] = ["Day", "Topic", "Speaker", "Format"];
 const headerData = header;
-const headerCta = headerData.cta;
 const mosaicData = mosaic;
 const agendaData = agenda;
 const helpfulResourcesData = helpfulResources;


### PR DESCRIPTION
## Changes

Closes #3476 

- `See you soon` --> `See you next year!`
- Remove the `register now CTA`
- Remove the `View the event` CTA in event card

## Screenshots

![image](https://github.com/Qiskit/qiskit.org/assets/7396204/06c33b9e-fe23-43b2-816f-5f24c105d01e)
