### PR TITLE
feat(ui-link): remove `noreferrer`

### DIFF
--- a/components/Ui/Link/UiLink.vue
+++ b/components/Ui/Link/UiLink.vue
@@ -2,6 +2,7 @@
   <NuxtLink
     v-track-click="segment"
     :external="computedExternal"
+    :rel="computedExternal ? 'noopener' : undefined"
     :target="computedTarget"
     :title="title"
     :to="url"


### PR DESCRIPTION
When linking to external links, we want to preserve `noopener` but remove `noreferrer`.

## Changes

<!--
  Required.

  Briefly describe the changes introduced by this pull request.
  Also link relevant issues with the "closes", "fixes" or "resolves" keywords,
  and add co-authors where appropriate with the "co-authored-by" keyword.

  Example:
  Implemented the functionality to update the user's name.
  Closes #42
  Co-authored-by: @octocat
-->

This PR removes the [`noreferrer`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/noreferrer) keyword for external links since we want to be able to use the `Referer` header.

Closes #3514

## Implementation details

<!--
  Optional.

  If useful for the code review, describe implementation details and, if
  necessary, why a certain approach was chosen.

  Example:
  Changes are introduced to the controller and the database model. UI changes
  are not in the scope of this PR.
-->

We instruct NuxtLink explicitely to only use `noopener` for external links.

https://nuxt.com/docs/api/components/nuxt-link