### PR TITLE
table scroll corrected in new branch

### DIFF
--- a/pages/events/fall-fest.vue
+++ b/pages/events/fall-fest.vue
@@ -149,8 +149,10 @@ const helpfulResourcesData = helpfulResources;
   }
 
   &__data-table {
-    max-height: 41rem;
-    overflow-y: auto;
+    :deep(.ui-data-table) {
+      max-height: 41rem;
+      overflow-y: auto;
+    }
   }
 }
 </style>


### PR DESCRIPTION
## Changes


- Corrected the table scroll, now the "Qiskit Fall Fest: Extension Events" title and the description underneath it doesn't scroll down with the table.

![image](https://github.com/Qiskit/qiskit.org/assets/124618211/8306416c-9a1d-4ddd-bb23-a3b442493d34)


